### PR TITLE
build: separate ci devshell to avoid overriding system neovim

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,37 +21,42 @@
     {
       formatter = forEachSystem (pkgs: pkgs.nixfmt-tree);
 
-      devShells = forEachSystem (pkgs: {
-        default =
-          let
-            ts-plugin = pkgs.vimPlugins.nvim-treesitter.withPlugins (p: [ p.diff ]);
-            diff-grammar = pkgs.vimPlugins.nvim-treesitter-parsers.diff;
-            luaEnv = pkgs.luajit.withPackages (
-              ps: with ps; [
-                busted
-                nlua
-              ]
-            );
-            busted-with-grammar = pkgs.writeShellScriptBin "busted" ''
-              nvim_bin=$(which nvim)
-              tmpdir=$(mktemp -d)
-              trap 'rm -rf "$tmpdir"' EXIT
-              printf '#!/bin/sh\nexec "%s" --cmd "set rtp+=${ts-plugin}/runtime" --cmd "set rtp+=${diff-grammar}" "$@"\n' "$nvim_bin" > "$tmpdir/nvim"
-              chmod +x "$tmpdir/nvim"
-              PATH="$tmpdir:$PATH" exec ${luaEnv}/bin/busted "$@"
-            '';
-          in
-          pkgs.mkShell {
-            packages = [
-              busted-with-grammar
-              pkgs.prettier
-              pkgs.stylua
-              pkgs.neovim
-              pkgs.selene
-              pkgs.lua-language-server
-              vimdoc-language-server.packages.${pkgs.system}.default
-            ];
+      devShells = forEachSystem (
+        pkgs:
+        let
+          ts-plugin = pkgs.vimPlugins.nvim-treesitter.withPlugins (p: [ p.diff ]);
+          diff-grammar = pkgs.vimPlugins.nvim-treesitter-parsers.diff;
+          luaEnv = pkgs.luajit.withPackages (
+            ps: with ps; [
+              busted
+              nlua
+            ]
+          );
+          busted-with-grammar = pkgs.writeShellScriptBin "busted" ''
+            nvim_bin=$(which nvim)
+            tmpdir=$(mktemp -d)
+            trap 'rm -rf "$tmpdir"' EXIT
+            printf '#!/bin/sh\nexec "%s" --cmd "set rtp+=${ts-plugin}/runtime" --cmd "set rtp+=${diff-grammar}" "$@"\n' "$nvim_bin" > "$tmpdir/nvim"
+            chmod +x "$tmpdir/nvim"
+            PATH="$tmpdir:$PATH" exec ${luaEnv}/bin/busted "$@"
+          '';
+          commonPackages = [
+            busted-with-grammar
+            pkgs.prettier
+            pkgs.stylua
+            pkgs.selene
+            pkgs.lua-language-server
+            vimdoc-language-server.packages.${pkgs.system}.default
+          ];
+        in
+        {
+          default = pkgs.mkShell {
+            packages = commonPackages;
           };
-      });
+          ci = pkgs.mkShell {
+            packages = commonPackages ++ [ pkgs.neovim ];
+          };
+        }
+      );
     };
 }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -eu
 
-nix develop --command stylua --check .
-git ls-files '*.lua' | xargs nix develop --command selene --display-style quiet
-nix develop --command prettier --check .
+nix develop .#ci --command stylua --check .
+git ls-files '*.lua' | xargs nix develop .#ci --command selene --display-style quiet
+nix develop .#ci --command prettier --check .
 nix fmt
 git diff --exit-code -- '*.nix'
-nix develop --command lua-language-server --check . --checklevel=Warning
-nix develop --command vimdoc-language-server check doc/ --no-runtime-tags
-nix develop --command busted
+nix develop .#ci --command lua-language-server --check . --checklevel=Warning
+nix develop .#ci --command vimdoc-language-server check doc/ --no-runtime-tags
+nix develop .#ci --command busted


### PR DESCRIPTION
## Problem

The default devshell included `pkgs.neovim` which overrode the user's system neovim (e.g. nightly) on PATH when entering the shell interactively.

## Solution

Move `pkgs.neovim` to a dedicated `ci` devshell. The default shell no longer includes neovim. `scripts/ci.sh` uses `nix develop .#ci` for all commands.