### PR TITLE
Parse Gdiff args into DiffSpec

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -409,9 +409,9 @@ syntax highlighting warning.
 ==============================================================================
 COMMANDS                                                      *diffs-commands*
 
-:Gdiff [revision]                                                     *:Gdiff*
-    Open a unified diff of the current file against a git revision. Displays
-    in a horizontal split below the current window.
+:Gdiff [object]                                                       *:Gdiff*
+    Open a unified diff of the current file against a Fugitive-style object.
+    Displays in a horizontal split below the current window.
 
     The diff buffer shows `+`/`-` lines with full syntax highlighting for the
     code language, plus diff header highlighting for `diff --git`, `---`,
@@ -421,20 +421,21 @@ COMMANDS                                                      *diffs-commands*
     diff replaces its buffer instead of creating another split.
 
     Parameters: ~
-        {revision}  (string, optional) Git revision to diff against.
-                    Defaults to HEAD.
+        {object}    (string, optional) Fugitive-style object to diff against.
+                    Defaults to the current file in the index.
 
     Examples: >vim
-        :Gdiff          " diff against HEAD
+        :Gdiff          " diff against the index
         :Gdiff main     " diff against main branch
         :Gdiff HEAD~3   " diff against 3 commits ago
+        :Gdiff :0:%     " diff against the index explicitly
         :Gdiff abc123   " diff against specific commit
 <
 
-:Gvdiff [revision]                                                   *:Gvdiff*
+:Gvdiff [object]                                                     *:Gvdiff*
     Like |:Gdiff| but opens in a vertical split.
 
-:Ghdiff [revision]                                                   *:Ghdiff*
+:Ghdiff [object]                                                     *:Ghdiff*
     Like |:Gdiff| but explicitly opens in a horizontal split.
 
 :Greview [review-spec]                                              *:Greview*

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local diffspec = require('diffs.spec')
+local gdiff_parser = require('diffs.gdiff')
 local git = require('diffs.git')
 local dbg = require('diffs.log').dbg
 local runtime = require('diffs.runtime')
@@ -89,11 +90,54 @@ local function generate_unified_diff(old_lines, new_lines, old_name, new_name)
   return result
 end
 
----@param revision? string
----@param rel_path string
----@return diffs.DiffSpec
-local function gdiff_revision_spec(revision, rel_path)
-  return diffspec.rev_to_worktree(revision or 'HEAD', rel_path)
+---@param diff_spec diffs.DiffSpec
+---@return string
+local function gdiff_buffer_label(diff_spec)
+  diff_spec = diffspec.new(diff_spec)
+  local left = diff_spec.left
+  local right = diff_spec.right
+
+  if
+    left.kind == diffspec.endpoint_kind.index and right.kind == diffspec.endpoint_kind.worktree
+  then
+    return 'unstaged'
+  end
+
+  if
+    left.kind == diffspec.endpoint_kind.tree
+    and left.rev == 'HEAD'
+    and right.kind == diffspec.endpoint_kind.index
+  then
+    return 'staged'
+  end
+
+  if left.kind == diffspec.endpoint_kind.tree and right.kind == diffspec.endpoint_kind.worktree then
+    return left.rev
+  end
+
+  return diffspec.label(diff_spec)
+end
+
+---@param endpoint diffs.Endpoint
+---@param filepath string
+---@param bufnr integer
+---@return string[]?, string?
+local function read_gdiff_endpoint(endpoint, filepath, bufnr)
+  endpoint = diffspec.endpoint(endpoint)
+
+  if endpoint.kind == diffspec.endpoint_kind.tree then
+    return git.get_file_content(endpoint.rev, filepath)
+  end
+
+  if endpoint.kind == diffspec.endpoint_kind.index then
+    return git.get_index_content(filepath)
+  end
+
+  if endpoint.kind == diffspec.endpoint_kind.worktree then
+    return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), nil
+  end
+
+  return nil, 'unsupported endpoint: ' .. tostring(endpoint.kind)
 end
 
 ---@param raw_lines string[]
@@ -123,9 +167,9 @@ local function replace_combined_diffs(raw_lines, repo_root)
   return result
 end
 
----@param revision? string
+---@param args? string
 ---@param vertical? boolean
-function M.gdiff(revision, vertical)
+function M.gdiff(args, vertical)
   local bufnr = vim.api.nvim_get_current_buf()
   local filepath = vim.api.nvim_buf_get_name(bufnr)
 
@@ -140,22 +184,39 @@ function M.gdiff(revision, vertical)
     return
   end
 
-  local diff_spec = gdiff_revision_spec(revision, rel_path)
-  local revision_label = diff_spec.left.rev
+  local parsed, parse_err = gdiff_parser.parse(args, {
+    path = rel_path,
+    current = diffspec.worktree(),
+  })
+  if not parsed then
+    vim.notify('[diffs.nvim]: ' .. parse_err, vim.log.levels.ERROR)
+    return
+  end
+
+  if parsed.novertical then
+    vertical = false
+  end
+
+  local diff_spec = parsed.spec
+  local diff_label = gdiff_buffer_label(diff_spec)
   local diff_path = diff_spec.scope.path
 
-  local old_lines, err = git.get_file_content(revision_label, filepath)
+  local old_lines, err = read_gdiff_endpoint(diff_spec.left, filepath, bufnr)
   if not old_lines then
     vim.notify('[diffs.nvim]: ' .. (err or 'unknown error'), vim.log.levels.ERROR)
     return
   end
 
-  local new_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local new_lines, new_err = read_gdiff_endpoint(diff_spec.right, filepath, bufnr)
+  if not new_lines then
+    vim.notify('[diffs.nvim]: ' .. (new_err or 'unknown error'), vim.log.levels.ERROR)
+    return
+  end
 
   local diff_lines = generate_unified_diff(old_lines, new_lines, diff_path, diff_path)
 
   if #diff_lines == 0 then
-    vim.notify('[diffs.nvim]: no diff against ' .. revision_label, vim.log.levels.INFO)
+    vim.notify('[diffs.nvim]: no changes for ' .. diffspec.label(diff_spec), vim.log.levels.INFO)
     return
   end
 
@@ -168,7 +229,7 @@ function M.gdiff(revision, vertical)
   vim.api.nvim_set_option_value('swapfile', false, { buf = diff_buf })
   vim.api.nvim_set_option_value('modifiable', false, { buf = diff_buf })
   vim.api.nvim_set_option_value('filetype', 'diff', { buf = diff_buf })
-  vim.api.nvim_buf_set_name(diff_buf, 'diffs://' .. revision_label .. ':' .. diff_path)
+  vim.api.nvim_buf_set_name(diff_buf, 'diffs://' .. diff_label .. ':' .. diff_path)
   if repo_root then
     vim.api.nvim_buf_set_var(diff_buf, 'diffs_repo_root', repo_root)
   end
@@ -183,7 +244,7 @@ function M.gdiff(revision, vertical)
   end
 
   M.setup_diff_buf(diff_buf)
-  dbg('opened diff buffer %d for %s against %s', diff_buf, diff_path, revision_label)
+  dbg('opened diff buffer %d for %s (%s)', diff_buf, diff_path, diffspec.label(diff_spec))
 
   vim.schedule(function()
     runtime.attach(diff_buf)
@@ -928,22 +989,22 @@ function M.setup()
   vim.api.nvim_create_user_command('Gdiff', function(opts)
     M.gdiff(opts.args ~= '' and opts.args or nil, false)
   end, {
-    nargs = '?',
-    desc = 'Show unified diff against git revision (default: HEAD)',
+    nargs = '*',
+    desc = 'Show unified diff against a Fugitive object',
   })
 
   vim.api.nvim_create_user_command('Gvdiff', function(opts)
     M.gdiff(opts.args ~= '' and opts.args or nil, true)
   end, {
-    nargs = '?',
-    desc = 'Show unified diff against git revision in vertical split',
+    nargs = '*',
+    desc = 'Show unified diff against a Fugitive object in vertical split',
   })
 
   vim.api.nvim_create_user_command('Ghdiff', function(opts)
     M.gdiff(opts.args ~= '' and opts.args or nil, false)
   end, {
-    nargs = '?',
-    desc = 'Show unified diff against git revision in horizontal split',
+    nargs = '*',
+    desc = 'Show unified diff against a Fugitive object in horizontal split',
   })
 
   vim.api.nvim_create_user_command('Greview', function(opts)
@@ -962,9 +1023,10 @@ end
 
 M._test = {
   complete_greview = complete_greview,
-  gdiff_revision_spec = gdiff_revision_spec,
+  gdiff_buffer_label = gdiff_buffer_label,
   normalize_greview = normalize_greview,
   parse_review_arg = parse_review_arg,
+  read_gdiff_endpoint = read_gdiff_endpoint,
 }
 
 return M

--- a/lua/diffs/gdiff.lua
+++ b/lua/diffs/gdiff.lua
@@ -1,0 +1,135 @@
+local M = {}
+
+local diffspec = require('diffs.spec')
+
+---@class diffs.GdiffParseContext
+---@field path string
+---@field current? diffs.Endpoint
+
+---@class diffs.GdiffParseResult
+---@field spec diffs.DiffSpec
+---@field novertical boolean
+
+local function normalize_rev(rev)
+  if rev == '@' then
+    return 'HEAD'
+  end
+  return rev
+end
+
+---@param args? string
+---@return string[]
+local function split_args(args)
+  args = vim.trim(args or '')
+  if args == '' then
+    return {}
+  end
+  return vim.split(args, '%s+', { trimempty = true })
+end
+
+---@param endpoint diffs.Endpoint
+---@return boolean
+local function is_index(endpoint)
+  return endpoint.kind == diffspec.endpoint_kind.index
+end
+
+---@param endpoint diffs.Endpoint
+---@return boolean
+local function is_worktree(endpoint)
+  return endpoint.kind == diffspec.endpoint_kind.worktree
+end
+
+---@param object string
+---@return diffs.Endpoint?, string?
+local function parse_object_endpoint(object)
+  if object == ':' or object == ':%' or object == ':0:%' then
+    return diffspec.index(), nil
+  end
+
+  local stage = object:match('^:(%d):%%$')
+  if stage then
+    return nil, 'unsupported index stage :' .. stage .. ':%'
+  end
+
+  local rev = object:match('^(.+):%%$')
+  if rev then
+    return diffspec.tree(normalize_rev(rev)), nil
+  end
+
+  if object:find(':', 1, true) then
+    return nil, 'unsupported Fugitive object: ' .. object
+  end
+
+  return diffspec.tree(normalize_rev(object)), nil
+end
+
+---@param current diffs.Endpoint
+---@param path string
+---@return diffs.DiffSpec
+local function default_spec(current, path)
+  if is_worktree(current) then
+    return diffspec.index_to_worktree(path)
+  end
+  if is_index(current) then
+    return diffspec.head_to_index(path)
+  end
+  return diffspec.file(diffspec.worktree(), current, path)
+end
+
+---@param args? string
+---@param context diffs.GdiffParseContext
+---@return diffs.GdiffParseResult?, string?
+function M.parse(args, context)
+  if not context or type(context) ~= 'table' then
+    error('diffs: gdiff parse context must be a table')
+  end
+  local path = context.path
+  if type(path) ~= 'string' or path == '' then
+    error('diffs: gdiff parse context path must be a non-empty string')
+  end
+
+  local current = context.current and diffspec.endpoint(context.current) or diffspec.worktree()
+  local tokens = split_args(args)
+  local novertical = false
+
+  while tokens[1] and tokens[1]:match('^%+%+') do
+    if tokens[1] == '++novertical' then
+      novertical = true
+      table.remove(tokens, 1)
+    else
+      return nil, 'unknown option ' .. tokens[1]
+    end
+  end
+
+  if tokens[1] and tokens[1]:match('^%-%-') then
+    return nil, 'unsupported option ' .. tokens[1]
+  end
+
+  if #tokens > 1 then
+    return nil, 'expected at most one Fugitive object'
+  end
+
+  if #tokens == 0 then
+    return {
+      spec = default_spec(current, path),
+      novertical = novertical,
+    }, nil
+  end
+
+  local endpoint, err = parse_object_endpoint(tokens[1])
+  if not endpoint then
+    return nil, err
+  end
+
+  return {
+    spec = diffspec.file(endpoint, current, path),
+    novertical = novertical,
+  }, nil
+end
+
+M._test = {
+  normalize_rev = normalize_rev,
+  split_args = split_args,
+}
+
+return M

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -161,30 +161,55 @@ describe('commands', function()
     end)
   end)
 
-  describe('Gdiff DiffSpec mapping', function()
-    it('expresses default :Gdiff as HEAD to worktree for the current file', function()
-      local spec = commands._test.gdiff_revision_spec(nil, 'lua/foo.lua')
+  describe('Gdiff DiffSpec rendering', function()
+    it('opens default :Gdiff as an unstaged index to worktree diff', function()
+      local source_buf = vim.api.nvim_create_buf(false, true)
+      table.insert(test_buffers, source_buf)
+      vim.api.nvim_buf_set_name(source_buf, '/tmp/repo/lua/foo.lua')
+      vim.api.nvim_buf_set_lines(source_buf, 0, -1, false, {
+        'local M = {}',
+        'local x = 1',
+        'return M',
+      })
+      vim.api.nvim_set_current_buf(source_buf)
 
-      assert.are.same({
-        left = { kind = 'tree', rev = 'HEAD' },
-        right = { kind = 'worktree' },
-        scope = { kind = 'file', path = 'lua/foo.lua' },
-        mode = 'unified',
-      }, spec)
+      local called_index = false
+      local called_head = false
+      mock_git_method('get_relative_path', function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return 'lua/foo.lua'
+      end)
+      mock_git_method('get_index_content', function(filepath)
+        called_index = true
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return { 'local M = {}', 'return M' }
+      end)
+      mock_git_method('get_file_content', function()
+        called_head = true
+        return { 'should not be used' }
+      end)
+      mock_repo_root(function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return '/tmp/repo'
+      end)
+
+      commands.gdiff(nil, false)
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+      vim.wait(10, function()
+        return false
+      end)
+      local lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
+
+      assert.is_true(called_index)
+      assert.is_false(called_head)
+      assert.are.equal('diffs://unstaged:lua/foo.lua', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.equal('diff --git a/lua/foo.lua b/lua/foo.lua', lines[1])
+      assert.is_true(table.concat(lines, '\n'):find('+local x = 1', 1, true) ~= nil)
     end)
 
-    it('expresses explicit :Gdiff revision args as revision to worktree', function()
-      local spec = commands._test.gdiff_revision_spec('HEAD~3', 'lua/foo.lua')
-
-      assert.are.same({
-        left = { kind = 'tree', rev = 'HEAD~3' },
-        right = { kind = 'worktree' },
-        scope = { kind = 'file', path = 'lua/foo.lua' },
-        mode = 'unified',
-      }, spec)
-    end)
-
-    it('preserves the existing generated buffer surface while using the spec', function()
+    it('preserves the explicit revision generated buffer surface', function()
       local source_buf = vim.api.nvim_create_buf(false, true)
       table.insert(test_buffers, source_buf)
       vim.api.nvim_buf_set_name(source_buf, '/tmp/repo/lua/foo.lua')

--- a/spec/gdiff_spec.lua
+++ b/spec/gdiff_spec.lua
@@ -1,0 +1,97 @@
+require('spec.helpers')
+
+local diffspec = require('diffs.spec')
+local gdiff = require('diffs.gdiff')
+
+describe('diffs.gdiff', function()
+  local path = 'lua/foo.lua'
+
+  local function parse(args, current)
+    local result, err = gdiff.parse(args, {
+      path = path,
+      current = current or diffspec.worktree(),
+    })
+    assert.is_nil(err)
+    return result
+  end
+
+  it('maps default worktree :Gdiff to index -> worktree', function()
+    local result = parse(nil)
+
+    assert.are.same(diffspec.index_to_worktree(path), result.spec)
+    assert.is_false(result.novertical)
+  end)
+
+  it('maps explicit revisions to revision -> worktree', function()
+    local result = parse('HEAD~3')
+
+    assert.are.same(diffspec.rev_to_worktree('HEAD~3', path), result.spec)
+  end)
+
+  it('normalizes @ as HEAD', function()
+    local result = parse('@')
+
+    assert.are.same(diffspec.rev_to_worktree('HEAD', path), result.spec)
+  end)
+
+  it('maps current-file index objects to index -> worktree', function()
+    for _, object in ipairs({ ':', ':%', ':0:%' }) do
+      local result = parse(object)
+
+      assert.are.same(diffspec.index_to_worktree(path), result.spec)
+    end
+  end)
+
+  it('maps revision current-file objects to tree -> worktree', function()
+    local result = parse('@:%')
+
+    assert.are.same(diffspec.rev_to_worktree('HEAD', path), result.spec)
+  end)
+
+  it('maps staged/index context default to HEAD -> index', function()
+    local result = parse(nil, diffspec.index())
+
+    assert.are.same(diffspec.head_to_index(path), result.spec)
+  end)
+
+  it('maps staged/index context @:% to HEAD -> index', function()
+    local result = parse('@:%', diffspec.index())
+
+    assert.are.same(diffspec.head_to_index(path), result.spec)
+  end)
+
+  it('keeps ++novertical separate from endpoint parsing', function()
+    local result = parse('++novertical HEAD')
+
+    assert.are.same(diffspec.rev_to_worktree('HEAD', path), result.spec)
+    assert.is_true(result.novertical)
+  end)
+
+  it('rejects unknown ++ options', function()
+    local result, err = gdiff.parse('++bogus HEAD', { path = path })
+
+    assert.is_nil(result)
+    assert.are.equal('unknown option ++bogus', err)
+  end)
+
+  it('rejects --staged as an unsupported flag', function()
+    local result, err = gdiff.parse('--staged', { path = path })
+
+    assert.is_nil(result)
+    assert.are.equal('unsupported option --staged', err)
+  end)
+
+  it('rejects multiple objects', function()
+    local result, err = gdiff.parse('HEAD :0:%', { path = path })
+
+    assert.is_nil(result)
+    assert.are.equal('expected at most one Fugitive object', err)
+  end)
+
+  it('rejects unsupported index stages for now', function()
+    local result, err = gdiff.parse(':2:%', { path = path })
+
+    assert.is_nil(result)
+    assert.are.equal('unsupported index stage :2:%', err)
+  end)
+end)


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #231.

## Solution

The solution adds a focused `:Gdiff` parser that maps Fugitive-style current-file objects into `DiffSpec`; switches default `:Gdiff` to index -> worktree while preserving explicit revision rendering; and rejects unknown `++` options and `--staged`, and document `:Gdiff [object]`.
