### PR TITLE
Preserve configured keymap ownership

### DIFF
--- a/lua/diffs/conflict.lua
+++ b/lua/diffs/conflict.lua
@@ -22,7 +22,7 @@ local attached_buffers = {}
 ---@type table<integer, boolean>
 local diagnostics_suppressed = {}
 
----@type table<integer, string[]>
+---@type table<integer, table<string, diffs.BufferKeymap>>
 local buffer_keymaps = {}
 
 ---@param lines string[]

--- a/lua/diffs/keymaps.lua
+++ b/lua/diffs/keymaps.lua
@@ -1,5 +1,42 @@
 local M = {}
 
+---@class diffs.BufferKeymap
+---@field rhs string?
+---@field callback function?
+
+---@param bufnr integer
+---@param lhs string
+---@return table?
+local function get_buffer_keymap(bufnr, lhs)
+  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, 'n')) do
+    if keymap.lhs == lhs then
+      return keymap
+    end
+  end
+end
+
+---@param keymap table
+---@return diffs.BufferKeymap
+local function keymap_identity(keymap)
+  if keymap.callback then
+    return { callback = keymap.callback }
+  end
+  return { rhs = keymap.rhs or '' }
+end
+
+---@param keymap table?
+---@param identity diffs.BufferKeymap?
+---@return boolean
+local function keymap_matches(keymap, identity)
+  if not keymap or not identity then
+    return false
+  end
+  if identity.callback then
+    return keymap.callback == identity.callback
+  end
+  return (keymap.rhs or '') == identity.rhs
+end
+
 ---@param config diffs.ConflictConfig
 ---@param key diffs.ConflictKeymapName
 ---@return string|false
@@ -11,33 +48,47 @@ function M.get_conflict_keymap(config, key)
   return keymaps[key] or false
 end
 
----@param registry table<integer, string[]>
+---@param registry table<integer, table<string, diffs.BufferKeymap>>
 ---@param bufnr integer
 function M.clear_buffer_keymaps(registry, bufnr)
-  local keymaps = registry[bufnr]
-  if not keymaps then
+  local registered = registry[bufnr]
+  if not registered then
     return
   end
-  for _, keymap in ipairs(keymaps) do
-    pcall(vim.keymap.del, 'n', keymap, { buffer = bufnr })
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    registry[bufnr] = nil
+    return
+  end
+  for lhs, identity in pairs(registered) do
+    local current = get_buffer_keymap(bufnr, lhs)
+    if keymap_matches(current, identity) then
+      pcall(vim.keymap.del, 'n', lhs, { buffer = bufnr })
+    end
   end
   registry[bufnr] = nil
 end
 
----@param registry table<integer, string[]>
+---@param registry table<integer, table<string, diffs.BufferKeymap>>
 ---@param bufnr integer
----@param maps [string|false, string][]
+---@param maps [string|false, string|function][]
 function M.set_buffer_keymaps(registry, bufnr, maps)
   M.clear_buffer_keymaps(registry, bufnr)
 
   local installed = {}
   for _, map in ipairs(maps) do
-    if map[1] then
-      vim.keymap.set('n', map[1], map[2], { buffer = bufnr })
-      installed[#installed + 1] = map[1]
+    local lhs = map[1]
+    if type(lhs) == 'string' then
+      local current = get_buffer_keymap(bufnr, lhs)
+      if not current or keymap_matches(current, installed[lhs]) then
+        vim.keymap.set('n', lhs, map[2], { buffer = bufnr })
+        local installed_keymap = get_buffer_keymap(bufnr, lhs)
+        if installed_keymap then
+          installed[lhs] = keymap_identity(installed_keymap)
+        end
+      end
     end
   end
-  if #installed > 0 then
+  if next(installed) then
     registry[bufnr] = installed
   end
 end

--- a/lua/diffs/merge.lua
+++ b/lua/diffs/merge.lua
@@ -8,7 +8,7 @@ local ns = vim.api.nvim_create_namespace('diffs-merge')
 ---@type table<integer, table<integer, true>>
 local resolved_hunks = {}
 
----@type table<integer, string[]>
+---@type table<integer, table<string, diffs.BufferKeymap>>
 local buffer_keymaps = {}
 
 ---@class diffs.MergeHunkInfo

--- a/spec/conflict_spec.lua
+++ b/spec/conflict_spec.lua
@@ -391,6 +391,56 @@ describe('conflict', function()
 
       helpers.delete_buffer(bufnr)
     end)
+
+    it('does not replace pre-existing buffer-local keymaps', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+      vim.keymap.set('n', 'gt', '<Nop>', { buffer = bufnr, desc = 'user theirs' })
+      local cfg = default_config({ keymaps = helpers.default_conflict_keymaps() })
+
+      conflict.attach(bufnr, cfg)
+
+      local theirs = helpers.get_keymap(bufnr, 'gt')
+      local ours = helpers.get_keymap(bufnr, 'go')
+      assert.are.equal('user theirs', theirs.desc)
+      assert.are.equal('<Plug>(diffs-conflict-ours)', ours.rhs)
+
+      conflict.detach(bufnr)
+
+      theirs = helpers.get_keymap(bufnr, 'gt')
+      assert.are.equal('user theirs', theirs.desc)
+      assert.is_false(helpers.has_keymap(bufnr, 'go'))
+
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('does not remove a user replacement during cleanup', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+      local cfg = default_config({ keymaps = helpers.default_conflict_keymaps() })
+
+      conflict.attach(bufnr, cfg)
+      assert.are.equal('<Plug>(diffs-conflict-ours)', helpers.get_keymap(bufnr, 'go').rhs)
+
+      vim.keymap.set('n', 'go', '<Nop>', { buffer = bufnr, desc = 'user ours' })
+      conflict.detach(bufnr)
+
+      local ours = helpers.get_keymap(bufnr, 'go')
+      assert.are.equal('user ours', ours.desc)
+      assert.is_false(helpers.has_keymap(bufnr, 'gt'))
+
+      helpers.delete_buffer(bufnr)
+    end)
   end)
 
   describe('resolution', function()

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -48,12 +48,15 @@ function M.get_extmarks(bufnr, ns)
 end
 
 function M.has_keymap(bufnr, lhs, mode)
+  return M.get_keymap(bufnr, lhs, mode) ~= nil
+end
+
+function M.get_keymap(bufnr, lhs, mode)
   for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, mode or 'n')) do
     if keymap.lhs == lhs then
-      return true
+      return keymap
     end
   end
-  return false
 end
 
 return M

--- a/spec/merge_spec.lua
+++ b/spec/merge_spec.lua
@@ -796,6 +796,58 @@ describe('merge', function()
       helpers.delete_buffer(d_bufnr)
       helpers.delete_buffer(w_bufnr)
     end)
+
+    it('does not replace pre-existing buffer-local keymaps', function()
+      local d_bufnr = create_diff_buffer({
+        'diff --git a/file.lua b/file.lua',
+        '--- a/file.lua',
+        '+++ b/file.lua',
+        '@@ -1,1 +1,1 @@',
+        '-local x = 1',
+        '+local x = 2',
+      })
+      vim.keymap.set('n', 'gt', '<Nop>', { buffer = d_bufnr, desc = 'user theirs' })
+      local cfg = default_config({ keymaps = helpers.default_conflict_keymaps() })
+
+      merge.setup_keymaps(d_bufnr, cfg)
+
+      local theirs = helpers.get_keymap(d_bufnr, 'gt')
+      local ours = helpers.get_keymap(d_bufnr, 'go')
+      assert.are.equal('user theirs', theirs.desc)
+      assert.are.equal('<Plug>(diffs-merge-ours)', ours.rhs)
+
+      merge.setup_keymaps(d_bufnr, default_config())
+
+      theirs = helpers.get_keymap(d_bufnr, 'gt')
+      assert.are.equal('user theirs', theirs.desc)
+      assert.is_false(helpers.has_keymap(d_bufnr, 'go'))
+
+      helpers.delete_buffer(d_bufnr)
+    end)
+
+    it('does not remove a user replacement during cleanup', function()
+      local d_bufnr = create_diff_buffer({
+        'diff --git a/file.lua b/file.lua',
+        '--- a/file.lua',
+        '+++ b/file.lua',
+        '@@ -1,1 +1,1 @@',
+        '-local x = 1',
+        '+local x = 2',
+      })
+      local cfg = default_config({ keymaps = helpers.default_conflict_keymaps() })
+
+      merge.setup_keymaps(d_bufnr, cfg)
+      assert.are.equal('<Plug>(diffs-merge-ours)', helpers.get_keymap(d_bufnr, 'go').rhs)
+
+      vim.keymap.set('n', 'go', '<Nop>', { buffer = d_bufnr, desc = 'user ours' })
+      merge.setup_keymaps(d_bufnr, default_config())
+
+      local ours = helpers.get_keymap(d_bufnr, 'go')
+      assert.are.equal('user ours', ours.desc)
+      assert.is_false(helpers.has_keymap(d_bufnr, 'gt'))
+
+      helpers.delete_buffer(d_bufnr)
+    end)
   end)
 
   describe('fugitive integration', function()


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #257.

## Solution

The solution makes configured conflict/merge buffer maps skip pre-existing user mappings; and track installed map identity by callback/rhs so cleanup only deletes maps still owned by diffs.nvim.
