### PR TITLE
build: add neovim to nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
               busted-with-grammar
               pkgs.prettier
               pkgs.stylua
+              pkgs.neovim
               pkgs.selene
               pkgs.lua-language-server
               vimdoc-language-server.packages.${pkgs.system}.default


### PR DESCRIPTION
## Problem

vimdoc-language-server `discover_vimruntime()` needs nvim in PATH to
resolve runtime tags in CI. The devshell didn't include neovim.

## Solution

Add `pkgs.neovim` to the nix devshell packages.