### PR TITLE
fix(highlight): reduce word-level blend alpha and match line number bg

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -404,7 +404,9 @@ always derived from the corresponding `Diff*` groups.
 
 All derived groups are computed by alpha-blending a source color into the
 `Normal` background. Line-level groups blend at 40% alpha for a subtle tint;
-character-level and line-number groups blend at 60% for more contrast.
+character-level groups blend at 60% for more contrast. Line-number groups
+combine both: background from the line-level blend, foreground from the
+character-level blend.
 
 Fugitive unified diff highlights: ~
                                                                   *DiffsAdd*
@@ -417,11 +419,11 @@ Fugitive unified diff highlights: ~
 
                                                                 *DiffsAddNr*
     DiffsAddNr          Line number for `+` lines. Foreground from
-                        `diffAdded`, background from `DiffsAddText`.
+                        `DiffsAddText`, background from `DiffsAdd`.
 
                                                              *DiffsDeleteNr*
     DiffsDeleteNr       Line number for `-` lines. Foreground from
-                        `diffRemoved`, background from `DiffsDeleteText`.
+                        `DiffsDeleteText`, background from `DiffsDelete`.
 
                                                               *DiffsAddText*
     DiffsAddText        Character-level background for changed characters

--- a/lua/diffs/init.lua
+++ b/lua/diffs/init.lua
@@ -198,8 +198,12 @@ local function compute_highlight_groups()
   vim.api.nvim_set_hl(0, 'DiffsClear', { default = true, fg = normal.fg or 0xc0c0c0 })
   vim.api.nvim_set_hl(0, 'DiffsAdd', { default = true, bg = blended_add })
   vim.api.nvim_set_hl(0, 'DiffsDelete', { default = true, bg = blended_del })
-  vim.api.nvim_set_hl(0, 'DiffsAddNr', { default = true, fg = add_fg, bg = blended_add_text })
-  vim.api.nvim_set_hl(0, 'DiffsDeleteNr', { default = true, fg = del_fg, bg = blended_del_text })
+  vim.api.nvim_set_hl(0, 'DiffsAddNr', { default = true, fg = blended_add_text, bg = blended_add })
+  vim.api.nvim_set_hl(
+    0,
+    'DiffsDeleteNr',
+    { default = true, fg = blended_del_text, bg = blended_del }
+  )
   vim.api.nvim_set_hl(0, 'DiffsAddText', { default = true, bg = blended_add_text })
   vim.api.nvim_set_hl(0, 'DiffsDeleteText', { default = true, bg = blended_del_text })
 


### PR DESCRIPTION
## Problem

Word-level diff highlights were too intense at 70% alpha, and line
number gutter colors didn't match the corresponding highlight groups —
the bg was word-level instead of line-level, and the fg was the raw
diffAdded/diffRemoved color instead of the character-level blend.

## Solution

Reduce DiffsAddText/DiffsDeleteText blend alpha from 0.7 to 0.6. Set
gutter bg to the line-level blend (matching DiffsAdd/DiffsDelete) and
fg to the character-level blend (matching DiffsAddText/DiffsDeleteText
bg). Updated vimdoc to document the blending strategy.

Closes #82, closes #89