### PR TITLE
fix(highlight): prevent duplicate extmarks from two-pass rendering

### DIFF
--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -65,6 +65,7 @@ end
 ---@field hide_prefix boolean
 ---@field highlights diffs.Highlights
 ---@field defer_vim_syntax? boolean
+---@field syntax_only? boolean
 
 ---@param bufnr integer
 ---@param ns integer
@@ -381,7 +382,13 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
   ---@type diffs.IntraChanges?
   local intra = nil
   local intra_cfg = opts.highlights.intra
-  if intra_cfg and intra_cfg.enabled and pw == 1 and #hunk.lines <= intra_cfg.max_lines then
+  if
+    not opts.syntax_only
+    and intra_cfg
+    and intra_cfg.enabled
+    and pw == 1
+    and #hunk.lines <= intra_cfg.max_lines
+  then
     dbg('computing intra for hunk %s:%d (%d lines)', hunk.filename, hunk.start_line, #hunk.lines)
     intra = diff.compute_intra_hunks(hunk.lines, intra_cfg.algorithm)
     if intra then
@@ -494,28 +501,70 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
         or content:match('^|||||||')
     end
 
-    if opts.hide_prefix then
-      local virt_hl = (opts.highlights.background and line_hl) or nil
-      pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
-        virt_text = { { string.rep(' ', pw), virt_hl } },
-        virt_text_pos = 'overlay',
-      })
-    end
+    if not opts.syntax_only then
+      if opts.hide_prefix then
+        local virt_hl = (opts.highlights.background and line_hl) or nil
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
+          virt_text = { { string.rep(' ', pw), virt_hl } },
+          virt_text_pos = 'overlay',
+        })
+      end
 
-    if pw > 1 then
-      pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
-        end_col = pw,
-        hl_group = 'DiffsClear',
-        priority = p.clear,
-      })
-      for ci = 0, pw - 1 do
-        local ch = line:sub(ci + 1, ci + 1)
-        if ch == '+' or ch == '-' then
-          pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, ci, {
-            end_col = ci + 1,
-            hl_group = ch == '+' and '@diff.plus' or '@diff.minus',
-            priority = p.syntax,
+      if pw > 1 then
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
+          end_col = pw,
+          hl_group = 'DiffsClear',
+          priority = p.clear,
+        })
+        for ci = 0, pw - 1 do
+          local ch = line:sub(ci + 1, ci + 1)
+          if ch == '+' or ch == '-' then
+            pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, ci, {
+              end_col = ci + 1,
+              hl_group = ch == '+' and '@diff.plus' or '@diff.minus',
+              priority = p.syntax,
+            })
+          end
+        end
+      end
+
+      if opts.highlights.background and is_diff_line then
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
+          line_hl_group = line_hl,
+          number_hl_group = opts.highlights.gutter and number_hl or nil,
+          priority = p.line_bg,
+        })
+      end
+
+      if is_marker and line_len > pw then
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, pw, {
+          end_col = line_len,
+          hl_group = 'DiffsConflictMarker',
+          priority = p.char_bg,
+        })
+      end
+
+      if char_spans_by_line[i] then
+        local char_hl = has_add and 'DiffsAddText' or 'DiffsDeleteText'
+        for _, span in ipairs(char_spans_by_line[i]) do
+          dbg(
+            'char extmark: line=%d buf_line=%d col=%d..%d hl=%s text="%s"',
+            i,
+            buf_line,
+            span.col_start,
+            span.col_end,
+            char_hl,
+            line:sub(span.col_start + 1, span.col_end)
+          )
+          local ok, err = pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, span.col_start, {
+            end_col = span.col_end,
+            hl_group = char_hl,
+            priority = p.char_bg,
           })
+          if not ok then
+            dbg('char extmark FAILED: %s', err)
+          end
+          extmark_count = extmark_count + 1
         end
       end
     end
@@ -526,46 +575,6 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
         hl_group = 'DiffsClear',
         priority = p.clear,
       })
-    end
-
-    if opts.highlights.background and is_diff_line then
-      pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
-        line_hl_group = line_hl,
-        number_hl_group = opts.highlights.gutter and number_hl or nil,
-        priority = p.line_bg,
-      })
-    end
-
-    if is_marker and line_len > pw then
-      pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, pw, {
-        end_col = line_len,
-        hl_group = 'DiffsConflictMarker',
-        priority = p.char_bg,
-      })
-    end
-
-    if char_spans_by_line[i] then
-      local char_hl = has_add and 'DiffsAddText' or 'DiffsDeleteText'
-      for _, span in ipairs(char_spans_by_line[i]) do
-        dbg(
-          'char extmark: line=%d buf_line=%d col=%d..%d hl=%s text="%s"',
-          i,
-          buf_line,
-          span.col_start,
-          span.col_end,
-          char_hl,
-          line:sub(span.col_start + 1, span.col_end)
-        )
-        local ok, err = pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, span.col_start, {
-          end_col = span.col_end,
-          hl_group = char_hl,
-          priority = p.char_bg,
-        })
-        if not ok then
-          dbg('char extmark FAILED: %s', err)
-        end
-        extmark_count = extmark_count + 1
-      end
     end
   end
 

--- a/lua/diffs/init.lua
+++ b/lua/diffs/init.lua
@@ -797,18 +797,13 @@ local function init()
             return
           end
           local t1 = config.debug and vim.uv.hrtime() or nil
-          local full_opts = {
+          local syntax_opts = {
             hide_prefix = config.hide_prefix,
             highlights = config.highlights,
+            syntax_only = true,
           }
           for _, hunk in ipairs(deferred_syntax) do
-            local start_row = hunk.start_line - 1
-            local end_row = hunk.start_line + #hunk.lines
-            if hunk.header_start_line then
-              start_row = hunk.header_start_line - 1
-            end
-            vim.api.nvim_buf_clear_namespace(bufnr, ns, start_row, end_row)
-            highlight.highlight_hunk(bufnr, ns, hunk, full_opts)
+            highlight.highlight_hunk(bufnr, ns, hunk, syntax_opts)
           end
           if t1 then
             dbg('deferred pass: %d hunks in %.2fms', #deferred_syntax, (vim.uv.hrtime() - t1) / 1e6)

--- a/spec/highlight_spec.lua
+++ b/spec/highlight_spec.lua
@@ -1249,6 +1249,123 @@ describe('highlight', function()
       end
       delete_buffer(bufnr)
     end)
+
+    it('two-pass rendering produces no duplicate extmarks', function()
+      vim.api.nvim_set_hl(0, 'DiffsAddText', { bg = 0x00FF00 })
+      vim.api.nvim_set_hl(0, 'DiffsDeleteText', { bg = 0xFF0000 })
+      vim.api.nvim_set_hl(0, 'DiffsAddNr', { fg = 0x80c080, bg = 0x2e4a3a })
+      vim.api.nvim_set_hl(0, 'DiffsDeleteNr', { fg = 0xc08080, bg = 0x4a2e3a })
+
+      local bufnr = create_buffer({
+        '@@ -1,2 +1,2 @@',
+        '-local x = 1',
+        '+local x = 2',
+      })
+
+      local hunk = {
+        filename = 'test.lua',
+        lang = 'lua',
+        start_line = 1,
+        lines = { '-local x = 1', '+local x = 2' },
+      }
+
+      local fast = default_opts({
+        highlights = {
+          treesitter = { enabled = false },
+          background = true,
+          gutter = true,
+          intra = { enabled = true, algorithm = 'default', max_lines = 500 },
+        },
+      })
+
+      local syntax = default_opts({
+        highlights = {
+          treesitter = { enabled = true },
+          background = true,
+          gutter = true,
+          intra = { enabled = true, algorithm = 'default', max_lines = 500 },
+        },
+      })
+      syntax.syntax_only = true
+
+      highlight.highlight_hunk(bufnr, ns, hunk, fast)
+      highlight.highlight_hunk(bufnr, ns, hunk, syntax)
+
+      local extmarks = get_extmarks(bufnr)
+      for row = 1, 2 do
+        local line_hl_count = 0
+        local number_hl_count = 0
+        local intra_count = 0
+        for _, mark in ipairs(extmarks) do
+          if mark[2] == row then
+            local d = mark[4]
+            if d.line_hl_group then
+              line_hl_count = line_hl_count + 1
+            end
+            if d.number_hl_group then
+              number_hl_count = number_hl_count + 1
+            end
+            if d.hl_group == 'DiffsAddText' or d.hl_group == 'DiffsDeleteText' then
+              intra_count = intra_count + 1
+            end
+          end
+        end
+        assert.are.equal(1, line_hl_count, 'row ' .. row .. ' has duplicate line_hl_group')
+        assert.are.equal(1, number_hl_count, 'row ' .. row .. ' has duplicate number_hl_group')
+        assert.is_true(intra_count <= 1, 'row ' .. row .. ' has duplicate intra extmarks')
+      end
+      delete_buffer(bufnr)
+    end)
+
+    it('syntax_only pass adds treesitter without duplicating backgrounds', function()
+      local bufnr = create_buffer({
+        '@@ -1,2 +1,3 @@',
+        ' local x = 1',
+        '+local y = 2',
+        ' return x',
+      })
+
+      local hunk = {
+        filename = 'test.lua',
+        lang = 'lua',
+        start_line = 1,
+        lines = { ' local x = 1', '+local y = 2', ' return x' },
+      }
+
+      local fast = default_opts({
+        highlights = {
+          treesitter = { enabled = false },
+          background = true,
+        },
+      })
+
+      local syntax = default_opts({
+        highlights = {
+          treesitter = { enabled = true },
+          background = true,
+        },
+      })
+      syntax.syntax_only = true
+
+      highlight.highlight_hunk(bufnr, ns, hunk, fast)
+      highlight.highlight_hunk(bufnr, ns, hunk, syntax)
+
+      local extmarks = get_extmarks(bufnr)
+      local has_ts = false
+      local line_hl_count = 0
+      for _, mark in ipairs(extmarks) do
+        local d = mark[4]
+        if d and d.hl_group and d.hl_group:match('^@.*%.lua$') then
+          has_ts = true
+        end
+        if d and d.line_hl_group then
+          line_hl_count = line_hl_count + 1
+        end
+      end
+      assert.is_true(has_ts)
+      assert.are.equal(1, line_hl_count)
+      delete_buffer(bufnr)
+    end)
   end)
 
   describe('diff header highlighting', function()


### PR DESCRIPTION
## Problem

Two-pass rendering (Pass 1: backgrounds + intra-line; Pass 2: treesitter) caused Pass 2 to re-apply all extmarks that Pass 1 already set, doubling the extmark count on affected lines.

## Solution

Add `syntax_only` mode to `highlight_hunk`. When `syntax_only = true`, only treesitter syntax and content `DiffsClear` extmarks are applied — backgrounds, intra-line, prefix clears, and per-char prefix highlights are skipped. Pass 2 now uses `syntax_only = true` and no longer calls `nvim_buf_clear_namespace`, so Pass 1's extmarks persist while Pass 2 layers syntax on top.

Closes #143