### PR TITLE
fix(parser): emit hunks for files with unknown filetypes

### DIFF
--- a/lua/diffs/parser.lua
+++ b/lua/diffs/parser.lua
@@ -68,7 +68,7 @@ function M.parse_buffer(bufnr)
   local header_lines = {}
 
   local function flush_hunk()
-    if hunk_start and #hunk_lines > 0 and (current_lang or current_ft) then
+    if hunk_start and #hunk_lines > 0 then
       local hunk = {
         filename = current_filename,
         ft = current_ft,

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -285,5 +285,24 @@ describe('parser', function()
       assert.are.equal('diff --git a/parser.lua b/parser.lua', hunks[1].header_lines[1])
       delete_buffer(bufnr)
     end)
+
+    it('emits hunk for files with unknown filetype', function()
+      local bufnr = create_buffer({
+        'M config.obscuretype',
+        '@@ -1,2 +1,3 @@',
+        ' setting1 = value1',
+        '-setting2 = value2',
+        '+setting2 = MODIFIED',
+        '+setting4 = newvalue',
+      })
+      local hunks = parser.parse_buffer(bufnr)
+
+      assert.are.equal(1, #hunks)
+      assert.are.equal('config.obscuretype', hunks[1].filename)
+      assert.is_nil(hunks[1].ft)
+      assert.is_nil(hunks[1].lang)
+      assert.are.equal(4, #hunks[1].lines)
+      delete_buffer(bufnr)
+    end)
   end)
 end)


### PR DESCRIPTION
Files with unrecognized extensions (no filetype detection) were receiving no highlighting at all in fugitive status - not even the basic green/red background colors for added/deleted lines.

The issue was in `flush_hunk()` which required `(current_lang or current_ft)` to be truthy before emitting a hunk. This meant unknown filetypes were silently discarded.

`highlight_hunk()` already handles nil ft/lang gracefully - it skips syntax highlighting but still applies `DiffsAdd`/`DiffsDelete` backgrounds. This fix lets those hunks through.

Closes #62

Thanks to @phanen for identifying this issue and drafting the fix.