### PR TITLE
feat: support email-quoted diffs

### DIFF
--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -371,7 +371,17 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
       header_map[i] = hunk.header_start_line - 1 + i
     end
     extmark_count = extmark_count
-      + highlight_treesitter(bufnr, ns, hunk.header_lines, 'diff', header_map, qw, nil, p, qw > 0 or pw > 1)
+      + highlight_treesitter(
+        bufnr,
+        ns,
+        hunk.header_lines,
+        'diff',
+        header_map,
+        qw,
+        nil,
+        p,
+        qw > 0 or pw > 1
+      )
   end
 
   local at_raw_line
@@ -574,11 +584,12 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
             char_hl,
             line:sub(span.col_start + 1, span.col_end)
           )
-          local ok, err = pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, span.col_start + qw, {
-            end_col = span.col_end + qw,
-            hl_group = char_hl,
-            priority = p.char_bg,
-          })
+          local ok, err =
+            pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, span.col_start + qw, {
+              end_col = span.col_end + qw,
+              hl_group = char_hl,
+              priority = p.char_bg,
+            })
           if not ok then
             dbg('char extmark FAILED: %s', err)
           end

--- a/lua/diffs/parser.lua
+++ b/lua/diffs/parser.lua
@@ -241,7 +241,10 @@ function M.parse_buffer(bufnr)
       or logical:match('^renamed%s+(.+)$')
       or logical:match('^copied%s+(.+)$')
     local bare_file = not hunk_start and logical:match('^([^%s]+%.[^%s]+)$')
-    local filename = logical:match('^[MADRCU%?!]%s+(.+)$') or diff_git_file or neogit_file or bare_file
+    local filename = logical:match('^[MADRCU%?!]%s+(.+)$')
+      or diff_git_file
+      or neogit_file
+      or bare_file
     if filename then
       flush_hunk()
       current_filename = filename

--- a/spec/email_quote_spec.lua
+++ b/spec/email_quote_spec.lua
@@ -1,6 +1,6 @@
 require('spec.helpers')
-local parser = require('diffs.parser')
 local highlight = require('diffs.highlight')
+local parser = require('diffs.parser')
 
 describe('email-quoted diffs', function()
   local function create_buffer(lines)
@@ -348,7 +348,10 @@ describe('email-quoted diffs', function()
       for _, mark in ipairs(extmarks) do
         local d = mark[4]
         if d and (d.hl_group == '@diff.plus' or d.hl_group == '@diff.minus') then
-          table.insert(diff_marks, { row = mark[2], col = mark[3], end_col = d.end_col, hl = d.hl_group })
+          table.insert(
+            diff_marks,
+            { row = mark[2], col = mark[3], end_col = d.end_col, hl = d.hl_group }
+          )
         end
       end
       assert.is_true(#diff_marks >= 2)
@@ -416,7 +419,9 @@ describe('email-quoted diffs', function()
         bufnr,
         ns,
         hunk,
-        default_opts({ highlights = { intra = { enabled = true, algorithm = 'default', max_lines = 500 } } })
+        default_opts({
+          highlights = { intra = { enabled = true, algorithm = 'default', max_lines = 500 } },
+        })
       )
 
       local extmarks = get_extmarks(bufnr)


### PR DESCRIPTION
## Problem

Email-quoted diffs (`> diff --git ...`, `> @@ ...`) from git-send-email / email reply workflows produce 0 hunks because the parser matches patterns against raw lines containing `> ` quote prefixes. Closes #141.

## Solution

Strip the `> ` quote prefix before pattern matching in the parser. Store `quote_width` on each hunk. In `highlight.lua`, offset all extmark column positions by `qw` and expand `pw > 1` guards to `qw > 0 or pw > 1` for DiffsClear suppression. Clamp body prefix DiffsClear `end_col` to the actual buffer line byte length for bare `>` lines (1-byte buffer lines where `end_col = pw + qw` would exceed bounds and cause `nvim_buf_set_extmark` to silently fail inside `pcall`).

15 new specs covering parser detection, stripping, false-positive rejection, and highlight column offsets including the bare `>` clamp edge case.