### PR TITLE
refactor: remove enabled field from fugitive/neogit config

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -115,11 +115,13 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              background color.
 
         {fugitive}           (boolean|table, default: false)
-                             Enable vim-fugitive integration. Accepts
-                             `true`, `false`, or a table with sub-options
-                             (see |diffs.FugitiveConfig|). When enabled,
-                             the `fugitive` filetype is active and status
-                             buffer keymaps are registered. >lua
+                             Enable vim-fugitive integration. Pass `true`
+                             for defaults, `false` to disable, or a table
+                             with sub-options (see |diffs.FugitiveConfig|).
+                             Passing a table implicitly enables the
+                             integration — no `enabled` field needed.
+                             When active, the `fugitive` filetype is
+                             registered and status buffer keymaps are set. >lua
                                  vim.g.diffs = { fugitive = true }
                                  vim.g.diffs = {
                                    fugitive = { horizontal = 'dd' },
@@ -127,13 +129,13 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
 <
 
         {neogit}             (boolean|table, default: false)
-                             Enable Neogit integration. Accepts `true`,
-                             `false`, or `{ enabled = false }`. When
-                             enabled, `NeogitStatus`, `NeogitCommitView`,
-                             and `NeogitDiffView` filetypes are active and
-                             Neogit highlight overrides are applied. See
-                             |diffs-neogit|. >lua
-                                 vim.g.diffs = { neogit = false }
+                             Enable Neogit integration. Pass `true` or
+                             `{}` to enable, `false` to disable. When
+                             active, `NeogitStatus`, `NeogitCommitView`,
+                             and `NeogitDiffView` filetypes are registered
+                             and Neogit highlight overrides are applied.
+                             See |diffs-neogit|. >lua
+                                 vim.g.diffs = { neogit = true }
 <
 
         {extra_filetypes}    (table, default: {})
@@ -438,20 +440,15 @@ Configuration: ~
 >lua
     vim.g.diffs = {
       fugitive = {
-        enabled = true,     -- false to disable fugitive integration entirely
         horizontal = 'du',  -- keymap for horizontal split, false to disable
         vertical = 'dU',    -- keymap for vertical split, false to disable
       },
     }
 <
-    Fields: ~
-        {enabled}            (boolean, default: false)
-                             Enable fugitive integration. When false, the
-                             `fugitive` filetype is excluded and no status
-                             buffer keymaps are registered. Shorthand:
-                             `fugitive = false` is equivalent to
-                             `fugitive = { enabled = false }`.
+    Passing a table enables fugitive integration. Use `fugitive = false`
+    to disable. There is no `enabled` field; table presence is sufficient.
 
+    Fields: ~
         {horizontal}         (string|false, default: 'du')
                              Keymap for unified diff in horizontal split.
                              Set to `false` to disable.

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -328,6 +328,95 @@ describe('diffs', function()
     end)
   end)
 
+  describe('compute_filetypes', function()
+    local compute = diffs.compute_filetypes
+
+    it('returns core filetypes with empty config', function()
+      local fts = compute({})
+      assert.are.same({ 'git', 'gitcommit' }, fts)
+    end)
+
+    it('includes fugitive when fugitive = true', function()
+      local fts = compute({ fugitive = true })
+      assert.is_true(vim.tbl_contains(fts, 'fugitive'))
+    end)
+
+    it('includes fugitive when fugitive is a table', function()
+      local fts = compute({ fugitive = { horizontal = 'dd' } })
+      assert.is_true(vim.tbl_contains(fts, 'fugitive'))
+    end)
+
+    it('excludes fugitive when fugitive = false', function()
+      local fts = compute({ fugitive = false })
+      assert.is_false(vim.tbl_contains(fts, 'fugitive'))
+    end)
+
+    it('excludes fugitive when fugitive is nil', function()
+      local fts = compute({})
+      assert.is_false(vim.tbl_contains(fts, 'fugitive'))
+    end)
+
+    it('includes neogit filetypes when neogit = true', function()
+      local fts = compute({ neogit = true })
+      assert.is_true(vim.tbl_contains(fts, 'NeogitStatus'))
+      assert.is_true(vim.tbl_contains(fts, 'NeogitCommitView'))
+      assert.is_true(vim.tbl_contains(fts, 'NeogitDiffView'))
+    end)
+
+    it('includes neogit filetypes when neogit is a table', function()
+      local fts = compute({ neogit = {} })
+      assert.is_true(vim.tbl_contains(fts, 'NeogitStatus'))
+    end)
+
+    it('excludes neogit when neogit = false', function()
+      local fts = compute({ neogit = false })
+      assert.is_false(vim.tbl_contains(fts, 'NeogitStatus'))
+    end)
+
+    it('excludes neogit when neogit is nil', function()
+      local fts = compute({})
+      assert.is_false(vim.tbl_contains(fts, 'NeogitStatus'))
+    end)
+
+    it('includes extra_filetypes', function()
+      local fts = compute({ extra_filetypes = { 'diff' } })
+      assert.is_true(vim.tbl_contains(fts, 'diff'))
+    end)
+
+    it('combines fugitive, neogit, and extra_filetypes', function()
+      local fts = compute({ fugitive = true, neogit = true, extra_filetypes = { 'diff' } })
+      assert.is_true(vim.tbl_contains(fts, 'git'))
+      assert.is_true(vim.tbl_contains(fts, 'fugitive'))
+      assert.is_true(vim.tbl_contains(fts, 'NeogitStatus'))
+      assert.is_true(vim.tbl_contains(fts, 'diff'))
+    end)
+
+    it('returns custom filetypes when filetypes key is set', function()
+      local fts = compute({ filetypes = { 'custom' } })
+      assert.are.same({ 'custom' }, fts)
+    end)
+
+    it('backward compat: includes fugitive when enabled = true in table', function()
+      local fts = compute({ fugitive = { enabled = true } })
+      assert.is_true(vim.tbl_contains(fts, 'fugitive'))
+    end)
+
+    it('backward compat: excludes fugitive when enabled = false in table', function()
+      local fts = compute({ fugitive = { enabled = false } })
+      assert.is_false(vim.tbl_contains(fts, 'fugitive'))
+    end)
+
+    it('backward compat: includes neogit when enabled = true in table', function()
+      local fts = compute({ neogit = { enabled = true } })
+      assert.is_true(vim.tbl_contains(fts, 'NeogitStatus'))
+    end)
+
+    it('backward compat: excludes neogit when enabled = false in table', function()
+      local fts = compute({ neogit = { enabled = false } })
+      assert.is_false(vim.tbl_contains(fts, 'NeogitStatus'))
+    end)
+  end)
+
   describe('diff mode', function()
     local function create_diff_window()
       vim.cmd('new')


### PR DESCRIPTION
## Problem

Users had to pass `enabled = true` or `enabled = false` inside
fugitive/neogit config tables, which was redundant — table presence
already implied the integration should be active.

## Solution

Remove the `enabled` field from the public API. Table presence now
implies enabled, `false` disables, `true` expands to sub-defaults.
The `enabled` field is still accepted for backward compatibility.

Added 20 `compute_filetypes` tests covering all config shapes (true,
false, table, nil, backward-compat enabled field). Updated docs
and type annotations.