### PR TITLE
Store DiffSpec metadata on Gdiff buffers

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -140,6 +140,78 @@ local function read_gdiff_endpoint(endpoint, filepath, bufnr)
   return nil, 'unsupported endpoint: ' .. tostring(endpoint.kind)
 end
 
+---@param endpoint diffs.Endpoint
+---@param filepath string
+---@return string[]?, string?
+local function read_repo_endpoint(endpoint, filepath)
+  endpoint = diffspec.endpoint(endpoint)
+
+  if endpoint.kind == diffspec.endpoint_kind.tree then
+    return git.get_file_content(endpoint.rev, filepath)
+  end
+
+  if endpoint.kind == diffspec.endpoint_kind.index then
+    return git.get_index_content(filepath)
+  end
+
+  if endpoint.kind == diffspec.endpoint_kind.worktree then
+    return git.get_working_content(filepath)
+  end
+
+  return nil, 'unsupported endpoint: ' .. tostring(endpoint.kind)
+end
+
+---@param bufnr integer
+---@param name string
+---@return any
+local function get_buf_var(bufnr, name)
+  local ok, value = pcall(vim.api.nvim_buf_get_var, bufnr, name)
+  if ok then
+    return value
+  end
+  return nil
+end
+
+---@param bufnr integer
+---@param diff_spec diffs.DiffSpec
+local function set_diff_spec_var(bufnr, diff_spec)
+  vim.api.nvim_buf_set_var(bufnr, 'diffs_spec', diffspec.new(diff_spec))
+end
+
+---@param bufnr integer
+---@return diffs.DiffSpec?, string?
+local function get_diff_spec_var(bufnr)
+  local raw = get_buf_var(bufnr, 'diffs_spec')
+  if raw == nil then
+    return nil, nil
+  end
+
+  local ok, parsed = pcall(diffspec.new, raw)
+  if not ok then
+    return nil, tostring(parsed)
+  end
+
+  return parsed, nil
+end
+
+---@param diff_spec diffs.DiffSpec
+---@param repo_root string
+---@return string[]?, string?
+local function read_diff_spec(diff_spec, repo_root)
+  diff_spec = diffspec.new(diff_spec)
+
+  if diff_spec.scope.kind ~= diffspec.scope_kind.file then
+    return nil, 'unsupported DiffSpec scope: ' .. tostring(diff_spec.scope.kind)
+  end
+
+  local path = diff_spec.scope.path
+  local abs_path = repo_root .. '/' .. path
+  local old_lines = read_repo_endpoint(diff_spec.left, abs_path) or {}
+  local new_lines = read_repo_endpoint(diff_spec.right, abs_path) or {}
+
+  return generate_unified_diff(old_lines, new_lines, path, path), nil
+end
+
 ---@param raw_lines string[]
 ---@param repo_root string
 ---@return string[]
@@ -230,6 +302,7 @@ function M.gdiff(args, vertical)
   vim.api.nvim_set_option_value('modifiable', false, { buf = diff_buf })
   vim.api.nvim_set_option_value('filetype', 'diff', { buf = diff_buf })
   vim.api.nvim_buf_set_name(diff_buf, 'diffs://' .. diff_label .. ':' .. diff_path)
+  set_diff_spec_var(diff_buf, diff_spec)
   if repo_root then
     vim.api.nvim_buf_set_var(diff_buf, 'diffs_repo_root', repo_root)
   end
@@ -876,19 +949,45 @@ function M.read_buffer(bufnr)
     return
   end
 
-  local label, path = url_body:match('^([^:]+):(.+)$')
-  if not label or not path then
-    return
-  end
-
-  local ok, repo_root = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_repo_root')
-  if not ok or not repo_root then
+  local repo_root = get_buf_var(bufnr, 'diffs_repo_root')
+  if not repo_root then
+    vim.notify(
+      '[diffs.nvim]: cannot reload diffs:// buffer without diffs_repo_root',
+      vim.log.levels.WARN
+    )
     return
   end
 
   local diff_lines
+  local stored_spec, spec_err = get_diff_spec_var(bufnr)
+  if spec_err then
+    vim.notify(
+      '[diffs.nvim]: invalid diffs_spec metadata: ' .. tostring(spec_err),
+      vim.log.levels.WARN
+    )
+    return
+  end
 
-  if path == 'all' then
+  local label, path
+  if stored_spec then
+    local read_err
+    diff_lines, read_err = read_diff_spec(stored_spec, repo_root)
+    if not diff_lines then
+      vim.notify('[diffs.nvim]: ' .. read_err, vim.log.levels.WARN)
+      return
+    end
+  else
+    label, path = url_body:match('^([^:]+):(.+)$')
+    if not label or not path then
+      vim.notify(
+        '[diffs.nvim]: cannot reload malformed diffs:// buffer: ' .. name,
+        vim.log.levels.WARN
+      )
+      return
+    end
+  end
+
+  if not stored_spec and path == 'all' then
     local cmd = { 'git', '-C', repo_root, 'diff', '--no-ext-diff', '--no-color' }
     if label == 'staged' then
       table.insert(cmd, '--cached')
@@ -899,20 +998,10 @@ function M.read_buffer(bufnr)
     end
 
     diff_lines = replace_combined_diffs(diff_lines, repo_root)
-  elseif label == 'review' then
-    local stored_base = nil
-    local stored_target = nil
-    local stored_mode = nil
-
-    pcall(function()
-      stored_base = vim.api.nvim_buf_get_var(bufnr, 'diffs_review_base')
-    end)
-    pcall(function()
-      stored_target = vim.api.nvim_buf_get_var(bufnr, 'diffs_review_target')
-    end)
-    pcall(function()
-      stored_mode = vim.api.nvim_buf_get_var(bufnr, 'diffs_review_mode')
-    end)
+  elseif not stored_spec and label == 'review' then
+    local stored_base = get_buf_var(bufnr, 'diffs_review_base')
+    local stored_target = get_buf_var(bufnr, 'diffs_review_target')
+    local stored_mode = get_buf_var(bufnr, 'diffs_review_mode')
 
     local review_spec
     if stored_base then
@@ -940,7 +1029,7 @@ function M.read_buffer(bufnr)
     else
       diff_lines = {}
     end
-  else
+  elseif not stored_spec then
     local abs_path = repo_root .. '/' .. path
 
     local old_ok, old_rel_path = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_old_filepath')
@@ -980,7 +1069,9 @@ function M.read_buffer(bufnr)
   vim.api.nvim_set_option_value('swapfile', false, { buf = bufnr })
   vim.api.nvim_set_option_value('filetype', 'diff', { buf = bufnr })
 
-  dbg('reloaded diff buffer %d (%s:%s)', bufnr, label, path)
+  local debug_label = stored_spec and diffspec.label(stored_spec)
+    or ((label or '?') .. ':' .. (path or '?'))
+  dbg('reloaded diff buffer %d (%s)', bufnr, debug_label)
 
   runtime.attach(bufnr)
 end

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1,6 +1,7 @@
 require('spec.helpers')
 
 local commands = require('diffs.commands')
+local diffspec = require('diffs.spec')
 local git = require('diffs.git')
 
 local saved_git = {}
@@ -205,6 +206,10 @@ describe('commands', function()
       assert.is_true(called_index)
       assert.is_false(called_head)
       assert.are.equal('diffs://unstaged:lua/foo.lua', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.same(
+        diffspec.index_to_worktree('lua/foo.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
       assert.are.equal('diff --git a/lua/foo.lua b/lua/foo.lua', lines[1])
       assert.is_true(table.concat(lines, '\n'):find('+local x = 1', 1, true) ~= nil)
     end)
@@ -247,6 +252,10 @@ describe('commands', function()
       assert.are.equal('HEAD~3', captured_revision)
       assert.are.equal('diffs://HEAD~3:lua/foo.lua', vim.api.nvim_buf_get_name(diff_buf))
       assert.are.equal('/tmp/repo', vim.api.nvim_buf_get_var(diff_buf, 'diffs_repo_root'))
+      assert.are.same(
+        diffspec.rev_to_worktree('HEAD~3', 'lua/foo.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
       assert.are.equal('diff --git a/lua/foo.lua b/lua/foo.lua', lines[1])
       assert.are.equal('--- a/lua/foo.lua', lines[2])
       assert.are.equal('+++ b/lua/foo.lua', lines[3])

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -1,10 +1,12 @@
 require('spec.helpers')
 
 local commands = require('diffs.commands')
+local diffspec = require('diffs.spec')
 local git = require('diffs.git')
 local runtime = require('diffs.runtime')
 
 local saved_git = {}
+local saved_notify
 local saved_systemlist
 local test_buffers = {}
 
@@ -37,11 +39,20 @@ local function mock_systemlist(fn)
   end
 end
 
+local function mock_notify(fn)
+  saved_notify = vim.notify
+  vim.notify = fn
+end
+
 local function restore_mocks()
   for k, v in pairs(saved_git) do
     git[k] = v
   end
   saved_git = {}
+  if saved_notify then
+    vim.notify = saved_notify
+    saved_notify = nil
+  end
   if saved_systemlist then
     vim.fn.systemlist = saved_systemlist
     saved_systemlist = nil
@@ -92,6 +103,10 @@ describe('read_buffer', function()
     end)
 
     it('does nothing on malformed url without colon separator', function()
+      local notification
+      mock_notify(function(message, level)
+        notification = { message = message, level = level }
+      end)
       local bufnr = create_diffs_buffer('diffs://nocolonseparator')
       vim.api.nvim_buf_set_var(bufnr, 'diffs_repo_root', '/tmp')
       local lines_before = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
@@ -99,14 +114,24 @@ describe('read_buffer', function()
         commands.read_buffer(bufnr)
       end)
       assert.are.same(lines_before, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
+      assert.is_not_nil(notification)
+      assert.are.equal(vim.log.levels.WARN, notification.level)
+      assert.is_true(notification.message:find('malformed diffs:// buffer', 1, true) ~= nil)
     end)
 
     it('does nothing when diffs_repo_root is missing', function()
+      local notification
+      mock_notify(function(message, level)
+        notification = { message = message, level = level }
+      end)
       local bufnr = create_diffs_buffer('diffs://staged:missing_root.lua')
       assert.has_no.errors(function()
         commands.read_buffer(bufnr)
       end)
       assert.are.same({ '' }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
+      assert.is_not_nil(notification)
+      assert.are.equal(vim.log.levels.WARN, notification.level)
+      assert.is_true(notification.message:find('without diffs_repo_root', 1, true) ~= nil)
     end)
   end)
 
@@ -218,6 +243,118 @@ describe('read_buffer', function()
 
       assert.are.equal('HEAD~3', captured_rev)
       assert.is_true(called_get_working)
+    end)
+
+    it('uses diffs_spec metadata without parsing the display name', function()
+      local calls = {}
+      mock_git({
+        get_file_content = function(rev, filepath)
+          table.insert(calls, { 'file', rev, filepath })
+          return { 'tree' }
+        end,
+        get_index_content = function(filepath)
+          table.insert(calls, { 'index', filepath })
+          return { 'index' }
+        end,
+        get_working_content = function(filepath)
+          table.insert(calls, { 'worktree', filepath })
+          return { 'worktree' }
+        end,
+      })
+
+      local bufnr = create_diffs_buffer('diffs://metadata-only', {
+        diffs_repo_root = '/tmp',
+        diffs_spec = diffspec.index_to_worktree('meta_unstaged.lua'),
+      })
+      commands.read_buffer(bufnr)
+
+      assert.are.same({
+        { 'index', '/tmp/meta_unstaged.lua' },
+        { 'worktree', '/tmp/meta_unstaged.lua' },
+      }, calls)
+    end)
+
+    it('prefers diffs_spec metadata for HEAD to index reloads', function()
+      local calls = {}
+      mock_git({
+        get_file_content = function(rev, filepath)
+          table.insert(calls, { 'file', rev, filepath })
+          return { 'head' }
+        end,
+        get_index_content = function(filepath)
+          table.insert(calls, { 'index', filepath })
+          return { 'index' }
+        end,
+        get_working_content = function(filepath)
+          table.insert(calls, { 'worktree', filepath })
+          return { 'worktree' }
+        end,
+      })
+
+      local bufnr = create_diffs_buffer('diffs://unstaged:meta_staged.lua', {
+        diffs_repo_root = '/tmp',
+        diffs_spec = diffspec.head_to_index('meta_staged.lua'),
+      })
+      commands.read_buffer(bufnr)
+
+      assert.are.same({
+        { 'file', 'HEAD', '/tmp/meta_staged.lua' },
+        { 'index', '/tmp/meta_staged.lua' },
+      }, calls)
+    end)
+
+    it('prefers diffs_spec metadata for revision to worktree reloads', function()
+      local calls = {}
+      mock_git({
+        get_file_content = function(rev, filepath)
+          table.insert(calls, { 'file', rev, filepath })
+          return { 'old' }
+        end,
+        get_index_content = function(filepath)
+          table.insert(calls, { 'index', filepath })
+          return { 'index' }
+        end,
+        get_working_content = function(filepath)
+          table.insert(calls, { 'worktree', filepath })
+          return { 'worktree' }
+        end,
+      })
+
+      local bufnr = create_diffs_buffer('diffs://unstaged:meta_rev.lua', {
+        diffs_repo_root = '/tmp',
+        diffs_spec = diffspec.rev_to_worktree('HEAD~3', 'meta_rev.lua'),
+      })
+      commands.read_buffer(bufnr)
+
+      assert.are.same({
+        { 'file', 'HEAD~3', '/tmp/meta_rev.lua' },
+        { 'worktree', '/tmp/meta_rev.lua' },
+      }, calls)
+    end)
+
+    it('warns and leaves content unchanged for invalid diffs_spec metadata', function()
+      local notification
+      mock_notify(function(message, level)
+        notification = { message = message, level = level }
+      end)
+
+      local bufnr = create_diffs_buffer('diffs://unstaged:invalid_meta.lua', {
+        diffs_repo_root = '/tmp',
+        diffs_spec = {
+          left = { kind = 'bogus' },
+          right = { kind = 'worktree' },
+          scope = { kind = 'file', path = 'invalid_meta.lua' },
+          mode = 'unified',
+        },
+      })
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'stale content' })
+
+      commands.read_buffer(bufnr)
+
+      assert.is_not_nil(notification)
+      assert.are.equal(vim.log.levels.WARN, notification.level)
+      assert.is_true(notification.message:find('invalid diffs_spec metadata', 1, true) ~= nil)
+      assert.are.same({ 'stale content' }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
     end)
 
     it('falls back from index to HEAD for unstaged when index returns nil', function()


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #232.

## Solution

The solution stores `b:diffs_spec` on generated `:Gdiff` buffers; prefers stored `DiffSpec` metadata when reloading `diffs://` buffers, leaving URI label parsing as the legacy fallback; and warns and preserve buffer contents for invalid reload metadata.
