### PR TITLE
fix(init): guard `read_file_lines` against directory paths

### DIFF
--- a/lua/diffs/init.lua
+++ b/lua/diffs/init.lua
@@ -347,6 +347,9 @@ end
 ---@param path string
 ---@return string[]?
 local function read_file_lines(path)
+  if vim.fn.isdirectory(path) == 1 then
+    return nil
+  end
   local f = io.open(path, 'r')
   if not f then
     return nil

--- a/spec/context_spec.lua
+++ b/spec/context_spec.lua
@@ -165,6 +165,39 @@ describe('context', function()
       assert.is_nil(hunks[1].context_after)
     end)
 
+    it('skips when path is a directory', function()
+      vim.fn.mkdir(vim.fs.joinpath(tmpdir, 'subdir'), 'p')
+
+      local hunks = {
+        make_hunk('subdir', {
+          file_new_start = 1,
+          file_new_count = 1,
+          lines = { '+x' },
+        }),
+      }
+      compute_hunk_context(hunks, 25)
+
+      assert.is_nil(hunks[1].context_before)
+      assert.is_nil(hunks[1].context_after)
+    end)
+
+    it('skips when path is a symlink to a directory', function()
+      vim.fn.mkdir(vim.fs.joinpath(tmpdir, 'real_dir'), 'p')
+      vim.uv.fs_symlink(vim.fs.joinpath(tmpdir, 'real_dir'), vim.fs.joinpath(tmpdir, 'link_dir'))
+
+      local hunks = {
+        make_hunk('link_dir', {
+          file_new_start = 1,
+          file_new_count = 1,
+          lines = { '+x' },
+        }),
+      }
+      compute_hunk_context(hunks, 25)
+
+      assert.is_nil(hunks[1].context_before)
+      assert.is_nil(hunks[1].context_after)
+    end)
+
     it('skips when file does not exist on disk', function()
       local hunks = {
         make_hunk('nonexistent.lua', {


### PR DESCRIPTION
Closes #189.

## Problem

When a commit contains a submodule or a symlink to a directory, `read_file_lines` passes the path to `io.open` which succeeds on directories, then `f:lines()` raises `"Is a directory"` inside the decoration provider's `on_buf` callback.

## Solution

Add a `vim.fn.isdirectory(path)` guard at the top of `read_file_lines` in `init.lua` to return nil early. `compute_hunk_context` already handles nil gracefully. Two new tests in `context_spec.lua` cover both a plain directory and a symlink-to-directory.