### PR TITLE
fix(lib): update vscode-diff download URL to codediff.nvim

### DIFF
--- a/lua/diffs/lib.lua
+++ b/lua/diffs/lib.lua
@@ -183,7 +183,7 @@ function M.ensure(callback)
   local arch = get_arch()
   local ext = get_ext()
   local filename = ('libvscode_diff_%s_%s_%s.%s'):format(os_name, arch, EXPECTED_VERSION, ext)
-  local url = ('https://github.com/esmuellert/vscode-diff.nvim/releases/download/v%s/%s'):format(
+  local url = ('https://github.com/esmuellert/codediff.nvim/releases/download/v%s/%s'):format(
     EXPECTED_VERSION,
     filename
   )


### PR DESCRIPTION
## Problem

The `esmuellert/vscode-diff.nvim` repo was renamed to `esmuellert/codediff.nvim`. The old URL in `lib.lua` still redirects but may break in the future.

## Solution

Update the release download URL in `lib.lua` to point to the new `codediff.nvim` repository name.

Closes #181