### PR TITLE
docs: document picker integration via `extra_filetypes`

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -184,6 +184,12 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                                    extra_filetypes = { 'diff' },
                                  }
 <
+                             Adding `'diff'` also enables highlighting in
+                             picker preview buffers that set `filetype=diff`:
+                             telescope.nvim (git_commits, git_bcommits,
+                             git_status), snacks.nvim (syntax style only),
+                             and fzf-lua (builtin previewer only). Terminal-
+                             based previewers are not supported.
 
         {highlights}         (table, default: see below)
                              Controls which highlight features are enabled.


### PR DESCRIPTION
## Problem

`extra_filetypes = { 'diff' }` enables highlighting in telescope, snacks, and fzf-lua git preview buffers, but this was not documented beyond a brief mention of `.diff` files.

## Solution

Add a README FAQ entry and expand the vimdoc `extra_filetypes` field description to mention specific pickers and which previewer styles are supported.