### PR TITLE
fix(fugitive): filetype attach fixes

### DIFF
--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -43,7 +43,8 @@ vim.api.nvim_create_autocmd('FileType', {
   callback = function(args)
     local diffs = require('diffs')
     if args.match == 'git' then
-      local is_fugitive = diffs.get_fugitive_config() and diffs.is_fugitive_buffer(args.buf)
+      local is_fugitive = diffs.get_fugitive_config()
+        and (diffs.is_fugitive_buffer(args.buf) or vim.b[args.buf].git_dir ~= nil)
       local is_committia = diffs.get_committia_config()
         and vim.api.nvim_buf_get_name(args.buf):match('__committia_diff__$')
       if not is_fugitive and not is_committia then


### PR DESCRIPTION
Problem: `:Git show` (and similar fugitive commands) creates temp
buffers under `/tmp/` with `filetype=git` instead of `fugitive://`
URIs. The `is_fugitive_buffer` check only matched `^fugitive://`,
so these buffers were silently skipped by the `FileType` autocmd.

Solution: also check `vim.b.git_dir` which fugitive sets on all its
managed buffers, including temp output buffers from `:Git` commands.
