### PR TITLE
Refine Gdiff action buffers

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -360,6 +360,7 @@ function M.gdiff_file(filepath, opts)
 
   local old_lines, new_lines, err
   local diff_label
+  local diff_spec
 
   if opts.unmerged then
     old_lines = git.get_file_content(':2', filepath)
@@ -389,6 +390,9 @@ function M.gdiff_file(filepath, opts)
       new_lines = {}
     end
     diff_label = 'staged'
+    if old_rel_path == rel_path then
+      diff_spec = diffspec.head_to_index(rel_path)
+    end
   else
     old_lines, err = git.get_index_content(opts.old_filepath or filepath)
     if not old_lines then
@@ -401,6 +405,9 @@ function M.gdiff_file(filepath, opts)
       end
     else
       diff_label = 'unstaged'
+      if old_rel_path == rel_path then
+        diff_spec = diffspec.index_to_worktree(rel_path)
+      end
     end
     new_lines, err = git.get_working_content(filepath)
     if not new_lines then
@@ -425,6 +432,10 @@ function M.gdiff_file(filepath, opts)
   vim.api.nvim_set_option_value('modifiable', false, { buf = diff_buf })
   vim.api.nvim_set_option_value('filetype', 'diff', { buf = diff_buf })
   vim.api.nvim_buf_set_name(diff_buf, 'diffs://' .. diff_label .. ':' .. rel_path)
+  if diff_spec then
+    set_diff_spec_var(diff_buf, diff_spec)
+    set_diff_hunks_var(diff_buf, diff_lines, diff_spec)
+  end
   if repo_root then
     vim.api.nvim_buf_set_var(diff_buf, 'diffs_repo_root', repo_root)
   end

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -3,8 +3,11 @@ local helpers = require('spec.helpers')
 local commands = require('diffs.commands')
 local diffspec = require('diffs.spec')
 local git = require('diffs.git')
+local runtime = require('diffs.runtime')
 
 local saved_git = {}
+local saved_runtime_attach
+local saved_schedule
 local saved_systemlist
 local test_buffers = {}
 
@@ -27,11 +30,28 @@ local function mock_systemlist(fn)
   end
 end
 
+local function mock_runtime_attach(fn)
+  saved_runtime_attach = runtime.attach
+  runtime.attach = fn
+  saved_schedule = vim.schedule
+  vim.schedule = function(callback)
+    callback()
+  end
+end
+
 local function restore_mocks()
   for k, v in pairs(saved_git) do
     git[k] = v
   end
   saved_git = {}
+  if saved_runtime_attach then
+    runtime.attach = saved_runtime_attach
+    saved_runtime_attach = nil
+  end
+  if saved_schedule then
+    vim.schedule = saved_schedule
+    saved_schedule = nil
+  end
   if saved_systemlist then
     vim.fn.systemlist = saved_systemlist
     saved_systemlist = nil
@@ -193,14 +213,12 @@ describe('commands', function()
         assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
         return '/tmp/repo'
       end)
+      mock_runtime_attach(function() end)
 
       commands.gdiff(nil, false)
 
       local diff_buf = vim.api.nvim_get_current_buf()
       table.insert(test_buffers, diff_buf)
-      vim.wait(10, function()
-        return false
-      end)
       local lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
 
       assert.is_true(called_index)
@@ -250,14 +268,12 @@ describe('commands', function()
         assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
         return '/tmp/repo'
       end)
+      mock_runtime_attach(function() end)
 
       commands.gdiff('HEAD~3', false)
 
       local diff_buf = vim.api.nvim_get_current_buf()
       table.insert(test_buffers, diff_buf)
-      vim.wait(10, function()
-        return false
-      end)
       local lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
 
       assert.are.equal('HEAD~3', captured_revision)
@@ -275,6 +291,85 @@ describe('commands', function()
       assert.are.equal('--- a/lua/foo.lua', lines[2])
       assert.are.equal('+++ b/lua/foo.lua', lines[3])
       assert.is_true(table.concat(lines, '\n'):find('+local x = 1', 1, true) ~= nil)
+    end)
+  end)
+
+  describe('gdiff_file DiffSpec metadata', function()
+    it('marks fugitive-style staged file diffs as HEAD to index buffers', function()
+      mock_git_method('get_relative_path', function(filepath)
+        if filepath == '/tmp/repo/lua/foo.lua' then
+          return 'lua/foo.lua'
+        end
+        return nil
+      end)
+      mock_git_method('get_file_content', function(revision, filepath)
+        assert.are.equal('HEAD', revision)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return { 'local M = {}', 'return M' }
+      end)
+      mock_git_method('get_index_content', function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return { 'local M = {}', 'local x = 1', 'return M' }
+      end)
+      mock_repo_root(function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return '/tmp/repo'
+      end)
+      mock_runtime_attach(function() end)
+
+      commands.gdiff_file('/tmp/repo/lua/foo.lua', { staged = true })
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+
+      assert.are.equal('diffs://staged:lua/foo.lua', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.same(
+        diffspec.head_to_index('lua/foo.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      local diff_hunks = vim.api.nvim_buf_get_var(diff_buf, 'diffs_hunks')
+      assert.are.equal(1, #diff_hunks)
+      assert.are.equal('index', diff_hunks[1].mutation_target)
+      assert.is_true(helpers.has_keymap(diff_buf, 'do'))
+      assert.is_true(helpers.has_keymap(diff_buf, 'dp'))
+    end)
+
+    it('marks fugitive-style unstaged file diffs as index to worktree buffers', function()
+      mock_git_method('get_relative_path', function(filepath)
+        if filepath == '/tmp/repo/lua/foo.lua' then
+          return 'lua/foo.lua'
+        end
+        return nil
+      end)
+      mock_git_method('get_index_content', function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return { 'local M = {}', 'return M' }
+      end)
+      mock_git_method('get_working_content', function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return { 'local M = {}', 'local x = 1', 'return M' }
+      end)
+      mock_repo_root(function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return '/tmp/repo'
+      end)
+      mock_runtime_attach(function() end)
+
+      commands.gdiff_file('/tmp/repo/lua/foo.lua')
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+
+      assert.are.equal('diffs://unstaged:lua/foo.lua', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.same(
+        diffspec.index_to_worktree('lua/foo.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      local diff_hunks = vim.api.nvim_buf_get_var(diff_buf, 'diffs_hunks')
+      assert.are.equal(1, #diff_hunks)
+      assert.are.equal('worktree', diff_hunks[1].mutation_target)
+      assert.is_true(helpers.has_keymap(diff_buf, 'do'))
+      assert.is_true(helpers.has_keymap(diff_buf, 'dp'))
     end)
   end)
 
@@ -390,6 +485,7 @@ describe('commands', function()
           '+new',
         }
       end)
+      mock_runtime_attach(function() end)
 
       local bufnr = commands.greview({
         base = 'origin/main',
@@ -398,9 +494,6 @@ describe('commands', function()
         repo = '/tmp/repo',
       })
       table.insert(test_buffers, bufnr)
-      vim.wait(10, function()
-        return false
-      end)
 
       assert.are.same({
         'git',

--- a/spec/integration_spec.lua
+++ b/spec/integration_spec.lua
@@ -128,15 +128,34 @@ describe('integration', function()
   end)
 
   describe('ft_retry_pending', function()
+    local saved_schedule
+    local scheduled_callbacks
+
+    local function run_scheduled_callbacks()
+      local callbacks = scheduled_callbacks
+      scheduled_callbacks = {}
+      for _, callback in ipairs(callbacks) do
+        callback()
+      end
+    end
+
     before_each(function()
       rawset(vim.fn, 'did_filetype', function()
         return 1
       end)
+      saved_schedule = vim.schedule
+      scheduled_callbacks = {}
+      vim.schedule = function(callback)
+        scheduled_callbacks[#scheduled_callbacks + 1] = callback
+      end
       require('diffs.parser')._test.ft_lang_cache = {}
     end)
 
     after_each(function()
       rawset(vim.fn, 'did_filetype', nil)
+      vim.schedule = saved_schedule
+      saved_schedule = nil
+      scheduled_callbacks = nil
     end)
 
     it('sets ft_retry_pending when nil-ft hunks detected under did_filetype', function()
@@ -166,13 +185,7 @@ describe('integration', function()
       runtime.attach(bufnr)
       assert.is_true(runtime._test.ft_retry_pending[bufnr] == true)
 
-      local done = false
-      vim.schedule(function()
-        done = true
-      end)
-      vim.wait(1000, function()
-        return done
-      end)
+      run_scheduled_callbacks()
 
       assert.is_nil(runtime._test.ft_retry_pending[bufnr])
       delete_buffer(bufnr)
@@ -190,13 +203,7 @@ describe('integration', function()
       local tick_after_attach = runtime._test.hunk_cache[bufnr].tick
       assert.is_true(tick_after_attach >= 0)
 
-      local done = false
-      vim.schedule(function()
-        done = true
-      end)
-      vim.wait(1000, function()
-        return done
-      end)
+      run_scheduled_callbacks()
 
       local entry = runtime._test.hunk_cache[bufnr]
       assert.are.equal(-1, entry.tick)


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

## Solution

The solution preserves DiffSpec and hunk metadata on fugitive-style staged/unstaged `gdiff_file` buffers so `do`/`dp` work there too.
