### PR TITLE
docs: add lazy.nvim installation FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ luarocks install diffs.nvim
 }
 ```
 
-Do not lazy load `diffs.nvim` with `event`, `lazy`, `ft`, `config`, or `keys` to control
-loading - `diffs.nvim` lazy-loads itself.
+Do not lazy load `diffs.nvim` with `event`, `lazy`, `ft`, `config`, or `keys` to
+control loading - `diffs.nvim` lazy-loads itself.
 
 **Does diffs.nvim support vim-fugitive/Neogit?**
 


### PR DESCRIPTION
## Problem

Users attempt to lazy-load diffs.nvim with `event`, `ft`, `lazy`, or
`keys` options, which interferes with the plugin's own `FileType`
autocmd registered at startup.

## Solution

Add a FAQ entry with a correct lazy.nvim snippet using `init` and a
note explaining that the plugin lazy-loads itself.