### PR TITLE
fix: diff treesitter highlighting when no ft/lang detected in hunk

### DIFF
--- a/lua/diffs/parser.lua
+++ b/lua/diffs/parser.lua
@@ -68,7 +68,7 @@ function M.parse_buffer(bufnr)
   local header_lines = {}
 
   local function flush_hunk()
-    if hunk_start and #hunk_lines > 0 and (current_lang or current_ft) then
+    if hunk_start and #hunk_lines > 0 then
       local hunk = {
         filename = current_filename,
         ft = current_ft,


### PR DESCRIPTION
You can reproduce with `nvim --cmd 'lua vim.filetype.match = function() end'`.
