### PR TITLE
fix: make conflict keymaps opt-in

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -125,14 +125,7 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
         disable_diagnostics = true,
         show_virtual_text = true,
         show_actions = false,
-        keymaps = {
-          ours = 'co',
-          theirs = 'ct',
-          both = 'cb',
-          none = 'c0',
-          next = ']c',
-          prev = '[c',
-        },
+        keymaps = false,
       },
     }
 <
@@ -565,12 +558,12 @@ Example configuration: >lua
                         Jump to previous conflict marker. Wraps around.
 
 Example configuration: >lua
-    vim.keymap.set('n', 'co', '<Plug>(diffs-conflict-ours)')
-    vim.keymap.set('n', 'ct', '<Plug>(diffs-conflict-theirs)')
-    vim.keymap.set('n', 'cb', '<Plug>(diffs-conflict-both)')
-    vim.keymap.set('n', 'cn', '<Plug>(diffs-conflict-none)')
-    vim.keymap.set('n', ']c', '<Plug>(diffs-conflict-next)')
-    vim.keymap.set('n', '[c', '<Plug>(diffs-conflict-prev)')
+    vim.keymap.set('n', '<leader>co', '<Plug>(diffs-conflict-ours)')
+    vim.keymap.set('n', '<leader>ct', '<Plug>(diffs-conflict-theirs)')
+    vim.keymap.set('n', '<leader>cb', '<Plug>(diffs-conflict-both)')
+    vim.keymap.set('n', '<leader>c0', '<Plug>(diffs-conflict-none)')
+    vim.keymap.set('n', ']x', '<Plug>(diffs-conflict-next)')
+    vim.keymap.set('n', '[x', '<Plug>(diffs-conflict-prev)')
 <
 
                                                     *<Plug>(diffs-merge-ours)*
@@ -771,13 +764,20 @@ Configuration: ~
         show_virtual_text = true,
         show_actions = false,
         priority = 200,
+        keymaps = false,
+      },
+    }
+<
+    To opt in to buffer-local mappings, provide a table: >lua
+    vim.g.diffs = {
+      conflict = {
         keymaps = {
-          ours = 'co',
-          theirs = 'ct',
-          both = 'cb',
-          none = 'c0',
-          next = ']c',
-          prev = '[c',
+          ours = '<leader>co',
+          theirs = '<leader>ct',
+          both = '<leader>cb',
+          none = '<leader>c0',
+          next = ']x',
+          prev = '[x',
         },
       },
     }
@@ -821,37 +821,39 @@ Configuration: ~
                              Show a codelens-style action line above each
                              `<<<<<<<` marker listing available resolution
                              keymaps. Renders as virtual lines using the
-                             `DiffsConflictActions` highlight group.
-                             Only keymaps that are not `false` appear.
+                             `DiffsConflictActions` highlight group. Only
+                             configured keymaps appear.
 
         {priority}           (integer, default: 200)
                              Extmark priority for conflict region
                              backgrounds and markers. Adjust if other
                              plugins use the same priority range.
 
-        {keymaps}            (table, default: see above)
-                             Buffer-local keymaps for conflict resolution
-                             and navigation. Each value accepts a string
-                             (custom key) or `false` (disabled).
+        {keymaps}            (table|false, default: false)
+                             Opt-in buffer-local keymaps for conflict
+                             resolution and navigation in conflicted
+                             working buffers and merge diff views. Pass a
+                             table to enable plugin-defined mappings.
+                             Unspecified fields remain disabled.
 
                                                        *diffs.ConflictKeymaps*
     Keymap fields: ~
-        {ours}               (string|false, default: 'co')
+        {ours}               (string|false, default: false)
                              Accept current (ours) change.
 
-        {theirs}             (string|false, default: 'ct')
+        {theirs}             (string|false, default: false)
                              Accept incoming (theirs) change.
 
-        {both}               (string|false, default: 'cb')
+        {both}               (string|false, default: false)
                              Accept both changes (ours then theirs).
 
-        {none}               (string|false, default: 'c0')
+        {none}               (string|false, default: false)
                              Reject both changes (delete entire block).
 
-        {next}               (string|false, default: ']c')
+        {next}               (string|false, default: false)
                              Jump to next conflict marker. Wraps around.
 
-        {prev}               (string|false, default: '[c')
+        {prev}               (string|false, default: false)
                              Jump to previous conflict marker. Wraps
                              around.
 

--- a/lua/diffs/conflict.lua
+++ b/lua/diffs/conflict.lua
@@ -12,6 +12,8 @@
 
 local M = {}
 
+local keymaps = require('diffs.keymaps')
+
 local ns = vim.api.nvim_create_namespace('diffs-conflict')
 
 ---@type table<integer, true>
@@ -19,6 +21,9 @@ local attached_buffers = {}
 
 ---@type table<integer, boolean>
 local diagnostics_suppressed = {}
+
+---@type table<integer, string[]>
+local buffer_keymaps = {}
 
 ---@param lines string[]
 ---@return diffs.ConflictRegion[]
@@ -95,11 +100,14 @@ end
 ---@return string?
 local function get_virtual_text_label(side, config)
   if config.format_virtual_text then
-    local keymap = side == 'ours' and config.keymaps.ours or config.keymaps.theirs
+    local keymap = side == 'ours' and keymaps.get_conflict_keymap(config, 'ours')
+      or keymaps.get_conflict_keymap(config, 'theirs')
     return config.format_virtual_text(side, keymap)
   end
   return side == 'ours' and 'current' or 'incoming'
 end
+
+local setup_keymaps
 
 ---@param bufnr integer
 ---@param regions diffs.ConflictRegion[]
@@ -128,10 +136,10 @@ local function apply_highlights(bufnr, regions, config)
     if config.show_actions then
       local parts = {}
       local actions = {
-        { 'Current', config.keymaps.ours },
-        { 'Incoming', config.keymaps.theirs },
-        { 'Both', config.keymaps.both },
-        { 'None', config.keymaps.none },
+        { 'Current', keymaps.get_conflict_keymap(config, 'ours') },
+        { 'Incoming', keymaps.get_conflict_keymap(config, 'theirs') },
+        { 'Both', keymaps.get_conflict_keymap(config, 'both') },
+        { 'None', keymaps.get_conflict_keymap(config, 'none') },
       }
       for _, action in ipairs(actions) do
         if action[2] then
@@ -254,6 +262,7 @@ function M.refresh(bufnr, config)
   local regions = parse_buffer(bufnr)
   if #regions == 0 then
     vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
+    keymaps.clear_buffer_keymaps(buffer_keymaps, bufnr)
     if diagnostics_suppressed[bufnr] then
       pcall(vim.diagnostic.reset, nil, bufnr)
       pcall(vim.diagnostic.enable, true, { bufnr = bufnr })
@@ -263,6 +272,9 @@ function M.refresh(bufnr, config)
     return
   end
   apply_highlights(bufnr, regions, config)
+  if not buffer_keymaps[bufnr] then
+    setup_keymaps(bufnr, config)
+  end
   if config.disable_diagnostics and not diagnostics_suppressed[bufnr] then
     pcall(vim.diagnostic.enable, false, { bufnr = bufnr })
     diagnostics_suppressed[bufnr] = true
@@ -386,28 +398,27 @@ end
 
 ---@param bufnr integer
 ---@param config diffs.ConflictConfig
-local function setup_keymaps(bufnr, config)
+setup_keymaps = function(bufnr, config)
   local km = config.keymaps
+  if km == false then
+    keymaps.clear_buffer_keymaps(buffer_keymaps, bufnr)
+    return
+  end
 
-  local maps = {
+  keymaps.set_buffer_keymaps(buffer_keymaps, bufnr, {
     { km.ours, '<Plug>(diffs-conflict-ours)' },
     { km.theirs, '<Plug>(diffs-conflict-theirs)' },
     { km.both, '<Plug>(diffs-conflict-both)' },
     { km.none, '<Plug>(diffs-conflict-none)' },
     { km.next, '<Plug>(diffs-conflict-next)' },
     { km.prev, '<Plug>(diffs-conflict-prev)' },
-  }
-
-  for _, map in ipairs(maps) do
-    if map[1] then
-      vim.keymap.set('n', map[1], map[2], { buffer = bufnr })
-    end
-  end
+  })
 end
 
 ---@param bufnr integer
 function M.detach(bufnr)
   vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
+  keymaps.clear_buffer_keymaps(buffer_keymaps, bufnr)
   attached_buffers[bufnr] = nil
 
   if diagnostics_suppressed[bufnr] then
@@ -465,6 +476,7 @@ function M.attach(bufnr, config)
   vim.api.nvim_create_autocmd('BufWipeout', {
     buffer = bufnr,
     callback = function()
+      keymaps.clear_buffer_keymaps(buffer_keymaps, bufnr)
       attached_buffers[bufnr] = nil
       diagnostics_suppressed[bufnr] = nil
     end,

--- a/lua/diffs/init.lua
+++ b/lua/diffs/init.lua
@@ -55,6 +55,8 @@
 ---@field next string|false
 ---@field prev string|false
 
+---@alias diffs.ConflictKeymapName 'ours' | 'theirs' | 'both' | 'none' | 'next' | 'prev'
+
 ---@class diffs.ConflictConfig
 ---@field enabled boolean
 ---@field disable_diagnostics boolean
@@ -62,7 +64,7 @@
 ---@field format_virtual_text? fun(side: string, keymap: string|false): string?
 ---@field show_actions boolean
 ---@field priority integer
----@field keymaps diffs.ConflictKeymaps
+---@field keymaps diffs.ConflictKeymaps|false
 
 ---@class diffs.IntegrationsConfig
 ---@field fugitive diffs.FugitiveConfig|false
@@ -176,14 +178,7 @@ local default_config = {
     show_virtual_text = true,
     show_actions = false,
     priority = 200,
-    keymaps = {
-      ours = 'co',
-      theirs = 'ct',
-      both = 'cb',
-      none = 'c0',
-      next = ']c',
-      prev = '[c',
-    },
+    keymaps = false,
   },
 }
 
@@ -911,11 +906,13 @@ local function init()
     )
     vim.validate('conflict.show_actions', opts.conflict.show_actions, 'boolean', true)
     vim.validate('conflict.priority', opts.conflict.priority, 'number', true)
-    vim.validate('conflict.keymaps', opts.conflict.keymaps, 'table', true)
+    vim.validate('conflict.keymaps', opts.conflict.keymaps, function(v)
+      return v == nil or v == false or type(v) == 'table'
+    end, 'table or false')
 
-    if opts.conflict.keymaps then
+    if type(opts.conflict.keymaps) == 'table' then
       local keymap_validator = function(v)
-        return v == false or type(v) == 'string'
+        return v == nil or v == false or type(v) == 'string'
       end
       for _, key in ipairs({ 'ours', 'theirs', 'both', 'none', 'next', 'prev' }) do
         vim.validate(

--- a/lua/diffs/keymaps.lua
+++ b/lua/diffs/keymaps.lua
@@ -1,0 +1,45 @@
+local M = {}
+
+---@param config diffs.ConflictConfig
+---@param key diffs.ConflictKeymapName
+---@return string|false
+function M.get_conflict_keymap(config, key)
+  local keymaps = config.keymaps
+  if keymaps == false then
+    return false
+  end
+  return keymaps[key] or false
+end
+
+---@param registry table<integer, string[]>
+---@param bufnr integer
+function M.clear_buffer_keymaps(registry, bufnr)
+  local keymaps = registry[bufnr]
+  if not keymaps then
+    return
+  end
+  for _, keymap in ipairs(keymaps) do
+    pcall(vim.keymap.del, 'n', keymap, { buffer = bufnr })
+  end
+  registry[bufnr] = nil
+end
+
+---@param registry table<integer, string[]>
+---@param bufnr integer
+---@param maps [string|false, string][]
+function M.set_buffer_keymaps(registry, bufnr, maps)
+  M.clear_buffer_keymaps(registry, bufnr)
+
+  local installed = {}
+  for _, map in ipairs(maps) do
+    if map[1] then
+      vim.keymap.set('n', map[1], map[2], { buffer = bufnr })
+      installed[#installed + 1] = map[1]
+    end
+  end
+  if #installed > 0 then
+    registry[bufnr] = installed
+  end
+end
+
+return M

--- a/lua/diffs/merge.lua
+++ b/lua/diffs/merge.lua
@@ -1,11 +1,15 @@
 local M = {}
 
 local conflict = require('diffs.conflict')
+local keymaps = require('diffs.keymaps')
 
 local ns = vim.api.nvim_create_namespace('diffs-merge')
 
 ---@type table<integer, table<integer, true>>
 local resolved_hunks = {}
+
+---@type table<integer, string[]>
+local buffer_keymaps = {}
 
 ---@class diffs.MergeHunkInfo
 ---@field index integer
@@ -354,10 +358,10 @@ local function apply_hunk_hints(bufnr, config)
     else
       local parts = {}
       local actions = {
-        { 'current', config.keymaps.ours },
-        { 'incoming', config.keymaps.theirs },
-        { 'both', config.keymaps.both },
-        { 'none', config.keymaps.none },
+        { 'current', keymaps.get_conflict_keymap(config, 'ours') },
+        { 'incoming', keymaps.get_conflict_keymap(config, 'theirs') },
+        { 'both', keymaps.get_conflict_keymap(config, 'both') },
+        { 'none', keymaps.get_conflict_keymap(config, 'none') },
       }
       for _, action in ipairs(actions) do
         if action[2] then
@@ -384,20 +388,17 @@ function M.setup_keymaps(bufnr, config)
   vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
 
   local km = config.keymaps
-
-  local maps = {
-    { km.ours, '<Plug>(diffs-merge-ours)' },
-    { km.theirs, '<Plug>(diffs-merge-theirs)' },
-    { km.both, '<Plug>(diffs-merge-both)' },
-    { km.none, '<Plug>(diffs-merge-none)' },
-    { km.next, '<Plug>(diffs-merge-next)' },
-    { km.prev, '<Plug>(diffs-merge-prev)' },
-  }
-
-  for _, map in ipairs(maps) do
-    if map[1] then
-      vim.keymap.set('n', map[1], map[2], { buffer = bufnr })
-    end
+  if km ~= false then
+    keymaps.set_buffer_keymaps(buffer_keymaps, bufnr, {
+      { km.ours, '<Plug>(diffs-merge-ours)' },
+      { km.theirs, '<Plug>(diffs-merge-theirs)' },
+      { km.both, '<Plug>(diffs-merge-both)' },
+      { km.none, '<Plug>(diffs-merge-none)' },
+      { km.next, '<Plug>(diffs-merge-next)' },
+      { km.prev, '<Plug>(diffs-merge-prev)' },
+    })
+  else
+    keymaps.clear_buffer_keymaps(buffer_keymaps, bufnr)
   end
 
   apply_hunk_hints(bufnr, config)
@@ -405,6 +406,7 @@ function M.setup_keymaps(bufnr, config)
   vim.api.nvim_create_autocmd('BufWipeout', {
     buffer = bufnr,
     callback = function()
+      keymaps.clear_buffer_keymaps(buffer_keymaps, bufnr)
       resolved_hunks[bufnr] = nil
     end,
   })

--- a/spec/conflict_spec.lua
+++ b/spec/conflict_spec.lua
@@ -7,14 +7,7 @@ local function default_config(overrides)
     disable_diagnostics = false,
     show_virtual_text = true,
     show_actions = false,
-    keymaps = {
-      ours = 'co',
-      theirs = 'ct',
-      both = 'cb',
-      none = 'c0',
-      next = ']c',
-      prev = '[c',
-    },
+    keymaps = false,
   }
   if overrides then
     cfg = vim.tbl_deep_extend('force', cfg, overrides)
@@ -304,6 +297,97 @@ describe('conflict', function()
 
       conflict.detach(bufnr)
       assert.are.equal(0, #get_extmarks(bufnr))
+
+      helpers.delete_buffer(bufnr)
+    end)
+  end)
+
+  describe('keymaps', function()
+    it('does not set buffer-local keymaps when disabled', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+
+      conflict.attach(bufnr, default_config())
+
+      assert.is_false(helpers.has_keymap(bufnr, 'gt'))
+
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('removes buffer-local keymaps on detach', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+      local cfg = default_config({ keymaps = helpers.default_conflict_keymaps() })
+
+      conflict.attach(bufnr, cfg)
+
+      assert.is_true(helpers.has_keymap(bufnr, 'gt'))
+
+      conflict.detach(bufnr)
+
+      assert.is_false(helpers.has_keymap(bufnr, 'gt'))
+
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('removes buffer-local keymaps when all conflicts are resolved', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+      local cfg = default_config({ keymaps = helpers.default_conflict_keymaps() })
+
+      conflict.attach(bufnr, cfg)
+
+      assert.is_true(helpers.has_keymap(bufnr, 'gt'))
+
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'local x = 2' })
+      conflict.refresh(bufnr, cfg)
+
+      assert.is_false(helpers.has_keymap(bufnr, 'gt'))
+
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('reinstalls buffer-local keymaps when conflicts return', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+      local cfg = default_config({ keymaps = helpers.default_conflict_keymaps() })
+
+      conflict.attach(bufnr, cfg)
+
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'local x = 2' })
+      conflict.refresh(bufnr, cfg)
+      assert.is_false(helpers.has_keymap(bufnr, 'gt'))
+
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+      conflict.refresh(bufnr, cfg)
+
+      assert.is_true(helpers.has_keymap(bufnr, 'gt'))
 
       helpers.delete_buffer(bufnr)
     end)
@@ -825,7 +909,10 @@ describe('conflict', function()
         '>>>>>>> feature',
       })
 
-      conflict.attach(bufnr, default_config({ show_actions = true }))
+      conflict.attach(
+        bufnr,
+        default_config({ show_actions = true, keymaps = helpers.default_conflict_keymaps() })
+      )
 
       local extmarks = get_extmarks(bufnr)
       local virt_lines_count = 0
@@ -850,7 +937,10 @@ describe('conflict', function()
 
       conflict.attach(
         bufnr,
-        default_config({ show_actions = true, keymaps = { both = false, none = false } })
+        default_config({
+          show_actions = true,
+          keymaps = helpers.default_conflict_keymaps({ both = false, none = false }),
+        })
       )
 
       local extmarks = get_extmarks(bufnr)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -16,6 +16,21 @@ ensure_parser('vim')
 
 local M = {}
 
+function M.default_conflict_keymaps(overrides)
+  local keymaps = {
+    ours = 'go',
+    theirs = 'gt',
+    both = 'gb',
+    none = 'g0',
+    next = ']x',
+    prev = '[x',
+  }
+  if overrides then
+    keymaps = vim.tbl_extend('force', keymaps, overrides)
+  end
+  return keymaps
+end
+
 function M.create_buffer(lines)
   local bufnr = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines or {})
@@ -30,6 +45,15 @@ end
 
 function M.get_extmarks(bufnr, ns)
   return vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
+end
+
+function M.has_keymap(bufnr, lhs)
+  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, 'n')) do
+    if keymap.lhs == lhs then
+      return true
+    end
+  end
+  return false
 end
 
 return M

--- a/spec/merge_spec.lua
+++ b/spec/merge_spec.lua
@@ -7,14 +7,7 @@ local function default_config(overrides)
     disable_diagnostics = false,
     show_virtual_text = true,
     show_actions = false,
-    keymaps = {
-      ours = 'co',
-      theirs = 'ct',
-      both = 'cb',
-      none = 'c0',
-      next = ']c',
-      prev = '[c',
-    },
+    keymaps = false,
   }
   if overrides then
     cfg = vim.tbl_deep_extend('force', cfg, overrides)
@@ -695,7 +688,7 @@ describe('merge', function()
   end)
 
   describe('hunk hints', function()
-    it('adds keymap hints on hunk header lines', function()
+    it('does not add keymap hints without keymaps', function()
       local d_bufnr = create_diff_buffer({
         'diff --git a/file.lua b/file.lua',
         '--- a/file.lua',
@@ -712,6 +705,31 @@ describe('merge', function()
       local hint_marks = {}
       for _, mark in ipairs(extmarks) do
         if mark[4] and mark[4].virt_text then
+          table.insert(hint_marks, mark)
+        end
+      end
+      assert.are.equal(0, #hint_marks)
+
+      helpers.delete_buffer(d_bufnr)
+    end)
+
+    it('adds keymap hints on hunk header lines when keymaps are configured', function()
+      local d_bufnr = create_diff_buffer({
+        'diff --git a/file.lua b/file.lua',
+        '--- a/file.lua',
+        '+++ b/file.lua',
+        '@@ -1,1 +1,1 @@',
+        '-local x = 1',
+        '+local x = 2',
+      })
+
+      merge.setup_keymaps(d_bufnr, default_config({ keymaps = helpers.default_conflict_keymaps() }))
+
+      local extmarks =
+        vim.api.nvim_buf_get_extmarks(d_bufnr, merge.get_namespace(), 0, -1, { details = true })
+      local hint_marks = {}
+      for _, mark in ipairs(extmarks) do
+        if mark[4] and mark[4].virt_text then
           local text = ''
           for _, chunk in ipairs(mark[4].virt_text) do
             text = text .. chunk[1]
@@ -721,8 +739,8 @@ describe('merge', function()
       end
       assert.are.equal(1, #hint_marks)
       assert.are.equal(3, hint_marks[1].line)
-      assert.is_truthy(hint_marks[1].text:find('co'))
-      assert.is_truthy(hint_marks[1].text:find('ct'))
+      assert.is_truthy(hint_marks[1].text:find('go'))
+      assert.is_truthy(hint_marks[1].text:find('gt'))
 
       helpers.delete_buffer(d_bufnr)
     end)


### PR DESCRIPTION
## Problem

Issue #223 reports that conflict resolution mappings can show up in unwanted situations, including clobbering core motions like `ct` and diff-style navigation keys. The current conflict support installs default buffer-local mappings in normal worktree buffers and can leave those mappings behind after conflict markers are resolved.

## Solution

Make conflict and merge keymaps opt-in by default, keep the `<Plug>` targets as the manual mapping surface, and clear any installed buffer-local mappings when conflict state ends or a buffer detaches. Update the docs to describe the opt-in policy and add specs that cover keymap installation, cleanup on detach/resolve, reinstallation when conflicts return, and merge-hint behavior without configured keymaps.

Closes #223.