### PR TITLE
feat(fugitive): line position tracking for keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,5 @@ luarocks install diffs.nvim
 - [`vim-fugitive`](https://github.com/tpope/vim-fugitive)
 - [`codediff.nvim`](https://github.com/esmuellert/codediff.nvim)
 - [`diffview.nvim`](https://github.com/sindrets/diffview.nvim)
-- [@phanen](https://github.com/phanen) - diff header highlighting
+- [@phanen](https://github.com/phanen) - diff header highlighting, unknown
+  filetype fix, shebang/modeline detection


### PR DESCRIPTION
When pressing `du`/`dU` from a hunk line in the fugitive status buffer (after expanding with `=`), the unified diff now opens at the corresponding line instead of line 1.

**Before:** Cursor always at line 1 of diff buffer
**After:** Cursor lands on the same line you were viewing in the fugitive status

**Implementation:**
- `fugitive.get_hunk_position(bufnr, lnum)` - returns `@@` header and offset when cursor is on a hunk line
- `commands.find_hunk_line(diff_lines, hunk_position)` - finds matching `@@` header in diff buffer
- `commands.gdiff_file()` accepts optional `hunk_position` and jumps after opening

Also updates @phanen's README credit for the previous two fixes (#68, #69).

Closes #65