### PR TITLE
fix(highlight): omit DiffsClear bg on transparent themes

### DIFF
--- a/lua/diffs/init.lua
+++ b/lua/diffs/init.lua
@@ -528,7 +528,11 @@ local function compute_highlight_groups(is_default)
   local blended_add_text = blend_color(add_bg, bg, text_alpha)
   local blended_del_text = blend_color(del_bg, bg, text_alpha)
 
-  vim.api.nvim_set_hl(0, 'DiffsClear', { default = dflt, fg = normal_fg, bg = bg })
+  local clear_hl = { default = dflt, fg = normal_fg }
+  if not transparent then
+    clear_hl.bg = bg
+  end
+  vim.api.nvim_set_hl(0, 'DiffsClear', clear_hl)
   vim.api.nvim_set_hl(0, 'DiffsAdd', { default = dflt, bg = blended_add })
   vim.api.nvim_set_hl(0, 'DiffsDelete', { default = dflt, bg = blended_del })
   vim.api.nvim_set_hl(0, 'DiffsAddNr', { default = dflt, fg = add_fg, bg = blended_add })

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -554,7 +554,7 @@ describe('diffs', function()
       diffs._test.set_hl_retry_pending(false)
     end)
 
-    it('uses dark fallback bg for DiffsClear when Normal.bg is nil (transparent)', function()
+    it('omits DiffsClear.bg when Normal.bg is nil (transparent)', function()
       vim.api.nvim_get_hl = function(ns, opts)
         if opts.name == 'Normal' then
           return { fg = 0xc0c0c0 }
@@ -562,9 +562,20 @@ describe('diffs', function()
         return saved_get_hl(ns, opts)
       end
       diffs._test.compute_highlight_groups()
-      assert.are.equal(0x1a1a1a, set_calls.DiffsClear.bg)
+      assert.is_nil(set_calls.DiffsClear.bg)
       assert.is_table(set_calls.DiffsAdd)
       assert.is_table(set_calls.DiffsDelete)
+    end)
+
+    it('sets DiffsClear.bg to Normal.bg on opaque themes', function()
+      vim.api.nvim_get_hl = function(ns, opts)
+        if opts.name == 'Normal' then
+          return { fg = 0xebdbb2, bg = 0x282828 }
+        end
+        return saved_get_hl(ns, opts)
+      end
+      diffs._test.compute_highlight_groups()
+      assert.are.equal(0x282828, set_calls.DiffsClear.bg)
     end)
 
     it('blend_alpha controls DiffsAdd.bg intensity', function()


### PR DESCRIPTION
## Problem

#178 set `DiffsClear.bg` to a dark fallback (`#1a1a1a`) on transparent themes, painting a visible solid rectangle where the terminal background should show through.

## Solution

Only set `DiffsClear.bg` when `Normal.bg` is defined. Body lines are already protected by `line_hl_group` (`DiffsAdd`/`DiffsDelete`), which stacks above `hl_group` bg regardless of priority — `DiffsClear.bg` is redundant there. The only site where it matters is combined/email-quoted diff headers, an acceptable tradeoff.