### PR TITLE
Render DiffSpec endpoints centrally

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -4,6 +4,7 @@ local diffspec = require('diffs.spec')
 local gdiff_parser = require('diffs.gdiff')
 local git = require('diffs.git')
 local dbg = require('diffs.log').dbg
+local render = require('diffs.render')
 local runtime = require('diffs.runtime')
 
 ---@return integer?
@@ -57,39 +58,6 @@ function M.filter_combined_diffs(lines)
   return result
 end
 
----@param old_lines string[]
----@param new_lines string[]
----@param old_name string
----@param new_name string
----@return string[]
-local function generate_unified_diff(old_lines, new_lines, old_name, new_name)
-  local old_content = table.concat(old_lines, '\n')
-  local new_content = table.concat(new_lines, '\n')
-
-  local diff_fn = vim.text and vim.text.diff or vim.diff
-  local diff_output = diff_fn(old_content, new_content, {
-    result_type = 'unified',
-    ctxlen = 3,
-  })
-
-  if not diff_output or diff_output == '' then
-    return {}
-  end
-
-  local diff_lines = vim.split(diff_output, '\n', { plain = true })
-
-  local result = {
-    'diff --git a/' .. old_name .. ' b/' .. new_name,
-    '--- a/' .. old_name,
-    '+++ b/' .. new_name,
-  }
-  for _, line in ipairs(diff_lines) do
-    table.insert(result, line)
-  end
-
-  return result
-end
-
 ---@param diff_spec diffs.DiffSpec
 ---@return string
 local function gdiff_buffer_label(diff_spec)
@@ -116,49 +84,6 @@ local function gdiff_buffer_label(diff_spec)
   end
 
   return diffspec.label(diff_spec)
-end
-
----@param endpoint diffs.Endpoint
----@param filepath string
----@param bufnr integer
----@return string[]?, string?
-local function read_gdiff_endpoint(endpoint, filepath, bufnr)
-  endpoint = diffspec.endpoint(endpoint)
-
-  if endpoint.kind == diffspec.endpoint_kind.tree then
-    return git.get_file_content(endpoint.rev, filepath)
-  end
-
-  if endpoint.kind == diffspec.endpoint_kind.index then
-    return git.get_index_content(filepath)
-  end
-
-  if endpoint.kind == diffspec.endpoint_kind.worktree then
-    return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), nil
-  end
-
-  return nil, 'unsupported endpoint: ' .. tostring(endpoint.kind)
-end
-
----@param endpoint diffs.Endpoint
----@param filepath string
----@return string[]?, string?
-local function read_repo_endpoint(endpoint, filepath)
-  endpoint = diffspec.endpoint(endpoint)
-
-  if endpoint.kind == diffspec.endpoint_kind.tree then
-    return git.get_file_content(endpoint.rev, filepath)
-  end
-
-  if endpoint.kind == diffspec.endpoint_kind.index then
-    return git.get_index_content(filepath)
-  end
-
-  if endpoint.kind == diffspec.endpoint_kind.worktree then
-    return git.get_working_content(filepath)
-  end
-
-  return nil, 'unsupported endpoint: ' .. tostring(endpoint.kind)
 end
 
 ---@param bufnr integer
@@ -194,24 +119,6 @@ local function get_diff_spec_var(bufnr)
   return parsed, nil
 end
 
----@param diff_spec diffs.DiffSpec
----@param repo_root string
----@return string[]?, string?
-local function read_diff_spec(diff_spec, repo_root)
-  diff_spec = diffspec.new(diff_spec)
-
-  if diff_spec.scope.kind ~= diffspec.scope_kind.file then
-    return nil, 'unsupported DiffSpec scope: ' .. tostring(diff_spec.scope.kind)
-  end
-
-  local path = diff_spec.scope.path
-  local abs_path = repo_root .. '/' .. path
-  local old_lines = read_repo_endpoint(diff_spec.left, abs_path) or {}
-  local new_lines = read_repo_endpoint(diff_spec.right, abs_path) or {}
-
-  return generate_unified_diff(old_lines, new_lines, path, path), nil
-end
-
 ---@param raw_lines string[]
 ---@param repo_root string
 ---@return string[]
@@ -230,7 +137,7 @@ local function replace_combined_diffs(raw_lines, repo_root)
     local filepath = repo_root .. '/' .. filename
     local old_lines = git.get_file_content(':2', filepath) or {}
     local new_lines = git.get_file_content(':3', filepath) or {}
-    local diff_lines = generate_unified_diff(old_lines, new_lines, filename, filename)
+    local diff_lines = render.unified_lines(old_lines, new_lines, filename, filename)
     for _, dl in ipairs(diff_lines) do
       table.insert(result, dl)
     end
@@ -272,27 +179,24 @@ function M.gdiff(args, vertical)
   local diff_spec = parsed.spec
   local diff_label = gdiff_buffer_label(diff_spec)
   local diff_path = diff_spec.scope.path
-
-  local old_lines, err = read_gdiff_endpoint(diff_spec.left, filepath, bufnr)
-  if not old_lines then
-    vim.notify('[diffs.nvim]: ' .. (err or 'unknown error'), vim.log.levels.ERROR)
+  local repo_root = git.get_repo_root(filepath)
+  if not repo_root then
+    vim.notify('[diffs.nvim]: not in a git repository', vim.log.levels.ERROR)
     return
   end
 
-  local new_lines, new_err = read_gdiff_endpoint(diff_spec.right, filepath, bufnr)
-  if not new_lines then
-    vim.notify('[diffs.nvim]: ' .. (new_err or 'unknown error'), vim.log.levels.ERROR)
+  local diff_lines, render_err = render.file(diff_spec, repo_root, {
+    worktree_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false),
+  })
+  if not diff_lines then
+    vim.notify('[diffs.nvim]: ' .. (render_err or 'unknown error'), vim.log.levels.ERROR)
     return
   end
-
-  local diff_lines = generate_unified_diff(old_lines, new_lines, diff_path, diff_path)
 
   if #diff_lines == 0 then
     vim.notify('[diffs.nvim]: no changes for ' .. diffspec.label(diff_spec), vim.log.levels.INFO)
     return
   end
-
-  local repo_root = git.get_repo_root(filepath)
 
   local diff_buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(diff_buf, 0, -1, false, diff_lines)
@@ -395,7 +299,7 @@ function M.gdiff_file(filepath, opts)
     end
   end
 
-  local diff_lines = generate_unified_diff(old_lines, new_lines, old_rel_path, rel_path)
+  local diff_lines = render.unified_lines(old_lines, new_lines, old_rel_path, rel_path)
 
   if #diff_lines == 0 then
     vim.notify('[diffs.nvim]: no changes', vim.log.levels.INFO)
@@ -971,7 +875,7 @@ function M.read_buffer(bufnr)
   local label, path
   if stored_spec then
     local read_err
-    diff_lines, read_err = read_diff_spec(stored_spec, repo_root)
+    diff_lines, read_err = render.file(stored_spec, repo_root, { empty_on_missing = true })
     if not diff_lines then
       vim.notify('[diffs.nvim]: ' .. read_err, vim.log.levels.WARN)
       return
@@ -1058,7 +962,7 @@ function M.read_buffer(bufnr)
       new_lines = git.get_working_content(abs_path) or {}
     end
 
-    diff_lines = generate_unified_diff(old_lines, new_lines, old_name, path)
+    diff_lines = render.unified_lines(old_lines, new_lines, old_name, path)
   end
 
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
@@ -1117,7 +1021,6 @@ M._test = {
   gdiff_buffer_label = gdiff_buffer_label,
   normalize_greview = normalize_greview,
   parse_review_arg = parse_review_arg,
-  read_gdiff_endpoint = read_gdiff_endpoint,
 }
 
 return M

--- a/lua/diffs/render.lua
+++ b/lua/diffs/render.lua
@@ -1,0 +1,110 @@
+local M = {}
+
+local diffspec = require('diffs.spec')
+local git = require('diffs.git')
+
+---@class diffs.RenderFileOpts
+---@field worktree_lines? string[]
+---@field empty_on_missing? boolean
+---@field old_path? string
+---@field new_path? string
+
+---@param old_lines string[]
+---@param new_lines string[]
+---@param old_name string
+---@param new_name string
+---@return string[]
+function M.unified_lines(old_lines, new_lines, old_name, new_name)
+  local old_content = table.concat(old_lines, '\n')
+  local new_content = table.concat(new_lines, '\n')
+
+  local diff_fn = vim.text and vim.text.diff or vim.diff
+  local diff_output = diff_fn(old_content, new_content, {
+    result_type = 'unified',
+    ctxlen = 3,
+  })
+
+  if not diff_output or diff_output == '' then
+    return {}
+  end
+
+  local diff_lines = vim.split(diff_output, '\n', { plain = true })
+
+  local result = {
+    'diff --git a/' .. old_name .. ' b/' .. new_name,
+    '--- a/' .. old_name,
+    '+++ b/' .. new_name,
+  }
+  for _, line in ipairs(diff_lines) do
+    table.insert(result, line)
+  end
+
+  return result
+end
+
+---@param repo_root string
+---@param path string
+---@return string
+local function abs_path(repo_root, path)
+  return repo_root .. '/' .. path
+end
+
+---@param endpoint diffs.Endpoint
+---@param filepath string
+---@param opts? diffs.RenderFileOpts
+---@return string[]?, string?
+function M.read_endpoint(endpoint, filepath, opts)
+  endpoint = diffspec.endpoint(endpoint)
+  opts = opts or {}
+
+  local lines, err
+  if endpoint.kind == diffspec.endpoint_kind.tree then
+    lines, err = git.get_file_content(endpoint.rev, filepath)
+  elseif endpoint.kind == diffspec.endpoint_kind.index then
+    lines, err = git.get_index_content(filepath)
+  elseif endpoint.kind == diffspec.endpoint_kind.worktree then
+    lines = opts.worktree_lines
+    if not lines then
+      lines, err = git.get_working_content(filepath)
+    end
+  else
+    return nil, 'unsupported endpoint: ' .. tostring(endpoint.kind)
+  end
+
+  if not lines and opts.empty_on_missing then
+    return {}, nil
+  end
+
+  return lines, err
+end
+
+---@param diff_spec diffs.DiffSpec
+---@param repo_root string
+---@param opts? diffs.RenderFileOpts
+---@return string[]?, string?
+function M.file(diff_spec, repo_root, opts)
+  diff_spec = diffspec.new(diff_spec)
+  opts = opts or {}
+
+  if diff_spec.scope.kind ~= diffspec.scope_kind.file then
+    return nil, 'unsupported DiffSpec scope: ' .. tostring(diff_spec.scope.kind)
+  end
+
+  local path = diff_spec.scope.path
+  local old_path = opts.old_path or path
+  local new_path = opts.new_path or path
+
+  local old_lines, old_err = M.read_endpoint(diff_spec.left, abs_path(repo_root, old_path), opts)
+  if not old_lines then
+    return nil, old_err or 'could not read left endpoint'
+  end
+
+  local new_lines, new_err = M.read_endpoint(diff_spec.right, abs_path(repo_root, new_path), opts)
+  if not new_lines then
+    return nil, new_err or 'could not read right endpoint'
+  end
+
+  return M.unified_lines(old_lines, new_lines, old_path, new_path), nil
+end
+
+return M

--- a/spec/render_spec.lua
+++ b/spec/render_spec.lua
@@ -1,0 +1,134 @@
+require('spec.helpers')
+
+local diffspec = require('diffs.spec')
+local git = require('diffs.git')
+local render = require('diffs.render')
+
+local saved_git = {}
+
+local function mock_git_content()
+  saved_git.get_file_content = git.get_file_content
+  saved_git.get_index_content = git.get_index_content
+  saved_git.get_working_content = git.get_working_content
+
+  git.get_file_content = function(rev, filepath)
+    assert.are.equal('/tmp/repo/foo.lua', filepath)
+    if rev == 'HEAD' then
+      return { 'return "head"' }
+    end
+    if rev == 'HEAD~1' then
+      return { 'return "older"' }
+    end
+    if rev == 'feature' then
+      return { 'return "feature"' }
+    end
+    return nil, 'unknown rev'
+  end
+
+  git.get_index_content = function(filepath)
+    assert.are.equal('/tmp/repo/foo.lua', filepath)
+    return { 'return "index"' }
+  end
+
+  git.get_working_content = function(filepath)
+    assert.are.equal('/tmp/repo/foo.lua', filepath)
+    return { 'return "worktree"' }
+  end
+end
+
+local function restore_mocks()
+  for k, v in pairs(saved_git) do
+    git[k] = v
+  end
+  saved_git = {}
+end
+
+local function render_text(spec)
+  local lines, err = render.file(spec, '/tmp/repo')
+  assert.is_nil(err)
+  assert.is_not_nil(lines)
+  return table.concat(lines, '\n')
+end
+
+describe('diffs.render', function()
+  after_each(function()
+    restore_mocks()
+  end)
+
+  it('renders index to worktree edges separately from staged changes', function()
+    mock_git_content()
+
+    local text = render_text(diffspec.index_to_worktree('foo.lua'))
+
+    assert.is_true(text:find('-return "index"', 1, true) ~= nil)
+    assert.is_true(text:find('+return "worktree"', 1, true) ~= nil)
+    assert.is_false(text:find('return "head"', 1, true) ~= nil)
+  end)
+
+  it('renders HEAD to index edges separately from unstaged changes', function()
+    mock_git_content()
+
+    local text = render_text(diffspec.head_to_index('foo.lua'))
+
+    assert.is_true(text:find('-return "head"', 1, true) ~= nil)
+    assert.is_true(text:find('+return "index"', 1, true) ~= nil)
+    assert.is_false(text:find('return "worktree"', 1, true) ~= nil)
+  end)
+
+  it('renders arbitrary tree to index edges', function()
+    mock_git_content()
+
+    local text = render_text(diffspec.file(diffspec.tree('HEAD~1'), diffspec.index(), 'foo.lua'))
+
+    assert.is_true(text:find('-return "older"', 1, true) ~= nil)
+    assert.is_true(text:find('+return "index"', 1, true) ~= nil)
+    assert.is_false(text:find('return "worktree"', 1, true) ~= nil)
+  end)
+
+  it('renders revision to worktree edges', function()
+    mock_git_content()
+
+    local text = render_text(diffspec.rev_to_worktree('HEAD~1', 'foo.lua'))
+
+    assert.is_true(text:find('-return "older"', 1, true) ~= nil)
+    assert.is_true(text:find('+return "worktree"', 1, true) ~= nil)
+  end)
+
+  it('renders read-only revision to revision edges', function()
+    local calls = {}
+    mock_git_content()
+    git.get_file_content = function(rev, filepath)
+      table.insert(calls, { rev, filepath })
+      if rev == 'HEAD~1' then
+        return { 'return "older"' }
+      end
+      if rev == 'feature' then
+        return { 'return "feature"' }
+      end
+      return nil, 'unknown rev'
+    end
+
+    local text = render_text(diffspec.rev_to_rev('HEAD~1', 'feature', 'foo.lua'))
+
+    assert.are.same({
+      { 'HEAD~1', '/tmp/repo/foo.lua' },
+      { 'feature', '/tmp/repo/foo.lua' },
+    }, calls)
+    assert.is_true(text:find('-return "older"', 1, true) ~= nil)
+    assert.is_true(text:find('+return "feature"', 1, true) ~= nil)
+  end)
+
+  it('can render against current unsaved worktree lines', function()
+    mock_git_content()
+
+    local lines, err = render.file(diffspec.rev_to_worktree('HEAD', 'foo.lua'), '/tmp/repo', {
+      worktree_lines = { 'return "buffer"' },
+    })
+
+    assert.is_nil(err)
+    local text = table.concat(lines, '\n')
+    assert.is_true(text:find('-return "head"', 1, true) ~= nil)
+    assert.is_true(text:find('+return "buffer"', 1, true) ~= nil)
+    assert.is_false(text:find('return "worktree"', 1, true) ~= nil)
+  end)
+end)


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #233.

## Solution

The solution adds `diffs.render` for unified diff generation from `DiffSpec` file endpoints; routes `:Gdiff` and `diffs://` metadata reloads through the same endpoint renderer; and handles index -> worktree, tree -> index, tree -> worktree, tree -> tree, and unsaved-buffer worktree rendering.
