### PR TITLE
fix: preserve host treesitter assets in repros

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -64,6 +64,7 @@ body:
         Confirm the bug reproduces with this config before submitting.
       render: lua
       value: |
+        local host_data_site = vim.fn.stdpath('data') .. '/site'
         local root = vim.fn.fnamemodify('.repro', ':p')
         vim.fn.mkdir(root, 'p')
         vim.env.XDG_CONFIG_HOME = root
@@ -74,6 +75,9 @@ body:
         local data_site = vim.fn.stdpath('data') .. '/site'
         vim.fn.mkdir(data_site, 'p')
         vim.opt.packpath:prepend(data_site)
+        if vim.uv.fs_stat(host_data_site) then
+          vim.opt.runtimepath:append(host_data_site)
+        end
 
         vim.o.background = 'dark'
         vim.cmd.colorscheme('habamax')

--- a/minimal_init.lua
+++ b/minimal_init.lua
@@ -3,12 +3,16 @@ vim.o.background = 'dark'
 vim.o.number = true
 vim.o.relativenumber = true
 
+local host_data_site = vim.fn.stdpath('data') .. '/site'
 local root = vim.fn.fnamemodify('/tmp/diffs-harivansh-repro', ':p')
 vim.opt.packpath = { root }
 vim.env.XDG_CONFIG_HOME = root
 vim.env.XDG_DATA_HOME = root
 vim.env.XDG_STATE_HOME = root
 vim.env.XDG_CACHE_HOME = root
+if vim.uv.fs_stat(host_data_site) then
+  vim.opt.rtp:append(host_data_site)
+end
 
 vim.opt.rtp:prepend(vim.fn.expand('~/dev/diffs.nvim'))
 


### PR DESCRIPTION
This updates the issue-template repro and local minimal-init helper to preserve the original Neovim data-site runtime after redirecting XDG paths. Under Neovim 0.12 that keeps user-installed parser and query assets available on runtimepath, so language-specific diff highlighting can still be reproduced without loading the rest of the user's config.

I verified the change against the Elixir fugitive case from #221: with the preserved host data-site runtime, the clean repro resolves , , and applies Treesitter highlight extmarks again. 