### PR TITLE
fix: always attach for configured filetypes

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -224,12 +224,9 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                                    extra_filetypes = { 'diff' },
                                  }
 <
-                             Adding `'diff'` also enables highlighting in
-                             picker preview buffers that set `filetype=diff`:
-                             telescope.nvim (git_commits, git_bcommits,
-                             git_status), snacks.nvim (syntax style only),
-                             and fzf-lua (builtin previewer only). Terminal-
-                             based previewers are not supported.
+                             This also covers any other buffer (e.g.
+                             scratch preview buffers from pickers) that
+                             ends up with a registered filetype.
 
         {highlights}         (table, default: see below)
                              Controls which highlight features are enabled.
@@ -900,8 +897,9 @@ after each resolution.
 API                                                                *diffs-api*
 
 attach({bufnr})                                               *diffs.attach()*
-    Manually attach highlighting to a buffer. Called automatically for
-    fugitive buffers via the `FileType fugitive` autocmd.
+    Attach highlighting to a buffer. Called automatically when the buffer's
+    filetype matches `git`, `gitcommit`, an enabled integration filetype,
+    or any entry in `extra_filetypes`.
 
     Parameters: ~
         {bufnr}  (integer, optional) Buffer number. Defaults to current buffer.
@@ -918,7 +916,7 @@ IMPLEMENTATION                                          *diffs-implementation*
 
 Summary / commit detail views: ~
 1. `FileType` autocmd for computed filetypes (see |diffs-config|) triggers
-   |diffs.attach()|. For `git` buffers, only `fugitive://` URIs are attached.
+   |diffs.attach()|.
 2. The buffer is parsed to detect file headers (`M path/to/file`,
    `diff --git a/... b/...`) and hunk headers (`@@ -10,3 +10,4 @@`)
 3. For each hunk:

--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -42,15 +42,6 @@ vim.api.nvim_create_autocmd('FileType', {
   pattern = require('diffs').compute_filetypes(vim.g.diffs or {}),
   callback = function(args)
     local diffs = require('diffs')
-    if args.match == 'git' then
-      local is_fugitive = diffs.get_fugitive_config()
-        and (diffs.is_fugitive_buffer(args.buf) or vim.b[args.buf].git_dir ~= nil)
-      local is_committia = diffs.get_committia_config()
-        and vim.api.nvim_buf_get_name(args.buf):match('__committia_diff__$')
-      if not is_fugitive and not is_committia then
-        return
-      end
-    end
     diffs.attach(args.buf)
 
     if args.match == 'fugitive' then


### PR DESCRIPTION
The `FileType` autocmd previously bailed out for `ft=git` buffers unless they were fugitive (`fugitive://` URI or `b:git_dir` set) or committia (`__committia_diff__$` name). This blocked highlighting on every other legitimate `ft=git` source: scratch preview buffers from pickers (fzf-lua, telescope, snacks), piped `git show`/`git log` output, and any `:setf git` buffer.

Removing the bailout makes attach unconditional for every filetype returned by `compute_filetypes`. Non-diff buffers parse to zero hunks and produce no extmarks, so the cost on `.git/HEAD`, refs, and similar small files is negligible.

`is_fugitive_buffer` and `get_committia_config` remain as public API for any external consumer; they're just no longer used internally to gate attach.

Vimdoc updated for the three sites that documented the old gate (`extra_filetypes`, `attach()`, IMPLEMENTATION).