### PR TITLE
docs: scope vimdoc tags to diffs.nvim

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -1,4 +1,4 @@
-*diffs.nvim.txt*                    Syntax highlighting for diffs in Neovim
+*diffs.nvim.txt*        Syntax highlighting for diffs in Neovim
 
 Author:  Barrett Ruth <br.barrettruth@gmail.com> License: MIT
 
@@ -15,7 +15,7 @@ With no configuration, diffs.nvim provides:
 - Inline merge conflict detection, highlighting, and resolution
 - Background-only diff colors for `&diff` buffers (vimdiff, diffthis)
 
-All other integrations are opt-in. See |diffs-integrations|.
+All other integrations are opt-in. See |diffs.nvim-integrations|.
 
 Features: ~
 - Treesitter syntax highlighting in diff hunks
@@ -29,37 +29,37 @@ Features: ~
 - Email quoting/patch syntax support (`> diff ...`)
 
 ==============================================================================
-CONTENTS                                                      *diffs-contents*
+CONTENTS                                                 *diffs.nvim-contents*
 
   1. Introduction ............................................... |diffs.nvim|
-  2. Requirements ....................................... |diffs-requirements|
-  3. Setup ..................................................... |diffs-setup|
-  4. Configuration ............................................ |diffs-config|
-  5. Commands ............................................... |diffs-commands|
-  6. Mappings ............................................... |diffs-mappings|
-  7. Integrations ..................................... |diffs-integrations|
-       Fugitive .......................................... |diffs-fugitive|
-       Neogit .............................................. |diffs-neogit|
-       Neojj ............................................... |diffs-neojj|
-       Gitsigns .......................................... |diffs-gitsigns|
-       Telescope ........................................ |diffs-telescope|
-  8. Conflict Resolution .................................... |diffs-conflict|
-  9. Merge Diff Resolution ..................................... |diffs-merge|
- 10. API ......................................................... |diffs-api|
- 11. Implementation ................................... |diffs-implementation|
- 12. Known Limitations ................................... |diffs-limitations|
- 13. Highlight Groups ..................................... |diffs-highlights|
- 14. Health Check ............................................. |diffs-health|
- 15. Acknowledgements ............................... |diffs-acknowledgements|
+  2. Requirements .................................. |diffs.nvim-requirements|
+  3. Setup ................................................ |diffs.nvim-setup|
+  4. Configuration ....................................... |diffs.nvim-config|
+  5. Commands .......................................... |diffs.nvim-commands|
+  6. Mappings .......................................... |diffs.nvim-mappings|
+  7. Integrations .................................. |diffs.nvim-integrations|
+       Fugitive ........................................ |diffs.nvim-fugitive|
+       Neogit ............................................ |diffs.nvim-neogit|
+       Neojj .............................................. |diffs.nvim-neojj|
+       Gitsigns ........................................ |diffs.nvim-gitsigns|
+       Telescope ...................................... |diffs.nvim-telescope|
+  8. Conflict Resolution ............................... |diffs.nvim-conflict|
+  9. Merge Diff Resolution ................................ |diffs.nvim-merge|
+ 10. API .................................................... |diffs.nvim-api|
+ 11. Implementation .............................. |diffs.nvim-implementation|
+ 12. Known Limitations .............................. |diffs.nvim-limitations|
+ 13. Highlight Groups ................................ |diffs.nvim-highlights|
+ 14. Health Check ........................................ |diffs.nvim-health|
+ 15. Acknowledgements .......................... |diffs.nvim-acknowledgements|
 
 ==============================================================================
-REQUIREMENTS                                              *diffs-requirements*
+REQUIREMENTS                                         *diffs.nvim-requirements*
 
 - Neovim 0.9.0+
 - Treesitter parsers for languages you want highlighted
 
 ==============================================================================
-SETUP                                                            *diffs-setup*
+SETUP                                                       *diffs.nvim-setup*
 
 Install with lazy.nvim: >lua
     { 'barrettruth/diffs.nvim' }
@@ -71,10 +71,11 @@ lazy-loads itself.
 NOTE: Load your colorscheme before diffs.nvim. With lazy.nvim, set `priority =
 1000` and `lazy = false` on your colorscheme plugin.
 
-See |diffs-config| for customization, |diffs-integrations| for plugin support.
+See |diffs.nvim-config| for customization, |diffs.nvim-integrations| for
+plugin support.
 
 ==============================================================================
-CONFIGURATION                                                   *diffs-config*
+CONFIGURATION                                              *diffs.nvim-config*
 
 Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
 >lua
@@ -129,7 +130,7 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
       },
     }
 <
-                                                                *diffs.Config*
+                                                           *diffs.nvim.Config*
     Fields: ~
         {debug}              (boolean, default: false)
                              Enable debug logging to ` :messages` with
@@ -146,14 +147,14 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              Integration toggles. Each key accepts `true`,
                              `false`, or a table with sub-options. Passing
                              `true` or a table enables the integration;
-                             `false` disables it. See |diffs-integrations|.
-                                                    *diffs.IntegrationsConfig*
+                             `false` disables it. See |diffs.nvim-integrations|.
+                                               *diffs.nvim.IntegrationsConfig*
                              Fields: ~
 
             {fugitive}       (boolean|table, default: false)
                              Enable vim-fugitive integration. Pass `true`
                              for defaults, or a table with sub-options
-                             (see |diffs.FugitiveConfig|). When active,
+                             (see |diffs.nvim.FugitiveConfig|). When active,
                              the `fugitive` filetype is registered and
                              status buffer keymaps are set. >lua
                                  vim.g.diffs = {
@@ -170,7 +171,7 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              Enable Neogit integration. When active,
                              `NeogitStatus`, `NeogitCommitView`, and
                              `NeogitDiffView` filetypes are registered.
-                             See |diffs-neogit|. >lua
+                             See |diffs.nvim-neogit|. >lua
                                  integrations = { neogit = true }
 <
 
@@ -178,13 +179,13 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              Enable neojj integration. When active,
                              `NeojjStatus`, `NeojjCommitView`, and
                              `NeojjDiffView` filetypes are registered.
-                             See |diffs-neojj|. >lua
+                             See |diffs.nvim-neojj|. >lua
                                  integrations = { neojj = true }
 <
 
             {gitsigns}       (boolean|table, default: false)
                              Enable gitsigns.nvim blame popup highlighting.
-                             See |diffs-gitsigns|. >lua
+                             See |diffs.nvim-gitsigns|. >lua
                                  integrations = { gitsigns = true }
 <
 
@@ -197,7 +198,7 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
 
             {telescope}      (boolean|table, default: false)
                              Enable telescope.nvim preview highlighting.
-                             See |diffs-telescope|. >lua
+                             See |diffs.nvim-telescope|. >lua
                                  integrations = { telescope = true }
 <
 
@@ -223,13 +224,13 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
 
         {highlights}         (table, default: see below)
                              Controls which highlight features are enabled.
-                             See |diffs.Highlights| for fields.
+                             See |diffs.nvim.Highlights| for fields.
 
         {conflict}           (table, default: see below)
                              Inline merge conflict resolution options.
-                             See |diffs.ConflictConfig| for fields.
+                             See |diffs.nvim.ConflictConfig| for fields.
 
-                                                            *diffs.Highlights*
+                                                       *diffs.nvim.Highlights*
     Highlights table fields: ~
         {background}         (boolean, default: true)
                              Apply background highlighting to `+`/`-` lines
@@ -252,27 +253,27 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
         {warn_max_lines}     (boolean, default: true)
                              Show a `vim.notify()` warning when syntax
                              highlighting is skipped because a hunk exceeds
-                             {max_lines}. See |diffs-max-lines|.
+                             {max_lines}. See |diffs.nvim-max-lines|.
 
         {context}            (table, default: see below)
                              Syntax parsing context options.
-                             See |diffs.ContextConfig| for fields.
+                             See |diffs.nvim.ContextConfig| for fields.
 
         {treesitter}         (table, default: see below)
                              Treesitter highlighting options.
-                             See |diffs.TreesitterConfig| for fields.
+                             See |diffs.nvim.TreesitterConfig| for fields.
 
         {vim}                (table, default: see below)
                              Vim syntax fallback highlighting options.
-                             See |diffs.VimConfig| for fields.
+                             See |diffs.nvim.VimConfig| for fields.
 
         {intra}              (table, default: see below)
                              Character-level (intra-line) diff highlighting.
-                             See |diffs.IntraConfig| for fields.
+                             See |diffs.nvim.IntraConfig| for fields.
 
         {priorities}         (table, default: see below)
                              Extmark priority values.
-                             See |diffs.PrioritiesConfig| for fields.
+                             See |diffs.nvim.PrioritiesConfig| for fields.
 
         {overrides}          (table, default: {})
                              Map of highlight group names to highlight
@@ -281,7 +282,7 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              so overrides always win over both computed
                              defaults and colorscheme definitions.
 
-                                                         *diffs.ContextConfig*
+                                                    *diffs.nvim.ContextConfig*
     Context config fields: ~
         {enabled}            (boolean, default: true)
                              Read surrounding code from the working tree
@@ -299,7 +300,7 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              Files are read once per parse and cached across
                              hunks in the same file.
 
-                                                      *diffs.PrioritiesConfig*
+                                                 *diffs.nvim.PrioritiesConfig*
     Priorities config fields: ~
         {clear}              (integer, default: 198)
                              Priority for `DiffsClear` extmarks that reset
@@ -321,7 +322,7 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              character-level background extmarks. Highest
                              priority so changed characters stand out.
 
-                                                      *diffs.TreesitterConfig*
+                                                 *diffs.nvim.TreesitterConfig*
     Treesitter config fields: ~
         {enabled}            (boolean, default: true)
                              Apply treesitter syntax highlighting to code.
@@ -332,7 +333,7 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              Context lines are not counted. Prevents lag on
                              massive diffs.
 
-                                                             *diffs.VimConfig*
+                                                        *diffs.nvim.VimConfig*
     Vim config fields: ~
         {enabled}            (boolean, default: true)
                              Use vim syntax highlighting as fallback when no
@@ -352,7 +353,7 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              treesitter default due to the per-character cost
                              of `synID()`.
 
-                                                           *diffs.IntraConfig*
+                                                      *diffs.nvim.IntraConfig*
     Intra config fields: ~
         {enabled}            (boolean, default: true)
                              Enable character-level diff highlighting within
@@ -382,7 +383,7 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
     `vim.filetype.add()` and `vim.treesitter.language.register()`.
 
 ==============================================================================
-MAX LINES                                                    *diffs-max-lines*
+MAX LINES                                               *diffs.nvim-max-lines*
 
 When a hunk contains more highlighted lines (`+`/`-`) than the configured
 threshold, diffs.nvim skips syntax highlighting for that hunk to avoid lag.
@@ -407,7 +408,7 @@ character-level diff highlighting within changed lines. It does not affect the
 syntax highlighting warning.
 
 ==============================================================================
-COMMANDS                                                      *diffs-commands*
+COMMANDS                                                 *diffs.nvim-commands*
 
 :Gdiff [object]                                                       *:Gdiff*
     Open a unified diff of the current file against a Fugitive-style object.
@@ -517,7 +518,7 @@ COMMANDS                                                      *diffs-commands*
         to the nearest `diff --git` header.
 
 ==============================================================================
-MAPPINGS                                                      *diffs-mappings*
+MAPPINGS                                                 *diffs.nvim-mappings*
 
                                                          *<Plug>(diffs-gdiff)*
 <Plug>(diffs-gdiff)     Show unified diff against HEAD in a horizontal
@@ -594,13 +595,13 @@ Example configuration: >lua
                         diff.
 
 Diff buffer mappings: ~
-                                                                     *diffs-q*
+                                                                *diffs.nvim-q*
     q               Close the diff window. Available in all `diffs://`
                     buffers created by |:Gdiff|, |:Gvdiff|, |:Ghdiff|,
                     or the fugitive status keymaps.
 
 ==============================================================================
-INTEGRATIONS                                              *diffs-integrations*
+INTEGRATIONS                                         *diffs.nvim-integrations*
 
 diffs.nvim integrates with several plugins. There are two attachment patterns:
 
@@ -624,7 +625,7 @@ Opt-in: ~ For filetypes not covered by a built-in integration, use
 <
 
 ------------------------------------------------------------------------------
-FUGITIVE                                                      *diffs-fugitive*
+FUGITIVE                                                 *diffs.nvim-fugitive*
 
 Enable vim-fugitive (https://github.com/tpope/vim-fugitive) support: >lua
     vim.g.diffs = { integrations = { fugitive = true } }
@@ -632,7 +633,7 @@ Enable vim-fugitive (https://github.com/tpope/vim-fugitive) support: >lua
 
 `:Git` status and commit views receive treesitter syntax, line backgrounds,
 and intra-line diffs. |:Gdiff| opens a unified diff against any revision (see
-|diffs-commands|).
+|diffs.nvim-commands|).
 
 Fugitive status keymaps: ~
 
@@ -640,7 +641,7 @@ When inside a `:Git` status buffer, diffs.nvim provides keymaps to open
 unified diffs for files or entire sections.
 
 Keymaps: ~
-                                                         *diffs-du* *diffs-dU*
+                                               *diffs.nvim-du* *diffs.nvim-dU*
     du          Open unified diff in a horizontal split.
     dU          Open unified diff in a vertical split.
 
@@ -665,7 +666,7 @@ staged) and displays all changes in that section as a single unified diff.
 Untracked section headers show a warning since there is no meaningful diff.
 
 Configuration: ~
-                                                        *diffs.FugitiveConfig*
+                                                   *diffs.nvim.FugitiveConfig*
 >lua
     vim.g.diffs = {
       integrations = {
@@ -689,7 +690,7 @@ Configuration: ~
                              Set to `false` to disable.
 
 ------------------------------------------------------------------------------
-NEOGIT                                                          *diffs-neogit*
+NEOGIT                                                     *diffs.nvim-neogit*
 
 Enable Neogit (https://github.com/NeogitOrg/neogit) support: >lua
     vim.g.diffs = { integrations = { neogit = true } }
@@ -699,7 +700,7 @@ Expanding a diff in a Neogit buffer (e.g., TAB on a file in the status view)
 applies treesitter syntax highlighting and intra-line diffs to the hunk lines.
 
 ------------------------------------------------------------------------------
-NEOJJ                                                            *diffs-neojj*
+NEOJJ                                                       *diffs.nvim-neojj*
 
 Enable neojj (https://github.com/NicholasZolton/neojj) support: >lua
     vim.g.diffs = { integrations = { neojj = true } }
@@ -709,7 +710,7 @@ Expanding a diff in a neojj buffer (e.g., TAB on a file in the status view)
 applies treesitter syntax highlighting and intra-line diffs to the hunk lines.
 
 ------------------------------------------------------------------------------
-GITSIGNS                                                      *diffs-gitsigns*
+GITSIGNS                                                 *diffs.nvim-gitsigns*
 
 Enable gitsigns.nvim (https://github.com/lewis6991/gitsigns.nvim) blame popup
 highlighting: >lua
@@ -723,7 +724,7 @@ Highlights are applied in a separate `diffs-gitsigns` namespace and do not
 interfere with the main decoration provider used for diff buffers.
 
 ------------------------------------------------------------------------------
-TELESCOPE                                                    *diffs-telescope*
+TELESCOPE                                               *diffs.nvim-telescope*
 
 Enable telescope.nvim (https://github.com/nvim-telescope/telescope.nvim)
 preview highlighting: >lua
@@ -745,7 +746,7 @@ artifact unrelated to diffs.nvim. Tracked upstream:
 https://github.com/nvim-telescope/telescope.nvim/issues/3626
 
 ==============================================================================
-CONFLICT RESOLUTION                                           *diffs-conflict*
+CONFLICT RESOLUTION                                      *diffs.nvim-conflict*
 
 diffs.nvim detects inline merge conflict markers (`<<<<<<<`/`=======`/
 `>>>>>>>`) in working files and provides highlighting and resolution keymaps.
@@ -756,7 +757,7 @@ Conflict regions are detected automatically on `BufReadPost` and re-scanned on
 removed and diagnostics are re-enabled.
 
 Configuration: ~
-                                                        *diffs.ConflictConfig*
+                                                   *diffs.nvim.ConflictConfig*
 >lua
     vim.g.diffs = {
       conflict = {
@@ -837,7 +838,7 @@ Configuration: ~
                              table to enable plugin-defined mappings.
                              Unspecified fields remain disabled.
 
-                                                       *diffs.ConflictKeymaps*
+                                                  *diffs.nvim.ConflictKeymaps*
     Keymap fields: ~
         {ours}               (string|false, default: false)
                              Accept current (ours) change.
@@ -872,7 +873,7 @@ User events: ~
 <
 
 ==============================================================================
-MERGE DIFF RESOLUTION                                            *diffs-merge*
+MERGE DIFF RESOLUTION                                       *diffs.nvim-merge*
 
 When pressing `du`/`dU` on an unmerged (`U`) file in the fugitive status
 buffer, diffs.nvim opens a unified diff of ours (`git show :2:path`) vs theirs
@@ -893,13 +894,13 @@ correspond to auto-merged content (no conflict markers) show an informational
 notification and are left unchanged.
 
 The working file buffer is modified in place; save it when ready. Phase 1
-inline conflict highlights (see |diffs-conflict|) are refreshed automatically
-after each resolution.
+inline conflict highlights (see |diffs.nvim-conflict|) are refreshed
+automatically after each resolution.
 
 ==============================================================================
-API                                                                *diffs-api*
+API                                                           *diffs.nvim-api*
 
-attach({bufnr})                                               *diffs.attach()*
+attach({bufnr})                                          *diffs.nvim.attach()*
     Attach highlighting to a buffer. Called automatically when the buffer's
     filetype matches `git`, `gitcommit`, an enabled integration filetype,
     or any entry in `extra_filetypes`.
@@ -907,7 +908,7 @@ attach({bufnr})                                               *diffs.attach()*
     Parameters: ~
         {bufnr}  (integer, optional) Buffer number. Defaults to current buffer.
 
-refresh({bufnr})                                             *diffs.refresh()*
+refresh({bufnr})                                        *diffs.nvim.refresh()*
     Manually refresh highlighting for a buffer. Useful after external changes
     or for debugging.
 
@@ -915,11 +916,11 @@ refresh({bufnr})                                             *diffs.refresh()*
         {bufnr}  (integer, optional) Buffer number. Defaults to current buffer.
 
 ==============================================================================
-IMPLEMENTATION                                          *diffs-implementation*
+IMPLEMENTATION                                     *diffs.nvim-implementation*
 
 Summary / commit detail views: ~
-1. `FileType` autocmd for computed filetypes (see |diffs-config|) triggers
-   |diffs.attach()|.
+1. `FileType` autocmd for computed filetypes (see |diffs.nvim-config|) triggers
+   |diffs.nvim.attach()|.
 2. The buffer is parsed to detect file headers (`M path/to/file`,
    `diff --git a/... b/...`) and hunk headers (`@@ -10,3 +10,4 @@`)
 3. For each hunk:
@@ -934,7 +935,7 @@ Summary / commit detail views: ~
    - Character-level diff extmarks (`DiffsAddText`/`DiffsDeleteText`) at
      priority 201 overlay changed characters with an intense background
    - Conceal extmarks hide diff prefixes when `hide_prefix` is enabled
-   - All priorities are configurable via |diffs.PrioritiesConfig|
+   - All priorities are configurable via |diffs.nvim.PrioritiesConfig|
 4. A decoration provider re-highlights visible hunks on each redraw
 
 Diff mode views: ~
@@ -945,10 +946,10 @@ Diff mode views: ~
    show through the diff colors
 
 ==============================================================================
-KNOWN LIMITATIONS                                          *diffs-limitations*
+KNOWN LIMITATIONS                                     *diffs.nvim-limitations*
 
 Incomplete Syntax Context ~
-                                                        *diffs-syntax-context*
+                                                   *diffs.nvim-syntax-context*
 Treesitter parses each diff hunk in isolation. When `highlights.context` is
 enabled (the default), surrounding code is read from the working tree file and
 fed into the parser to improve accuracy at hunk boundaries. This helps when a
@@ -959,7 +960,7 @@ that start or end mid-expression may still produce imperfect highlights due to
 treesitter error recovery.
 
 Syntax Highlighting Flash ~
-                                                                 *diffs-flash*
+                                                            *diffs.nvim-flash*
 When opening a fugitive buffer, there is an unavoidable visual "flash" where
 the buffer briefly shows fugitive's default diff highlighting before
 diffs.nvim applies its own highlights.
@@ -973,7 +974,7 @@ treesitter parser, cold fallback syntax may appear one frame later, while
 stale deferred fallback renders are discarded if the buffer changes.
 
 Conflicting Diff Plugins ~
-                                                      *diffs-plugin-conflicts*
+                                                 *diffs.nvim-plugin-conflicts*
 diffs.nvim may not interact well with other plugins that modify diff
 highlighting or the sign column in diff views. Known plugins that may
 conflict:
@@ -994,13 +995,13 @@ conflict:
   - git-conflict.nvim (akinsho/git-conflict.nvim)
       Provides conflict marker highlighting and resolution keymaps.
       diffs.nvim now has built-in conflict resolution (see
-      |diffs-conflict|). Disable one or the other to avoid overlap.
+      |diffs.nvim-conflict|). Disable one or the other to avoid overlap.
 
 If you experience visual conflicts, try disabling the conflicting plugin's
 diff-related features.
 
 ==============================================================================
-HIGHLIGHT GROUPS                                            *diffs-highlights*
+HIGHLIGHT GROUPS                                       *diffs.nvim-highlights*
 
 diffs.nvim defines custom highlight groups. All groups use `default = true`,
 so colorschemes can override them by defining the group before the plugin
@@ -1111,7 +1112,7 @@ To customize these in your colorscheme: >lua
 <
 
 ==============================================================================
-HEALTH CHECK                                                    *diffs-health*
+HEALTH CHECK                                               *diffs.nvim-health*
 
 Run ` :checkhealth` diffs to verify your setup.
 
@@ -1121,7 +1122,7 @@ Checks performed:
 - libvscode_diff shared library is available (optional)
 
 ==============================================================================
-ACKNOWLEDGEMENTS                                      *diffs-acknowledgements*
+ACKNOWLEDGEMENTS                                 *diffs.nvim-acknowledgements*
 
 - vim-fugitive (https://github.com/tpope/vim-fugitive)
 - codediff.nvim (https://github.com/esmuellert/codediff.nvim)


### PR DESCRIPTION
## Problem

The bare `:help diffs` topic conflicts with Neovim's built-in help, so this plugin's vimdoc should be reachable only through the explicit `diffs.nvim` namespace.

## Solution

- keep the canonical help file and README target as `diffs.nvim`
- rename vimdoc section/type/API tags from `diffs-*` / `diffs.*` to `diffs.nvim-*` / `diffs.nvim.*`
- keep the contents table dot leaders aligned at 78 columns

Verification:

- [x] `git diff --check`
- [x] `vimdoc-language-server format --check doc/`
- [x] `vimdoc-language-server check doc/`
