### PR TITLE
Express Gdiff revision buffers with DiffSpec

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local diffspec = require('diffs.spec')
 local git = require('diffs.git')
 local dbg = require('diffs.log').dbg
 local runtime = require('diffs.runtime')
@@ -88,6 +89,13 @@ local function generate_unified_diff(old_lines, new_lines, old_name, new_name)
   return result
 end
 
+---@param revision? string
+---@param rel_path string
+---@return diffs.DiffSpec
+local function gdiff_revision_spec(revision, rel_path)
+  return diffspec.rev_to_worktree(revision or 'HEAD', rel_path)
+end
+
 ---@param raw_lines string[]
 ---@param repo_root string
 ---@return string[]
@@ -118,8 +126,6 @@ end
 ---@param revision? string
 ---@param vertical? boolean
 function M.gdiff(revision, vertical)
-  revision = revision or 'HEAD'
-
   local bufnr = vim.api.nvim_get_current_buf()
   local filepath = vim.api.nvim_buf_get_name(bufnr)
 
@@ -134,7 +140,11 @@ function M.gdiff(revision, vertical)
     return
   end
 
-  local old_lines, err = git.get_file_content(revision, filepath)
+  local diff_spec = gdiff_revision_spec(revision, rel_path)
+  local revision_label = diff_spec.left.rev
+  local diff_path = diff_spec.scope.path
+
+  local old_lines, err = git.get_file_content(revision_label, filepath)
   if not old_lines then
     vim.notify('[diffs.nvim]: ' .. (err or 'unknown error'), vim.log.levels.ERROR)
     return
@@ -142,10 +152,10 @@ function M.gdiff(revision, vertical)
 
   local new_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
-  local diff_lines = generate_unified_diff(old_lines, new_lines, rel_path, rel_path)
+  local diff_lines = generate_unified_diff(old_lines, new_lines, diff_path, diff_path)
 
   if #diff_lines == 0 then
-    vim.notify('[diffs.nvim]: no diff against ' .. revision, vim.log.levels.INFO)
+    vim.notify('[diffs.nvim]: no diff against ' .. revision_label, vim.log.levels.INFO)
     return
   end
 
@@ -158,7 +168,7 @@ function M.gdiff(revision, vertical)
   vim.api.nvim_set_option_value('swapfile', false, { buf = diff_buf })
   vim.api.nvim_set_option_value('modifiable', false, { buf = diff_buf })
   vim.api.nvim_set_option_value('filetype', 'diff', { buf = diff_buf })
-  vim.api.nvim_buf_set_name(diff_buf, 'diffs://' .. revision .. ':' .. rel_path)
+  vim.api.nvim_buf_set_name(diff_buf, 'diffs://' .. revision_label .. ':' .. diff_path)
   if repo_root then
     vim.api.nvim_buf_set_var(diff_buf, 'diffs_repo_root', repo_root)
   end
@@ -173,7 +183,7 @@ function M.gdiff(revision, vertical)
   end
 
   M.setup_diff_buf(diff_buf)
-  dbg('opened diff buffer %d for %s against %s', diff_buf, rel_path, revision)
+  dbg('opened diff buffer %d for %s against %s', diff_buf, diff_path, revision_label)
 
   vim.schedule(function()
     runtime.attach(diff_buf)
@@ -952,6 +962,7 @@ end
 
 M._test = {
   complete_greview = complete_greview,
+  gdiff_revision_spec = gdiff_revision_spec,
   normalize_greview = normalize_greview,
   parse_review_arg = parse_review_arg,
 }

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -12,6 +12,11 @@ local function mock_repo_root(fn)
   git.get_repo_root = fn
 end
 
+local function mock_git_method(name, fn)
+  saved_git[name] = git[name]
+  git[name] = fn
+end
+
 local function mock_systemlist(fn)
   saved_systemlist = vim.fn.systemlist
   vim.fn.systemlist = function(cmd)
@@ -153,6 +158,74 @@ describe('commands', function()
       }
       local result = commands.filter_combined_diffs(lines)
       assert.are.equal(0, #result)
+    end)
+  end)
+
+  describe('Gdiff DiffSpec mapping', function()
+    it('expresses default :Gdiff as HEAD to worktree for the current file', function()
+      local spec = commands._test.gdiff_revision_spec(nil, 'lua/foo.lua')
+
+      assert.are.same({
+        left = { kind = 'tree', rev = 'HEAD' },
+        right = { kind = 'worktree' },
+        scope = { kind = 'file', path = 'lua/foo.lua' },
+        mode = 'unified',
+      }, spec)
+    end)
+
+    it('expresses explicit :Gdiff revision args as revision to worktree', function()
+      local spec = commands._test.gdiff_revision_spec('HEAD~3', 'lua/foo.lua')
+
+      assert.are.same({
+        left = { kind = 'tree', rev = 'HEAD~3' },
+        right = { kind = 'worktree' },
+        scope = { kind = 'file', path = 'lua/foo.lua' },
+        mode = 'unified',
+      }, spec)
+    end)
+
+    it('preserves the existing generated buffer surface while using the spec', function()
+      local source_buf = vim.api.nvim_create_buf(false, true)
+      table.insert(test_buffers, source_buf)
+      vim.api.nvim_buf_set_name(source_buf, '/tmp/repo/lua/foo.lua')
+      vim.api.nvim_buf_set_lines(source_buf, 0, -1, false, {
+        'local M = {}',
+        'local x = 1',
+        'return M',
+      })
+      vim.api.nvim_set_current_buf(source_buf)
+
+      local captured_revision
+      mock_git_method('get_relative_path', function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return 'lua/foo.lua'
+      end)
+      mock_git_method('get_file_content', function(revision, filepath)
+        captured_revision = revision
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return { 'local M = {}', 'return M' }
+      end)
+      mock_repo_root(function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return '/tmp/repo'
+      end)
+
+      commands.gdiff('HEAD~3', false)
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+      vim.wait(10, function()
+        return false
+      end)
+      local lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
+
+      assert.are.equal('HEAD~3', captured_revision)
+      assert.are.equal('diffs://HEAD~3:lua/foo.lua', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.equal('/tmp/repo', vim.api.nvim_buf_get_var(diff_buf, 'diffs_repo_root'))
+      assert.are.equal('diff --git a/lua/foo.lua b/lua/foo.lua', lines[1])
+      assert.are.equal('--- a/lua/foo.lua', lines[2])
+      assert.are.equal('+++ b/lua/foo.lua', lines[3])
+      assert.is_true(table.concat(lines, '\n'):find('+local x = 1', 1, true) ~= nil)
     end)
   end)
 


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This is related to #230.

## Solution

The solution derives a DiffSpec for the existing :Gdiff revision/current-buffer flow.
