### PR TITLE
fix(parser): detect filetype from file content (shebang/modeline)

### DIFF
--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -2,6 +2,8 @@ local plugin_dir = vim.fn.getcwd()
 vim.opt.runtimepath:prepend(plugin_dir)
 vim.opt.packpath = {}
 
+vim.cmd('filetype on')
+
 local function ensure_parser(lang)
   local ok = pcall(vim.treesitter.language.inspect, lang)
   if not ok then


### PR DESCRIPTION
When a file has no recognizable extension, filetype detection now falls back to reading file content.

**The problem:** Files like `build` (no extension) got no syntax highlighting when expanded in fugitive status, because `vim.filetype.match({ filename = "build" })` returns nil without content hints.

**The fix:** When filename-based detection fails, read the first 10 lines from disk and use `vim.filetype.match({ filename, contents })` for content-based detection.

**Detection order:**
1. Existing buffer's filetype (from #69)
2. Filename extension
3. File content on disk (fallback for extensionless files)

This catches shebangs (`#!/bin/bash`), XML declarations, and other patterns Neovim detects from early file content.

**Also:**
- Adds `filetype on` to test helpers (required for `vim.g.ft_ignore_pat` which shell detection depends on)