### PR TITLE
fix: warn users when fugitive/neogit/diff integrations are unconfigured

### DIFF
--- a/lua/diffs/init.lua
+++ b/lua/diffs/init.lua
@@ -467,6 +467,31 @@ local function init()
     )
   end
 
+  if not opts.filetypes and opts.fugitive == nil and opts.neogit == nil then
+    local has_diff_ft = false
+    if type(opts.extra_filetypes) == 'table' then
+      for _, ft in ipairs(opts.extra_filetypes) do
+        if ft == 'diff' then
+          has_diff_ft = true
+          break
+        end
+      end
+    end
+    if not has_diff_ft then
+      vim.notify(
+        '[diffs.nvim] fugitive, neogit, and diff filetypes are now opt-in.\n'
+          .. 'Add the integrations you use to your config:\n\n'
+          .. '  vim.g.diffs = {\n'
+          .. '    fugitive = true,\n'
+          .. '    neogit = true,\n'
+          .. "    extra_filetypes = { 'diff' },\n"
+          .. '  }\n\n'
+          .. 'This warning will be removed in 0.3.0.',
+        vim.log.levels.WARN
+      )
+    end
+  end
+
   if opts.fugitive == true then
     opts.fugitive = { enabled = true }
   elseif opts.fugitive == false then


### PR DESCRIPTION
## Problem

Commit 0f27488 changed fugitive and neogit integrations from enabled by default
to disabled by default. Users who never explicitly set these keys in their config
saw no deprecation notice and silently lost integration support. The existing
deprecation warning only fires for the old `filetypes` key, missing the far more
common case of users who had no explicit config at all.

## Solution

Add an ephemeral migration check in `init()` that emits a `vim.notify` warning
at WARN level when `fugitive`, `neogit`, and `diff` (via `extra_filetypes`) are
all absent from the user's config. This covers the gap between the old `filetypes`
deprecation and users who relied on implicit defaults. To be removed in 0.3.0.