### PR TITLE
feat: highlight commit buffers

### DIFF
--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -6,7 +6,7 @@ vim.g.loaded_diffs = 1
 require('diffs.commands').setup()
 
 vim.api.nvim_create_autocmd('FileType', {
-  pattern = { 'fugitive', 'git' },
+  pattern = { 'fugitive', 'git', 'gitcommit' },
   callback = function(args)
     local diffs = require('diffs')
     if args.match == 'git' and not diffs.is_fugitive_buffer(args.buf) then

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -542,6 +542,36 @@ describe('parser', function()
       delete_buffer(bufnr)
     end)
 
+    it('parses diff from gitcommit verbose buffer', function()
+      local bufnr = create_buffer({
+        '',
+        '# Please enter the commit message for your changes.',
+        '#',
+        '# On branch main',
+        '# Changes to be committed:',
+        '#\tmodified:   test.lua',
+        '#',
+        '# ------------------------ >8 ------------------------',
+        '# Do not modify or remove the line above.',
+        'diff --git a/test.lua b/test.lua',
+        'index abc1234..def5678 100644',
+        '--- a/test.lua',
+        '+++ b/test.lua',
+        '@@ -1,3 +1,3 @@',
+        ' local function hello()',
+        '-  print("hello world")',
+        '+  print("hello universe")',
+        '   return true',
+      })
+      local hunks = parser.parse_buffer(bufnr)
+
+      assert.are.equal(1, #hunks)
+      assert.are.equal('test.lua', hunks[1].filename)
+      assert.are.equal('lua', hunks[1].ft)
+      assert.are.equal(4, #hunks[1].lines)
+      delete_buffer(bufnr)
+    end)
+
     it('stores repo_root on hunk when available', function()
       local bufnr = create_buffer({
         'M lua/test.lua',


### PR DESCRIPTION
closes #109 

`:G commit` buffers are now highlighted as follows:

<img width="556" height="502" alt="image" src="https://github.com/user-attachments/assets/4248dc42-c151-4ec8-b4b7-43b6fe919749" />
