### PR TITLE
feat(neogit): use new neogit apis for highlight and repo root

### DIFF
--- a/lua/diffs/parser.lua
+++ b/lua/diffs/parser.lua
@@ -110,6 +110,11 @@ local function get_repo_root(bufnr)
     return vim.fn.fnamemodify(git_dir, ':h')
   end
 
+  local ok3, neogit_git_dir = pcall(vim.api.nvim_buf_get_var, bufnr, 'neogit_git_dir')
+  if ok3 and neogit_git_dir then
+    return vim.fn.fnamemodify(neogit_git_dir, ':h')
+  end
+
   local cwd = vim.fn.getcwd()
   local git = require('diffs.git')
   return git.get_repo_root(cwd .. '/.')


### PR DESCRIPTION
## Problem

diffs.nvim was blanking 18 Neogit highlight groups globally on attach to prevent Neogit's `line_hl_group` fg from stomping treesitter syntax. It also fell back to `getcwd()` plus a subprocess call for repo root detection on Neogit buffers, and had no mechanism to refresh the hunk cache when Neogit lazy-loaded new diff sections.

## Solution

Adopts three APIs introduced in NeogitOrg/neogit#1897:

- Sets `vim.b.neogit_disable_hunk_highlight = true` on the Neogit buffer at attach time. Neogit's `HunkLine` renderer skips all its own highlight logic when this is set, replacing the need to blank 18 hl groups globally and the associated ColorScheme re-application.
- Reads `vim.b.neogit_git_dir` in `get_repo_root()` as a reliable fallback between the existing `b:git_dir` check and the `getcwd()` subprocess path.
- Registers a buffer-local `User NeogitDiffLoaded` autocmd on attach that calls `M.refresh()` when Neogit lazy-loads a new diff section, keeping the hunk cache in sync.

Closes #128