### PR TITLE
docs(readme): add repo links to FAQ integration names

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ luarocks install diffs.nvim
 Do not lazy load `diffs.nvim` with `event`, `lazy`, `ft`, `config`, or `keys` to
 control loading - `diffs.nvim` lazy-loads itself.
 
-**Q: Does diffs.nvim support [vim-fugitive](https://github.com/tpope/vim-fugitive)/[Neogit](https://github.com/NeogitOrg/neogit)/[neojj](https://github.com/NicholasZolton/neojj)/[gitsigns](https://github.com/lewis6991/gitsigns.nvim)?**
+**Q: Does diffs.nvim support
+[vim-fugitive](https://github.com/tpope/vim-fugitive)/[Neogit](https://github.com/NeogitOrg/neogit)/[neojj](https://github.com/NicholasZolton/neojj)/[gitsigns](https://github.com/lewis6991/gitsigns.nvim)?**
 
 Yes. Enable integrations in your config:
 


### PR DESCRIPTION
## Problem

The FAQ line listing supported integrations used plain text names with no links to the upstream repositories.

## Solution

Inline GitHub links for `vim-fugitive`, `Neogit`, `neojj`, and `gitsigns.nvim` in the FAQ question.