### PR TITLE
feat: add <Plug> mappings

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -228,6 +228,22 @@ COMMANDS                                                      *diffs-commands*
     Like |:Gdiff| but explicitly opens in a horizontal split.
 
 ==============================================================================
+MAPPINGS                                                     *diffs-mappings*
+
+                                                        *<Plug>(diffs-gdiff)*
+<Plug>(diffs-gdiff)     Show unified diff against HEAD in a horizontal
+                        split. Equivalent to |:Gdiff| with no arguments.
+
+                                                       *<Plug>(diffs-gvdiff)*
+<Plug>(diffs-gvdiff)    Show unified diff against HEAD in a vertical
+                        split. Equivalent to |:Gvdiff| with no arguments.
+
+Example configuration: >lua
+    vim.keymap.set('n', '<leader>gd', '<Plug>(diffs-gdiff)')
+    vim.keymap.set('n', '<leader>gD', '<Plug>(diffs-gvdiff)')
+<
+
+==============================================================================
 FUGITIVE STATUS KEYMAPS                                   *diffs-fugitive*
 
 When inside a vim-fugitive |:Git| status buffer, diffs.nvim provides keymaps

--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -40,3 +40,11 @@ vim.api.nvim_create_autocmd('OptionSet', {
     end
   end,
 })
+
+local cmds = require('diffs.commands')
+vim.keymap.set('n', '<Plug>(diffs-gdiff)', function()
+  cmds.gdiff(nil, false)
+end, { desc = 'Unified diff (horizontal)' })
+vim.keymap.set('n', '<Plug>(diffs-gvdiff)', function()
+  cmds.gdiff(nil, true)
+end, { desc = 'Unified diff (vertical)' })


### PR DESCRIPTION
## Problem

Users who want keybindings must wrap commands in closures. There is no
stable public API for key binding.

## Solution

Define <Plug> mappings in the plugin file and document them in a new
MAPPINGS section in the vimdoc.