### PR TITLE
fix(highlight): avoid stale vim syntax redraws

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ See the documentation for more information.
 - **Syntax "flashing"**: `diffs.nvim` hooks into the `FileType fugitive` event
   triggered by `vim-fugitive`, at which point the buffer is preliminarily
   painted. The decoration provider applies highlights on the next redraw cycle,
-  causing a brief visual "flash".
+  so a brief first-paint flash may still occur.
 
 - **Cold Start**: Treesitter grammar loading (~10ms) and query compilation
   (~4ms) are one-time costs per language per Neovim session. Each language pays
@@ -100,7 +100,9 @@ See the documentation for more information.
 - **Vim syntax fallback is deferred**: The vim syntax fallback (for languages
   without a treesitter parser) cannot run inside the decoration provider's
   redraw cycle due to Neovim's restriction on buffer mutations. Vim syntax
-  highlights for these hunks appear slightly delayed.
+  highlights for cold hunks may appear one frame later. Warm hunks can reuse
+  cached vim syntax spans, and stale deferred renders are ignored after buffer
+  changes.
 
 - **Conflicting diff plugins**: `diffs.nvim` may not interact well with other
   plugins that modify diff highlighting. Known plugins that may conflict:

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -350,9 +350,10 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              Creates a scratch buffer, sets the filetype, and
                              queries |synID()| per character to extract
                              highlight groups. Deferred via |vim.schedule()|
-                             so it never blocks the first paint. Slower than
-                             treesitter but covers languages without a TS
-                             parser installed (e.g., COBOL, Fortran).
+                             so cold renders never block the first paint.
+                             Warm hunks can reuse cached syntax spans. Slower
+                             than treesitter but covers languages without a
+                             TS parser installed (e.g., COBOL, Fortran).
 
         {max_lines}          (integer, default: 200)
                              Skip vim syntax highlighting for hunks with more
@@ -928,11 +929,15 @@ Syntax Highlighting Flash ~
                                                                  *diffs-flash*
 When opening a fugitive buffer, there is an unavoidable visual "flash" where
 the buffer briefly shows fugitive's default diff highlighting before
-diffs.nvim applies treesitter highlights.
+diffs.nvim applies its own highlights.
 
 This occurs because diffs.nvim hooks into the `FileType fugitive` event, which
 fires after vim-fugitive has already painted the buffer. The decoration
 provider applies highlights on the next redraw cycle.
+
+This is separate from vim syntax fallback rendering. For languages without a
+treesitter parser, cold fallback syntax may appear one frame later, while
+stale deferred fallback renders are discarded if the buffer changes.
 
 Conflicting Diff Plugins ~
                                                       *diffs-plugin-conflicts*

--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -3,6 +3,69 @@ local M = {}
 local dbg = require('diffs.log').dbg
 local diff = require('diffs.diff')
 
+local vim_syntax_cache = {}
+local vim_syntax_cache_size = 0
+local vim_syntax_cache_clock = 0
+local vim_syntax_cache_limit = 128
+
+local function get_vim_syntax_cache_key(ft, code_lines)
+  return ft .. '\0' .. table.concat(code_lines, '\n')
+end
+
+local function touch_vim_syntax_cache(entry)
+  vim_syntax_cache_clock = vim_syntax_cache_clock + 1
+  entry.used = vim_syntax_cache_clock
+end
+
+local function trim_vim_syntax_cache()
+  while vim_syntax_cache_size > vim_syntax_cache_limit do
+    local oldest_key = nil
+    local oldest_used = nil
+    for key, entry in pairs(vim_syntax_cache) do
+      if oldest_used == nil or entry.used < oldest_used then
+        oldest_key = key
+        oldest_used = entry.used
+      end
+    end
+    if not oldest_key then
+      break
+    end
+    vim_syntax_cache[oldest_key] = nil
+    vim_syntax_cache_size = vim_syntax_cache_size - 1
+  end
+end
+
+local function clear_vim_syntax_cache()
+  vim_syntax_cache = {}
+  vim_syntax_cache_size = 0
+  vim_syntax_cache_clock = 0
+end
+
+local function get_cached_vim_syntax_spans(ft, code_lines)
+  local key = get_vim_syntax_cache_key(ft, code_lines)
+  local entry = vim_syntax_cache[key]
+  if not entry then
+    return nil
+  end
+  touch_vim_syntax_cache(entry)
+  return entry.spans
+end
+
+local function put_vim_syntax_cache(ft, code_lines, spans)
+  local key = get_vim_syntax_cache_key(ft, code_lines)
+  local entry = vim_syntax_cache[key]
+  if not entry then
+    entry = { spans = spans }
+    vim_syntax_cache[key] = entry
+    vim_syntax_cache_size = vim_syntax_cache_size + 1
+  else
+    entry.spans = spans
+  end
+  touch_vim_syntax_cache(entry)
+  trim_vim_syntax_cache()
+  return spans
+end
+
 ---@param bufnr integer
 ---@param ns integer
 ---@param hunk diffs.Hunk
@@ -241,34 +304,7 @@ function M.coalesce_syntax_spans(query_fn, code_lines)
   return spans
 end
 
----@param bufnr integer
----@param ns integer
----@param hunk diffs.Hunk
----@param code_lines string[]
----@param covered_lines? table<integer, true>
----@param leading_offset? integer
----@param priorities diffs.PrioritiesConfig
----@return integer
-local function highlight_vim_syntax(
-  bufnr,
-  ns,
-  hunk,
-  code_lines,
-  covered_lines,
-  leading_offset,
-  priorities
-)
-  local ft = hunk.ft
-  if not ft then
-    return 0
-  end
-
-  if #code_lines == 0 then
-    return 0
-  end
-
-  leading_offset = leading_offset or 0
-
+local function compute_vim_syntax_spans(ft, code_lines)
   local scratch = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(scratch, 0, -1, false, code_lines)
   vim.api.nvim_set_option_value('bufhidden', 'wipe', { buf = scratch })
@@ -295,6 +331,20 @@ local function highlight_vim_syntax(
 
   pcall(vim.api.nvim_buf_delete, scratch, { force = true })
 
+  return spans
+end
+
+local function apply_vim_syntax_spans(
+  bufnr,
+  ns,
+  hunk,
+  spans,
+  covered_lines,
+  leading_offset,
+  priorities
+)
+  leading_offset = leading_offset or 0
+
   local hunk_line_count = #hunk.lines
   local col_off = (hunk.prefix_width or 1) + (hunk.quote_width or 0) - 1
   local extmark_count = 0
@@ -315,6 +365,67 @@ local function highlight_vim_syntax(
   end
 
   return extmark_count
+end
+
+---@param bufnr integer
+---@param ns integer
+---@param hunk diffs.Hunk
+---@param code_lines string[]
+---@param covered_lines? table<integer, true>
+---@param leading_offset? integer
+---@param priorities diffs.PrioritiesConfig
+---@return integer
+local function highlight_vim_syntax(
+  bufnr,
+  ns,
+  hunk,
+  code_lines,
+  covered_lines,
+  leading_offset,
+  priorities
+)
+  local ft = hunk.ft
+  if not ft then
+    return 0
+  end
+
+  if #code_lines == 0 then
+    return 0
+  end
+
+  local spans = get_cached_vim_syntax_spans(ft, code_lines)
+  if not spans then
+    spans = put_vim_syntax_cache(ft, code_lines, compute_vim_syntax_spans(ft, code_lines))
+  end
+
+  return apply_vim_syntax_spans(bufnr, ns, hunk, spans, covered_lines, leading_offset, priorities)
+end
+
+local function highlight_cached_vim_syntax(
+  bufnr,
+  ns,
+  hunk,
+  code_lines,
+  covered_lines,
+  leading_offset,
+  priorities
+)
+  local ft = hunk.ft
+  if not ft then
+    return 0, false
+  end
+
+  if #code_lines == 0 then
+    return 0, false
+  end
+
+  local spans = get_cached_vim_syntax_spans(ft, code_lines)
+  if not spans then
+    return 0, false
+  end
+
+  return apply_vim_syntax_spans(bufnr, ns, hunk, spans, covered_lines, leading_offset, priorities),
+    true
 end
 
 ---@param bufnr integer
@@ -352,14 +463,11 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
     end
   end
 
-  if use_vim and opts.defer_vim_syntax then
-    use_vim = false
-  end
-
   ---@type table<integer, true>
   local covered_lines = {}
 
   local extmark_count = 0
+  local vim_cache_hit = false
   ---@type string[]
   local new_code = {}
 
@@ -440,12 +548,16 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
       extmark_count = extmark_count + header_extmarks
     end
   elseif use_vim then
-    ---@type string[]
     local code_lines = {}
     for _, line in ipairs(hunk.lines) do
       table.insert(code_lines, line:sub(pw + 1))
     end
-    extmark_count = highlight_vim_syntax(bufnr, ns, hunk, code_lines, covered_lines, 0, p)
+    if opts.defer_vim_syntax then
+      extmark_count, vim_cache_hit =
+        highlight_cached_vim_syntax(bufnr, ns, hunk, code_lines, covered_lines, 0, p)
+    else
+      extmark_count = highlight_vim_syntax(bufnr, ns, hunk, code_lines, covered_lines, 0, p)
+    end
   end
 
   if
@@ -715,6 +827,14 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
   end
 
   dbg('hunk %s:%d applied %d extmarks', hunk.filename, hunk.start_line, extmark_count)
+  return extmark_count, vim_cache_hit
 end
+
+M._test = {
+  clear_vim_syntax_cache = clear_vim_syntax_cache,
+  get_vim_syntax_cache_size = function()
+    return vim_syntax_cache_size
+  end,
+}
 
 return M

--- a/lua/diffs/init.lua
+++ b/lua/diffs/init.lua
@@ -217,6 +217,83 @@ local diff_windows = {}
 ---@type table<integer, diffs.HunkCacheEntry>
 local hunk_cache = {}
 
+local syntax_jobs = {}
+
+local function next_syntax_job(bufnr)
+  local job_id = (syntax_jobs[bufnr] or 0) + 1
+  syntax_jobs[bufnr] = job_id
+  return job_id
+end
+
+local function collect_syntax_hunks(hunks)
+  local syntax_hunks = {}
+  for _, hunk in ipairs(hunks or {}) do
+    local has_syntax = hunk.lang and config.highlights.treesitter.enabled
+    local needs_vim = not hunk.lang and hunk.ft and config.highlights.vim.enabled
+    if has_syntax or needs_vim then
+      syntax_hunks[#syntax_hunks + 1] = hunk
+    end
+  end
+  return syntax_hunks
+end
+
+local function run_deferred_syntax(bufnr, tick, changedtick, job_id, deferred_syntax)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return false
+  end
+  if syntax_jobs[bufnr] ~= job_id then
+    log.dbg('deferred syntax job superseded: cur=%s job=%d', tostring(syntax_jobs[bufnr]), job_id)
+    return false
+  end
+  local live_changedtick = vim.api.nvim_buf_get_changedtick(bufnr)
+  if live_changedtick ~= changedtick then
+    log.dbg(
+      'deferred syntax changedtick changed: cur=%d captured=%d',
+      live_changedtick,
+      changedtick
+    )
+    return false
+  end
+  local cur = hunk_cache[bufnr]
+  if not cur then
+    return false
+  end
+  local hunks_to_hl = deferred_syntax
+  if cur.tick ~= tick then
+    log.dbg(
+      'deferred syntax tick changed: cur.tick=%s captured=%d, using current hunks',
+      tostring(cur.tick),
+      tick
+    )
+    hunks_to_hl = collect_syntax_hunks(cur.hunks or {})
+    if #hunks_to_hl == 0 then
+      return false
+    end
+    live_changedtick = vim.api.nvim_buf_get_changedtick(bufnr)
+    if live_changedtick ~= changedtick then
+      log.dbg(
+        'deferred syntax changedtick changed after refresh: cur=%d captured=%d',
+        live_changedtick,
+        changedtick
+      )
+      return false
+    end
+  end
+  local t1 = config.debug and vim.uv.hrtime() or nil
+  local syntax_opts = {
+    hide_prefix = config.hide_prefix,
+    highlights = config.highlights,
+    syntax_only = true,
+  }
+  for _, hunk in ipairs(hunks_to_hl) do
+    highlight.highlight_hunk(bufnr, ns, hunk, syntax_opts)
+  end
+  if t1 then
+    log.dbg('deferred pass: %d hunks in %.2fms', #hunks_to_hl, (vim.uv.hrtime() - t1) / 1e6)
+  end
+  return true
+end
+
 ---@param bufnr integer
 ---@return boolean
 function M.is_fugitive_buffer(bufnr)
@@ -265,6 +342,7 @@ local dbg = log.dbg
 
 ---@param bufnr integer
 local function invalidate_cache(bufnr)
+  syntax_jobs[bufnr] = (syntax_jobs[bufnr] or 0) + 1
   local entry = hunk_cache[bufnr]
   if entry then
     entry.tick = -1
@@ -966,14 +1044,17 @@ local function init()
             clear_start = hunk.header_start_line - 1
           end
           clear_ns_by_start(bufnr, ns, clear_start, clear_end)
-          highlight.highlight_hunk(bufnr, ns, hunk, fast_hl_opts)
+          local _, vim_cache_hit = highlight.highlight_hunk(bufnr, ns, hunk, fast_hl_opts)
           entry.highlighted[i] = true
           count = count + 1
           if hunk._skipped_max_lines then
             skipped_count = skipped_count + 1
           end
           local has_syntax = hunk.lang and config.highlights.treesitter.enabled
-          local needs_vim = not hunk.lang and hunk.ft and config.highlights.vim.enabled
+          local needs_vim = not hunk.lang
+            and hunk.ft
+            and config.highlights.vim.enabled
+            and not vim_cache_hit
           if has_syntax or needs_vim then
             table.insert(deferred_syntax, hunk)
           end
@@ -994,44 +1075,17 @@ local function init()
       end
       if #deferred_syntax > 0 then
         local tick = entry.tick
-        dbg('deferred syntax scheduled: %d hunks tick=%d', #deferred_syntax, tick)
+        local changedtick = vim.api.nvim_buf_get_changedtick(bufnr)
+        local job_id = next_syntax_job(bufnr)
+        dbg(
+          'deferred syntax scheduled: %d hunks tick=%d changedtick=%d job=%d',
+          #deferred_syntax,
+          tick,
+          changedtick,
+          job_id
+        )
         vim.schedule(function()
-          if not vim.api.nvim_buf_is_valid(bufnr) then
-            return
-          end
-          local cur = hunk_cache[bufnr]
-          if not cur then
-            return
-          end
-          local hunks_to_hl = deferred_syntax
-          if cur.tick ~= tick then
-            dbg(
-              'deferred syntax tick changed: cur.tick=%s captured=%d, using current hunks',
-              tostring(cur.tick),
-              tick
-            )
-            hunks_to_hl = {}
-            for _, hunk in ipairs(cur.hunks or {}) do
-              if hunk.lang then
-                hunks_to_hl[#hunks_to_hl + 1] = hunk
-              end
-            end
-            if #hunks_to_hl == 0 then
-              return
-            end
-          end
-          local t1 = config.debug and vim.uv.hrtime() or nil
-          local syntax_opts = {
-            hide_prefix = config.hide_prefix,
-            highlights = config.highlights,
-            syntax_only = true,
-          }
-          for _, hunk in ipairs(hunks_to_hl) do
-            highlight.highlight_hunk(bufnr, ns, hunk, syntax_opts)
-          end
-          if t1 then
-            dbg('deferred pass: %d hunks in %.2fms', #deferred_syntax, (vim.uv.hrtime() - t1) / 1e6)
-          end
+          run_deferred_syntax(bufnr, tick, changedtick, job_id, deferred_syntax)
         end)
       end
       if t0 and count > 0 then
@@ -1109,6 +1163,7 @@ function M.attach(bufnr)
       attached_buffers[bufnr] = nil
       hunk_cache[bufnr] = nil
       ft_retry_pending[bufnr] = nil
+      syntax_jobs[bufnr] = nil
       if neogit_augroup then
         pcall(vim.api.nvim_del_augroup_by_id, neogit_augroup)
       end
@@ -1230,6 +1285,8 @@ M._test = {
   get_config = function()
     return config
   end,
+  next_syntax_job = next_syntax_job,
+  run_deferred_syntax = run_deferred_syntax,
 }
 
 return M

--- a/spec/decoration_provider_spec.lua
+++ b/spec/decoration_provider_spec.lua
@@ -149,6 +149,52 @@ describe('decoration_provider', function()
     end)
   end)
 
+  describe('deferred vim syntax', function()
+    it('skips stale deferred vim syntax when changedtick advanced', function()
+      local orig_synID = vim.fn.synID
+      local orig_synIDtrans = vim.fn.synIDtrans
+      local orig_synIDattr = vim.fn.synIDattr
+      vim.fn.synID = function(_line, _col, _trans)
+        return 1
+      end
+      vim.fn.synIDtrans = function(id)
+        return id
+      end
+      vim.fn.synIDattr = function(_id, _what)
+        return 'Identifier'
+      end
+
+      local bufnr = create_buffer({
+        'M video.txt',
+        '@@ -1,1 +1,2 @@',
+        ' alpha',
+        '+beta',
+      })
+      diffs.attach(bufnr)
+      local entry = diffs._test.hunk_cache[bufnr]
+      local changedtick = vim.api.nvim_buf_get_changedtick(bufnr)
+      local job_id = diffs._test.next_syntax_job(bufnr)
+
+      vim.api.nvim_buf_set_lines(bufnr, 1, 4, false, {
+        '@@ -1,1 +1,1 @@',
+        ' gamma',
+      })
+
+      local ok =
+        diffs._test.run_deferred_syntax(bufnr, entry.tick, changedtick, job_id, { entry.hunks[1] })
+      local ns_id = vim.api.nvim_create_namespace('diffs')
+      local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, ns_id, 0, -1, { details = true })
+
+      vim.fn.synID = orig_synID
+      vim.fn.synIDtrans = orig_synIDtrans
+      vim.fn.synIDattr = orig_synIDattr
+
+      assert.is_false(ok)
+      assert.are.equal(0, #extmarks)
+      delete_buffer(bufnr)
+    end)
+  end)
+
   describe('BufWipeout cleanup', function()
     it('removes hunk_cache entry after buffer wipeout', function()
       local bufnr = create_buffer({

--- a/spec/highlight_spec.lua
+++ b/spec/highlight_spec.lua
@@ -7,6 +7,7 @@ describe('highlight', function()
 
     before_each(function()
       ns = vim.api.nvim_create_namespace('diffs_test')
+      highlight._test.clear_vim_syntax_cache()
       local normal = vim.api.nvim_get_hl(0, { name = 'Normal' })
       local diff_add = vim.api.nvim_get_hl(0, { name = 'DiffAdd' })
       local diff_delete = vim.api.nvim_get_hl(0, { name = 'DiffDelete' })
@@ -14,6 +15,10 @@ describe('highlight', function()
       vim.api.nvim_set_hl(0, 'DiffsAdd', { bg = diff_add.bg })
       vim.api.nvim_set_hl(0, 'DiffsDelete', { bg = diff_delete.bg })
       vim.api.nvim_set_hl(0, 'DiffsConflictMarker', { fg = 0x808080, bold = true })
+    end)
+
+    after_each(function()
+      highlight._test.clear_vim_syntax_cache()
     end)
 
     local function create_buffer(lines)
@@ -692,6 +697,73 @@ describe('highlight', function()
       end
       assert.is_true(has_syntax_hl)
       delete_buffer(bufnr)
+    end)
+
+    it('uses cached vim syntax extmarks when defer_vim_syntax enabled', function()
+      local orig_synID = vim.fn.synID
+      local orig_synIDtrans = vim.fn.synIDtrans
+      local orig_synIDattr = vim.fn.synIDattr
+      vim.fn.synID = function(_line, _col, _trans)
+        return 1
+      end
+      vim.fn.synIDtrans = function(id)
+        return id
+      end
+      vim.fn.synIDattr = function(_id, _what)
+        return 'Identifier'
+      end
+
+      highlight._test.clear_vim_syntax_cache()
+
+      local warm_bufnr = create_buffer({
+        '@@ -1,1 +1,2 @@',
+        ' alpha',
+        '+beta',
+      })
+
+      local cached_bufnr = create_buffer({
+        '@@ -1,1 +1,2 @@',
+        ' alpha',
+        '+beta',
+      })
+
+      local hunk = {
+        filename = 'video.txt',
+        ft = 'text',
+        lang = nil,
+        start_line = 1,
+        lines = { ' alpha', '+beta' },
+      }
+
+      highlight.highlight_hunk(
+        warm_bufnr,
+        ns,
+        hunk,
+        default_opts({ highlights = { treesitter = { enabled = false }, vim = { enabled = true } } })
+      )
+
+      local opts = default_opts({
+        highlights = { treesitter = { enabled = false }, vim = { enabled = true } },
+      })
+      opts.defer_vim_syntax = true
+      highlight.highlight_hunk(cached_bufnr, ns, hunk, opts)
+
+      vim.fn.synID = orig_synID
+      vim.fn.synIDtrans = orig_synIDtrans
+      vim.fn.synIDattr = orig_synIDattr
+
+      local extmarks = get_extmarks(cached_bufnr)
+      local has_syntax_hl = false
+      for _, mark in ipairs(extmarks) do
+        if mark[4] and mark[4].hl_group == 'Identifier' then
+          has_syntax_hl = true
+          break
+        end
+      end
+      assert.is_true(has_syntax_hl)
+      delete_buffer(warm_bufnr)
+      delete_buffer(cached_bufnr)
+      highlight._test.clear_vim_syntax_cache()
     end)
 
     it('respects vim.max_lines', function()


### PR DESCRIPTION
## Summary
- cache vim fallback syntax spans so deferred renders can reuse warm syntax immediately instead of always waiting for a scratch-buffer pass
- track per-buffer deferred syntax jobs and changedticks so stale scheduled syntax work is skipped after buffer changes or refreshes
- add regression coverage for cached vim syntax reuse and stale deferred syntax cancellation

#### Test plan
- [x] nix develop -c busted spec/highlight_spec.lua
- [x] nix develop -c busted spec/decoration_provider_spec.lua
- [x] nix develop -c busted
- [x] nix develop -c stylua --check lua/diffs/highlight.lua lua/diffs/init.lua spec/highlight_spec.lua spec/decoration_provider_spec.lua