### PR TITLE
perf: cache repo root and harden async paths

### DIFF
--- a/lua/diffs/git.lua
+++ b/lua/diffs/git.lua
@@ -1,13 +1,19 @@
 local M = {}
 
+local repo_root_cache = {}
+
 ---@param filepath string
 ---@return string?
 function M.get_repo_root(filepath)
   local dir = vim.fn.fnamemodify(filepath, ':h')
+  if repo_root_cache[dir] ~= nil then
+    return repo_root_cache[dir]
+  end
   local result = vim.fn.systemlist({ 'git', '-C', dir, 'rev-parse', '--show-toplevel' })
   if vim.v.shell_error ~= 0 then
     return nil
   end
+  repo_root_cache[dir] = result[1]
   return result[1]
 end
 

--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -238,7 +238,7 @@ local function highlight_vim_syntax(bufnr, ns, hunk, code_lines, covered_lines, 
 
   local spans = {}
 
-  vim.api.nvim_buf_call(scratch, function()
+  pcall(vim.api.nvim_buf_call, scratch, function()
     vim.cmd('setlocal syntax=' .. ft)
     vim.cmd('redraw')
 
@@ -256,7 +256,7 @@ local function highlight_vim_syntax(bufnr, ns, hunk, code_lines, covered_lines, 
     spans = M.coalesce_syntax_spans(query_fn, code_lines)
   end)
 
-  vim.api.nvim_buf_delete(scratch, { force = true })
+  pcall(vim.api.nvim_buf_delete, scratch, { force = true })
 
   local hunk_line_count = #hunk.lines
   local extmark_count = 0

--- a/lua/diffs/init.lua
+++ b/lua/diffs/init.lua
@@ -200,7 +200,9 @@ local function create_debounced_highlight(bufnr)
           timer = nil
           t:close()
         end
-        highlight_buffer(bufnr)
+        if vim.api.nvim_buf_is_valid(bufnr) then
+          highlight_buffer(bufnr)
+        end
       end)
     )
   end


### PR DESCRIPTION
## Problem

`get_repo_root()` shells out to `git rev-parse` on every call, causing 4-6
redundant subprocesses per `gdiff_file()` invocation. Three other minor
issues: `highlight_vim_syntax()` leaks a scratch buffer if `nvim_buf_call`
errors, `lib.ensure()` silently drops callbacks during download so hunks
highlighted mid-download permanently miss intra-line highlights, and the
debounce timer callback can operate on a deleted buffer.

## Solution

Cache `get_repo_root()` results by parent directory — repo roots don't
change within a session. Wrap `nvim_buf_call` and `nvim_buf_delete` in
pcall so the scratch buffer is always cleaned up. Replace the early
`callback(nil)` in `lib.ensure()` with a pending callback queue that fires
once the download completes. Guard the debounce timer callback with
`nvim_buf_is_valid`.