### PR TITLE
fix(highlight): make hl_eol work on background extmarks

### DIFF
--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -458,12 +458,17 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
 
     if opts.highlights.background and is_diff_line then
       pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
-        end_col = line_len,
+        end_row = buf_line + 1,
         hl_group = line_hl,
         hl_eol = true,
-        number_hl_group = opts.highlights.gutter and number_hl or nil,
         priority = PRIORITY_LINE_BG,
       })
+      if opts.highlights.gutter then
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
+          number_hl_group = number_hl,
+          priority = PRIORITY_LINE_BG,
+        })
+      end
     end
 
     if char_spans_by_line[i] then


### PR DESCRIPTION
## Problem

`hl_eol` requires a multiline extmark to extend the background past end-of-line. The extmark used `end_col = line_len` on the same row, making it single-line, so `hl_eol` was effectively a no-op.

Reported by @phanen in #81.

## Solution

Replace `end_col` with `end_row` targeting the next line so the extmark is multiline and `hl_eol` takes effect. Split `number_hl_group` into a separate extmark to prevent it bleeding to adjacent lines.