### PR TITLE
Add visual Gdiff range actions

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -606,10 +606,12 @@ Diff buffer mappings: ~
     <CR>            Open the real worktree file at the current |:Gdiff| hunk
                     location when the right side is worktree-backed.
     o               Same as <CR>.
-    dp              Stage the current whole hunk when the buffer compares the
-                    index to the worktree.
-    do              Unstage the current whole hunk when the buffer compares a
-                    tree to the index.
+    dp              In Normal mode, stage the current whole hunk when the
+                    buffer compares the index to the worktree. In Visual mode,
+                    stage selected changed lines inside one hunk.
+    do              In Normal mode, unstage the current whole hunk when the
+                    buffer compares a tree to the index. In Visual mode,
+                    unstage selected changed lines inside one hunk.
 
 ==============================================================================
 INTEGRATIONS                                         *diffs.nvim-integrations*

--- a/lua/diffs/actions.lua
+++ b/lua/diffs/actions.lua
@@ -66,6 +66,26 @@ local function extend_patch_lines(patch, lines)
   end
 end
 
+---@param line diffs.GdiffHunkLine
+---@return boolean
+local function is_change_line(line)
+  return line.kind == 'add' or line.kind == 'delete'
+end
+
+---@param line diffs.GdiffHunkLine
+---@return string
+local function context_text(line)
+  return ' ' .. line.text:sub(2)
+end
+
+---@param lnum integer
+---@param range_start integer
+---@param range_finish integer
+---@return boolean
+local function in_range(lnum, range_start, range_finish)
+  return lnum >= range_start and lnum <= range_finish
+end
+
 ---@param hunk diffs.GdiffHunk
 ---@return string?, string?
 function M.patch_for_hunk(hunk)
@@ -85,6 +105,134 @@ function M.patch_for_hunk(hunk)
   return table.concat(patch_lines, '\n') .. '\n', nil
 end
 
+---@class diffs.GdiffChangeGroup
+---@field lines diffs.GdiffHunkLine[]
+---@field has_add boolean
+---@field has_delete boolean
+
+---@param hunk diffs.GdiffHunk
+---@return diffs.GdiffChangeGroup[]
+local function change_groups(hunk)
+  local groups = {}
+  local current = nil
+
+  local function finish_group()
+    if current then
+      groups[#groups + 1] = current
+      current = nil
+    end
+  end
+
+  for _, line in ipairs(hunk.lines or {}) do
+    if is_change_line(line) then
+      current = current or { lines = {}, has_add = false, has_delete = false }
+      current.lines[#current.lines + 1] = line
+      current.has_add = current.has_add or line.kind == 'add'
+      current.has_delete = current.has_delete or line.kind == 'delete'
+    elseif line.kind ~= 'meta' then
+      finish_group()
+    end
+  end
+
+  finish_group()
+  return groups
+end
+
+---@param hunk diffs.GdiffHunk
+---@param range_start integer
+---@param range_finish integer
+---@return string?
+local function validate_range(hunk, range_start, range_finish)
+  for _, group in ipairs(change_groups(hunk)) do
+    if group.has_add and group.has_delete then
+      local selected = 0
+      for _, line in ipairs(group.lines) do
+        if in_range(line.lnum, range_start, range_finish) then
+          selected = selected + 1
+        end
+      end
+      if selected > 0 and selected < #group.lines then
+        return 'select the complete replacement group before applying it'
+      end
+    end
+  end
+  return nil
+end
+
+---@param hunk diffs.GdiffHunk
+---@param range_start integer
+---@param range_finish integer
+---@param opts? { target?: "left"|"right" }
+---@return string?, string?
+function M.patch_for_range(hunk, range_start, range_finish, opts)
+  opts = opts or {}
+  local target = opts.target or 'left'
+  if not hunk then
+    return nil, 'no Gdiff hunk under cursor'
+  end
+  if target ~= 'left' and target ~= 'right' then
+    return nil, 'invalid Gdiff range patch target'
+  end
+  if type(range_start) ~= 'number' or type(range_finish) ~= 'number' then
+    return nil, 'invalid Gdiff visual range'
+  end
+  if range_finish < range_start then
+    range_start, range_finish = range_finish, range_start
+  end
+  if range_start < hunk.buffer_range.start or range_finish > hunk.buffer_range.finish then
+    return nil, 'visual selection must stay within one Gdiff hunk'
+  end
+
+  local range_err = validate_range(hunk, range_start, range_finish)
+  if range_err then
+    return nil, range_err
+  end
+  if type(hunk.file_header_lines) ~= 'table' or #hunk.file_header_lines == 0 then
+    return nil, 'cannot build hunk patch without file headers'
+  end
+
+  local patch_lines = {}
+  local has_change = false
+  local previous_emitted_change = false
+  extend_patch_lines(patch_lines, hunk.file_header_lines)
+  patch_lines[#patch_lines + 1] = hunk.header
+
+  for _, line in ipairs(hunk.lines or {}) do
+    local emitted = nil
+    local emitted_change = false
+    if line.kind == 'context' or (line.kind == 'meta' and previous_emitted_change) then
+      emitted = line.text
+    elseif line.kind == 'add' then
+      if in_range(line.lnum, range_start, range_finish) then
+        emitted = line.text
+        emitted_change = true
+        has_change = true
+      elseif target == 'right' then
+        emitted = context_text(line)
+      end
+    elseif line.kind == 'delete' then
+      if in_range(line.lnum, range_start, range_finish) then
+        emitted = line.text
+        emitted_change = true
+        has_change = true
+      elseif target == 'left' then
+        emitted = context_text(line)
+      end
+    end
+
+    if emitted then
+      patch_lines[#patch_lines + 1] = emitted
+    end
+    previous_emitted_change = emitted_change
+  end
+
+  if not has_change then
+    return nil, 'visual selection does not include changed Gdiff lines'
+  end
+
+  return table.concat(patch_lines, '\n') .. '\n', nil
+end
+
 ---@param output string[]?
 ---@return string
 local function format_git_output(output)
@@ -98,13 +246,16 @@ end
 ---@param repo_root string
 ---@param patch string
 ---@param operation "stage"|"unstage"
+---@param opts? { recount?: boolean }
 ---@return boolean, string?
-local function checked_apply(repo_root, patch, operation)
+local function checked_apply(repo_root, patch, operation, opts)
+  opts = opts or {}
   local reverse = operation == 'unstage'
   local ok, output = git.apply_patch(repo_root, patch, {
     cached = true,
     reverse = reverse,
     check = true,
+    recount = opts.recount,
   })
   if not ok then
     return false, format_git_output(output)
@@ -113,6 +264,7 @@ local function checked_apply(repo_root, patch, operation)
   ok, output = git.apply_patch(repo_root, patch, {
     cached = true,
     reverse = reverse,
+    recount = opts.recount,
   })
   if not ok then
     return false, format_git_output(output)
@@ -137,6 +289,30 @@ local function current_action_context(bufnr)
   return hunk, spec, nil
 end
 
+---@param bufnr integer
+---@param range_start integer
+---@param range_finish integer
+---@return diffs.GdiffHunk?, diffs.DiffSpec?, string?
+local function range_action_context(bufnr, range_start, range_finish)
+  if range_finish < range_start then
+    range_start, range_finish = range_finish, range_start
+  end
+
+  local parsed = buffer_hunks(bufnr)
+  local start_hunk = hunk_model.hunk_at_line(parsed, range_start)
+  local finish_hunk = hunk_model.hunk_at_line(parsed, range_finish)
+  if not start_hunk or not finish_hunk or start_hunk.index ~= finish_hunk.index then
+    return nil, nil, 'visual selection must stay within one Gdiff hunk'
+  end
+
+  local spec = hunk_diff_spec(start_hunk)
+  if not spec then
+    return nil, nil, 'cannot resolve Gdiff hunk edge'
+  end
+
+  return start_hunk, spec, nil
+end
+
 ---@param message string
 ---@param level integer
 local function notify(message, level)
@@ -146,21 +322,26 @@ end
 ---@param bufnr integer
 ---@param hunk diffs.GdiffHunk
 ---@param operation "stage"|"unstage"
+---@param opts? { patch?: string, recount?: boolean }
 ---@return boolean
-local function mutate_hunk(bufnr, hunk, operation)
+local function mutate_hunk(bufnr, hunk, operation, opts)
+  opts = opts or {}
   local repo_root = get_buf_var(bufnr, 'diffs_repo_root')
   if not repo_root then
     notify('cannot mutate Gdiff hunk without diffs_repo_root', vim.log.levels.ERROR)
     return false
   end
 
-  local patch, patch_err = M.patch_for_hunk(hunk)
+  local patch, patch_err = opts.patch, nil
+  if not patch then
+    patch, patch_err = M.patch_for_hunk(hunk)
+  end
   if not patch then
     notify(patch_err or 'cannot build hunk patch', vim.log.levels.ERROR)
     return false
   end
 
-  local ok, err = checked_apply(repo_root, patch, operation)
+  local ok, err = checked_apply(repo_root, patch, operation, { recount = opts.recount })
   if not ok then
     notify('failed to ' .. operation .. ' Gdiff hunk: ' .. err, vim.log.levels.ERROR)
     return false
@@ -210,6 +391,102 @@ function M.obtain_hunk(bufnr)
 
   if is_tree_to_index(spec) then
     return mutate_hunk(bufnr, hunk, 'unstage')
+  end
+
+  if is_index_to_worktree(spec) then
+    notify('restoring worktree hunks is not supported', vim.log.levels.WARN)
+    return false
+  end
+
+  notify('cannot obtain read-only Gdiff hunk', vim.log.levels.WARN)
+  return false
+end
+
+---@param bufnr integer
+---@param range_start integer
+---@param range_finish integer
+---@return diffs.GdiffHunk?, diffs.DiffSpec?, string?
+local function range_context_or_notify(bufnr, range_start, range_finish)
+  local hunk, spec, err = range_action_context(bufnr, range_start, range_finish)
+  if err then
+    notify(err, vim.log.levels.WARN)
+    return nil, nil, err
+  end
+  if not hunk or not spec then
+    local fallback = 'cannot resolve Gdiff hunk edge'
+    notify(fallback, vim.log.levels.WARN)
+    return nil, nil, fallback
+  end
+
+  return hunk, spec, nil
+end
+
+---@param hunk diffs.GdiffHunk
+---@param range_start integer
+---@param range_finish integer
+---@param target "left"|"right"
+---@return string?
+local function range_patch_or_notify(hunk, range_start, range_finish, target)
+  local patch, patch_err = M.patch_for_range(hunk, range_start, range_finish, {
+    target = target,
+  })
+  if not patch then
+    notify(patch_err or 'cannot build hunk patch', vim.log.levels.WARN)
+    return nil
+  end
+
+  return patch
+end
+
+---@param bufnr integer
+---@param range_start integer
+---@param range_finish integer
+---@return boolean
+function M.put_range(bufnr, range_start, range_finish)
+  local hunk, spec = range_context_or_notify(bufnr, range_start, range_finish)
+  if not hunk or not spec then
+    return false
+  end
+
+  if is_index_to_worktree(spec) then
+    local patch = range_patch_or_notify(hunk, range_start, range_finish, 'left')
+    if not patch then
+      return false
+    end
+    return mutate_hunk(bufnr, hunk, 'stage', {
+      patch = patch,
+      recount = true,
+    })
+  end
+
+  if is_tree_to_index(spec) then
+    notify('Gdiff hunk is already in the index', vim.log.levels.WARN)
+    return false
+  end
+
+  notify('cannot put read-only Gdiff hunk', vim.log.levels.WARN)
+  return false
+end
+
+---@param bufnr integer
+---@param range_start integer
+---@param range_finish integer
+---@return boolean
+function M.obtain_range(bufnr, range_start, range_finish)
+  local hunk, spec = range_context_or_notify(bufnr, range_start, range_finish)
+  if not hunk or not spec then
+    return false
+  end
+
+  if is_tree_to_index(spec) then
+    local patch = range_patch_or_notify(hunk, range_start, range_finish, 'right')
+    if not patch then
+      return false
+    end
+    return mutate_hunk(bufnr, hunk, 'unstage', {
+      patch = patch,
+      recount = true,
+    })
   end
 
   if is_index_to_worktree(spec) then

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -9,16 +9,22 @@ local dbg = require('diffs.log').dbg
 local render = require('diffs.render')
 local runtime = require('diffs.runtime')
 
----@type table<integer, table<string, function>>
+---@class diffs.HunkKeymap
+---@field mode string
+---@field lhs string
+---@field callback function
+
+---@type table<integer, diffs.HunkKeymap[]>
 local hunk_keymaps = {}
 ---@type table<integer, integer>
 local hunk_keymap_autocmds = {}
 
 ---@param bufnr integer
+---@param mode string
 ---@param lhs string
 ---@return table?
-local function get_buffer_keymap(bufnr, lhs)
-  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, 'n')) do
+local function get_buffer_keymap(bufnr, mode, lhs)
+  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, mode)) do
     if keymap.lhs == lhs then
       return keymap
     end
@@ -32,10 +38,10 @@ local function clear_hunk_keymaps(bufnr)
   if not registered then
     return
   end
-  for lhs, callback in pairs(registered) do
-    local current = get_buffer_keymap(bufnr, lhs)
-    if current and current.callback == callback then
-      pcall(vim.keymap.del, 'n', lhs, { buffer = bufnr })
+  for _, keymap in ipairs(registered) do
+    local current = get_buffer_keymap(bufnr, keymap.mode, keymap.lhs)
+    if current and current.callback == keymap.callback then
+      pcall(vim.keymap.del, keymap.mode, keymap.lhs, { buffer = bufnr })
     end
   end
   hunk_keymaps[bufnr] = nil
@@ -58,17 +64,30 @@ local function ensure_hunk_keymap_cleanup(bufnr)
 end
 
 ---@param bufnr integer
+---@param mode string
 ---@param lhs string
 ---@param callback function
 ---@param desc string
-local function set_hunk_keymap(bufnr, lhs, callback, desc)
-  if get_buffer_keymap(bufnr, lhs) then
+local function set_hunk_keymap(bufnr, mode, lhs, callback, desc)
+  if get_buffer_keymap(bufnr, mode, lhs) then
     return
   end
 
-  vim.keymap.set('n', lhs, callback, { buffer = bufnr, desc = desc })
+  vim.keymap.set(mode, lhs, callback, { buffer = bufnr, desc = desc })
   hunk_keymaps[bufnr] = hunk_keymaps[bufnr] or {}
-  hunk_keymaps[bufnr][lhs] = callback
+  hunk_keymaps[bufnr][#hunk_keymaps[bufnr] + 1] = {
+    mode = mode,
+    lhs = lhs,
+    callback = callback,
+  }
+end
+
+---@param bufnr integer
+---@return integer, integer
+local function visual_range(bufnr)
+  local start_line = vim.api.nvim_buf_get_mark(bufnr, '<')[1]
+  local finish_line = vim.api.nvim_buf_get_mark(bufnr, '>')[1]
+  return math.min(start_line, finish_line), math.max(start_line, finish_line)
 end
 
 ---@return integer?
@@ -89,7 +108,7 @@ end
 ---@param bufnr integer
 function M.setup_diff_buf(bufnr)
   vim.diagnostic.enable(false, { bufnr = bufnr })
-  if not get_buffer_keymap(bufnr, 'q') then
+  if not get_buffer_keymap(bufnr, 'n', 'q') then
     vim.keymap.set('n', 'q', '<cmd>close<CR>', { buffer = bufnr })
   end
   local has_hunks = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_hunks')
@@ -98,28 +117,40 @@ function M.setup_diff_buf(bufnr)
     return
   end
 
-  set_hunk_keymap(bufnr, ']c', function()
+  set_hunk_keymap(bufnr, 'n', ']c', function()
     hunk_model.goto_next(bufnr)
   end, 'Next diff hunk')
-  set_hunk_keymap(bufnr, '[c', function()
+  set_hunk_keymap(bufnr, 'n', '[c', function()
     hunk_model.goto_prev(bufnr)
   end, 'Previous diff hunk')
-  set_hunk_keymap(bufnr, '<CR>', function()
+  set_hunk_keymap(bufnr, 'n', '<CR>', function()
     hunk_model.open_source(bufnr)
   end, 'Open source file')
-  set_hunk_keymap(bufnr, 'o', function()
+  set_hunk_keymap(bufnr, 'n', 'o', function()
     hunk_model.open_source(bufnr)
   end, 'Open source file')
-  set_hunk_keymap(bufnr, 'do', function()
+  set_hunk_keymap(bufnr, 'n', 'do', function()
     if actions.obtain_hunk(bufnr) then
       M.read_buffer(bufnr)
     end
   end, 'Unstage Gdiff hunk')
-  set_hunk_keymap(bufnr, 'dp', function()
+  set_hunk_keymap(bufnr, 'n', 'dp', function()
     if actions.put_hunk(bufnr) then
       M.read_buffer(bufnr)
     end
   end, 'Stage Gdiff hunk')
+  set_hunk_keymap(bufnr, 'x', 'do', function()
+    local range_start, range_finish = visual_range(bufnr)
+    if actions.obtain_range(bufnr, range_start, range_finish) then
+      M.read_buffer(bufnr)
+    end
+  end, 'Unstage selected Gdiff lines')
+  set_hunk_keymap(bufnr, 'x', 'dp', function()
+    local range_start, range_finish = visual_range(bufnr)
+    if actions.put_range(bufnr, range_start, range_finish) then
+      M.read_buffer(bufnr)
+    end
+  end, 'Stage selected Gdiff lines')
 
   ensure_hunk_keymap_cleanup(bufnr)
 end

--- a/lua/diffs/git.lua
+++ b/lua/diffs/git.lua
@@ -120,6 +120,7 @@ end
 ---@field cached? boolean
 ---@field reverse? boolean
 ---@field check? boolean
+---@field recount? boolean
 
 ---@param repo_root string
 ---@param patch string
@@ -136,6 +137,9 @@ function M.apply_patch(repo_root, patch, opts)
   end
   if opts.check then
     table.insert(cmd, '--check')
+  end
+  if opts.recount then
+    table.insert(cmd, '--recount')
   end
 
   local output = vim.fn.systemlist(cmd, patch)

--- a/spec/actions_spec.lua
+++ b/spec/actions_spec.lua
@@ -42,6 +42,22 @@ local function file_lines(overrides)
   return lines
 end
 
+local function file_lines_with_insertions(after, inserted)
+  local lines = file_lines()
+  for offset, line in ipairs(inserted) do
+    table.insert(lines, after + offset, line)
+  end
+  return lines
+end
+
+local function file_lines_without(start, count)
+  local lines = file_lines()
+  for _ = 1, count do
+    table.remove(lines, start)
+  end
+  return lines
+end
+
 local function create_repo()
   local repo_root = vim.fn.tempname()
   vim.fn.mkdir(repo_root, 'p')
@@ -73,13 +89,33 @@ local function create_diff_buffer(repo_root, diff_spec)
   return bufnr
 end
 
-local function keymap_callback(bufnr, lhs)
-  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, 'n')) do
+local function keymap_callback(bufnr, lhs, mode)
+  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, mode or 'n')) do
     if keymap.lhs == lhs then
       return keymap.callback
     end
   end
   return nil
+end
+
+local function find_hunk_line(bufnr, kind, text)
+  for _, hunk in ipairs(vim.api.nvim_buf_get_var(bufnr, 'diffs_hunks')) do
+    for _, line in ipairs(hunk.lines) do
+      if line.kind == kind and line.text == text then
+        return line, hunk
+      end
+    end
+  end
+  error('could not find hunk line ' .. kind .. ' ' .. text)
+end
+
+local function find_hunks(bufnr)
+  return vim.api.nvim_buf_get_var(bufnr, 'diffs_hunks')
+end
+
+local function set_visual_range(bufnr, range_start, range_finish)
+  vim.api.nvim_buf_set_mark(bufnr, '<', range_start, 0, {})
+  vim.api.nvim_buf_set_mark(bufnr, '>', range_finish, 0, {})
 end
 
 local function move_to_hunk(bufnr, index)
@@ -154,6 +190,108 @@ describe('diffs.actions', function()
     )
   end)
 
+  it('builds a selected-add range patch for the side receiving the patch', function()
+    local diff_lines = {
+      'diff --git a/file.txt b/file.txt',
+      '--- a/file.txt',
+      '+++ b/file.txt',
+      '@@ -1 +1,3 @@',
+      ' line 1',
+      '+insert alpha',
+      '+insert beta',
+    }
+    local hunk = hunk_model.parse(diff_lines, diffspec.index_to_worktree('file.txt'))[1]
+
+    local patch = assert(actions.patch_for_range(hunk, 7, 7, { target = 'left' }))
+    local reverse_patch = assert(actions.patch_for_range(hunk, 7, 7, { target = 'right' }))
+
+    assert.are.equal(
+      table.concat({
+        'diff --git a/file.txt b/file.txt',
+        '--- a/file.txt',
+        '+++ b/file.txt',
+        '@@ -1 +1,3 @@',
+        ' line 1',
+        '+insert beta',
+        '',
+      }, '\n'),
+      patch
+    )
+    assert.are.equal(
+      table.concat({
+        'diff --git a/file.txt b/file.txt',
+        '--- a/file.txt',
+        '+++ b/file.txt',
+        '@@ -1 +1,3 @@',
+        ' line 1',
+        ' insert alpha',
+        '+insert beta',
+        '',
+      }, '\n'),
+      reverse_patch
+    )
+  end)
+
+  it('builds a selected-delete range patch for the side receiving the patch', function()
+    local diff_lines = {
+      'diff --git a/file.txt b/file.txt',
+      '--- a/file.txt',
+      '+++ b/file.txt',
+      '@@ -1,3 +1 @@',
+      ' line 1',
+      '-delete alpha',
+      '-delete beta',
+    }
+    local hunk = hunk_model.parse(diff_lines, diffspec.index_to_worktree('file.txt'))[1]
+
+    local patch = assert(actions.patch_for_range(hunk, 7, 7, { target = 'left' }))
+    local reverse_patch = assert(actions.patch_for_range(hunk, 7, 7, { target = 'right' }))
+
+    assert.are.equal(
+      table.concat({
+        'diff --git a/file.txt b/file.txt',
+        '--- a/file.txt',
+        '+++ b/file.txt',
+        '@@ -1,3 +1 @@',
+        ' line 1',
+        ' delete alpha',
+        '-delete beta',
+        '',
+      }, '\n'),
+      patch
+    )
+    assert.are.equal(
+      table.concat({
+        'diff --git a/file.txt b/file.txt',
+        '--- a/file.txt',
+        '+++ b/file.txt',
+        '@@ -1,3 +1 @@',
+        ' line 1',
+        '-delete beta',
+        '',
+      }, '\n'),
+      reverse_patch
+    )
+  end)
+
+  it('rejects partial replacement-group ranges before building a patch', function()
+    local diff_lines = {
+      'diff --git a/file.txt b/file.txt',
+      '--- a/file.txt',
+      '+++ b/file.txt',
+      '@@ -1,2 +1,2 @@',
+      ' line 1',
+      '-old',
+      '+new',
+    }
+    local hunk = hunk_model.parse(diff_lines, diffspec.index_to_worktree('file.txt'))[1]
+
+    local patch, err = actions.patch_for_range(hunk, 7, 7)
+
+    assert.is_nil(patch)
+    assert.are.equal('select the complete replacement group before applying it', err)
+  end)
+
   it('stages only the current unstaged hunk and refreshes the buffer', function()
     local repo_root = create_repo()
     write_repo_file(
@@ -185,6 +323,84 @@ describe('diffs.actions', function()
     assert.is_true(buffer_text(bufnr):find('+line 22 changed', 1, true) ~= nil)
   end)
 
+  it('stages only selected added lines from a visual range', function()
+    local repo_root = create_repo()
+    write_repo_file(
+      repo_root,
+      file_lines_with_insertions(2, {
+        'insert alpha',
+        'insert beta',
+      })
+    )
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.index_to_worktree('file.txt'))
+    local selected = find_hunk_line(bufnr, 'add', '+insert beta')
+
+    assert.is_true(actions.put_range(bufnr, selected.lnum, selected.lnum))
+
+    local cached = git_text(
+      repo_root,
+      { 'diff', '--cached', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' }
+    )
+    local worktree =
+      git_text(repo_root, { 'diff', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' })
+
+    assert.is_true(cached:find('+insert beta', 1, true) ~= nil)
+    assert.is_nil(cached:find('+insert alpha', 1, true))
+    assert.is_true(worktree:find('+insert alpha', 1, true) ~= nil)
+    assert.is_nil(worktree:find('+insert beta', 1, true))
+  end)
+
+  it('stages a visual selection through the buffer-local dp map and refreshes', function()
+    local repo_root = create_repo()
+    write_repo_file(
+      repo_root,
+      file_lines_with_insertions(2, {
+        'insert alpha',
+        'insert beta',
+      })
+    )
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.index_to_worktree('file.txt'))
+    local selected = find_hunk_line(bufnr, 'add', '+insert beta')
+    local callback = assert(keymap_callback(bufnr, 'dp', 'x'))
+
+    set_visual_range(bufnr, selected.lnum, selected.lnum)
+    callback()
+
+    local cached = git_text(
+      repo_root,
+      { 'diff', '--cached', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' }
+    )
+
+    assert.is_true(cached:find('+insert beta', 1, true) ~= nil)
+    assert.is_nil(cached:find('+insert alpha', 1, true))
+    assert.is_nil(buffer_text(bufnr):find('+insert beta', 1, true))
+    assert.is_true(buffer_text(bufnr):find('+insert alpha', 1, true) ~= nil)
+  end)
+
+  it('stages only selected deleted lines from a visual range', function()
+    local repo_root = create_repo()
+    write_repo_file(repo_root, file_lines_without(3, 2))
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.index_to_worktree('file.txt'))
+    local selected = find_hunk_line(bufnr, 'delete', '-line 4')
+
+    assert.is_true(actions.put_range(bufnr, selected.lnum, selected.lnum))
+
+    local cached = git_text(
+      repo_root,
+      { 'diff', '--cached', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' }
+    )
+    local worktree =
+      git_text(repo_root, { 'diff', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' })
+
+    assert.is_true(cached:find('-line 4', 1, true) ~= nil)
+    assert.is_nil(cached:find('-line 3', 1, true))
+    assert.is_true(worktree:find('-line 3', 1, true) ~= nil)
+    assert.is_nil(worktree:find('-line 4', 1, true))
+  end)
+
   it('unstages only the current staged hunk and refreshes the buffer', function()
     local repo_root = create_repo()
     write_repo_file(repo_root, file_lines({ [2] = 'line 2 changed' }))
@@ -214,6 +430,139 @@ describe('diffs.actions', function()
     assert.is_true(worktree:find('+line 2 changed', 1, true) ~= nil)
     assert.is_true(worktree:find('+line 22 changed', 1, true) ~= nil)
     assert.are.equal(0, #vim.api.nvim_buf_get_var(bufnr, 'diffs_hunks'))
+  end)
+
+  it('unstages only selected added lines from a visual range', function()
+    local repo_root = create_repo()
+    write_repo_file(
+      repo_root,
+      file_lines_with_insertions(2, {
+        'insert alpha',
+        'insert beta',
+      })
+    )
+    git_cmd(repo_root, { 'add', 'file.txt' })
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.head_to_index('file.txt'))
+    local selected = find_hunk_line(bufnr, 'add', '+insert beta')
+
+    assert.is_true(actions.obtain_range(bufnr, selected.lnum, selected.lnum))
+
+    local cached = git_text(
+      repo_root,
+      { 'diff', '--cached', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' }
+    )
+    local worktree =
+      git_text(repo_root, { 'diff', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' })
+
+    assert.is_true(cached:find('+insert alpha', 1, true) ~= nil)
+    assert.is_nil(cached:find('+insert beta', 1, true))
+    assert.is_true(worktree:find('+insert beta', 1, true) ~= nil)
+    assert.is_nil(worktree:find('+insert alpha', 1, true))
+  end)
+
+  it('unstages a visual selection through the buffer-local do map and refreshes', function()
+    local repo_root = create_repo()
+    write_repo_file(
+      repo_root,
+      file_lines_with_insertions(2, {
+        'insert alpha',
+        'insert beta',
+      })
+    )
+    git_cmd(repo_root, { 'add', 'file.txt' })
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.head_to_index('file.txt'))
+    local selected = find_hunk_line(bufnr, 'add', '+insert beta')
+    local callback = assert(keymap_callback(bufnr, 'do', 'x'))
+
+    set_visual_range(bufnr, selected.lnum, selected.lnum)
+    callback()
+
+    local cached = git_text(
+      repo_root,
+      { 'diff', '--cached', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' }
+    )
+
+    assert.is_true(cached:find('+insert alpha', 1, true) ~= nil)
+    assert.is_nil(cached:find('+insert beta', 1, true))
+    assert.is_nil(buffer_text(bufnr):find('+insert beta', 1, true))
+    assert.is_true(buffer_text(bufnr):find('+insert alpha', 1, true) ~= nil)
+  end)
+
+  it('unstages only selected deleted lines from a visual range', function()
+    local repo_root = create_repo()
+    write_repo_file(repo_root, file_lines_without(3, 2))
+    git_cmd(repo_root, { 'add', 'file.txt' })
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.head_to_index('file.txt'))
+    local selected = find_hunk_line(bufnr, 'delete', '-line 4')
+
+    assert.is_true(actions.obtain_range(bufnr, selected.lnum, selected.lnum))
+
+    local cached = git_text(
+      repo_root,
+      { 'diff', '--cached', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' }
+    )
+    local worktree =
+      git_text(repo_root, { 'diff', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' })
+
+    assert.is_true(cached:find('-line 3', 1, true) ~= nil)
+    assert.is_nil(cached:find('-line 4', 1, true))
+    assert.is_true(worktree:find('-line 4', 1, true) ~= nil)
+    assert.is_nil(worktree:find('-line 3', 1, true))
+  end)
+
+  it('rejects visual ranges that cross Gdiff hunks without touching the index', function()
+    local notifications = capture_notifications()
+    local repo_root = create_repo()
+    write_repo_file(
+      repo_root,
+      file_lines({
+        [2] = 'line 2 changed',
+        [22] = 'line 22 changed',
+      })
+    )
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.index_to_worktree('file.txt'))
+    local hunks = find_hunks(bufnr)
+
+    assert.is_false(
+      actions.put_range(bufnr, hunks[1].buffer_range.finish, hunks[2].buffer_range.start)
+    )
+
+    local cached = git_text(
+      repo_root,
+      { 'diff', '--cached', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' }
+    )
+    assert.are.equal('', cached)
+    assert.is_true(
+      notifications[#notifications].message:find(
+        'visual selection must stay within one Gdiff hunk',
+        1,
+        true
+      ) ~= nil
+    )
+  end)
+
+  it('rejects partial replacement visual ranges without touching the index', function()
+    local notifications = capture_notifications()
+    local repo_root = create_repo()
+    write_repo_file(repo_root, file_lines({ [2] = 'line 2 changed' }))
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.index_to_worktree('file.txt'))
+    local selected = find_hunk_line(bufnr, 'add', '+line 2 changed')
+
+    assert.is_false(actions.put_range(bufnr, selected.lnum, selected.lnum))
+
+    local cached = git_text(
+      repo_root,
+      { 'diff', '--cached', '--no-ext-diff', '--no-color', '-U0', '--', 'file.txt' }
+    )
+    assert.are.equal('', cached)
+    assert.is_true(
+      notifications[#notifications].message:find('complete replacement group', 1, true) ~= nil
+    )
   end)
 
   it('leaves the index untouched when the apply check fails', function()

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -47,8 +47,8 @@ function M.get_extmarks(bufnr, ns)
   return vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
 end
 
-function M.has_keymap(bufnr, lhs)
-  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, 'n')) do
+function M.has_keymap(bufnr, lhs, mode)
+  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, mode or 'n')) do
     if keymap.lhs == lhs then
       return true
     end

--- a/spec/ux_spec.lua
+++ b/spec/ux_spec.lua
@@ -36,8 +36,8 @@ local function add_hunk_metadata(bufnr)
   vim.api.nvim_buf_set_var(bufnr, 'diffs_repo_root', '/tmp/repo')
 end
 
-local function keymap_desc(bufnr, lhs)
-  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, 'n')) do
+local function keymap_desc(bufnr, lhs, mode)
+  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, mode or 'n')) do
     if keymap.lhs == lhs then
       return keymap.desc
     end
@@ -124,6 +124,8 @@ describe('ux', function()
       assert.is_false(helpers.has_keymap(bufnr, 'o'))
       assert.is_false(helpers.has_keymap(bufnr, 'do'))
       assert.is_false(helpers.has_keymap(bufnr, 'dp'))
+      assert.is_false(helpers.has_keymap(bufnr, 'do', 'x'))
+      assert.is_false(helpers.has_keymap(bufnr, 'dp', 'x'))
 
       add_hunk_metadata(bufnr)
       commands.setup_diff_buf(bufnr)
@@ -134,6 +136,8 @@ describe('ux', function()
       assert.is_true(helpers.has_keymap(bufnr, 'o'))
       assert.is_true(helpers.has_keymap(bufnr, 'do'))
       assert.is_true(helpers.has_keymap(bufnr, 'dp'))
+      assert.is_true(helpers.has_keymap(bufnr, 'do', 'x'))
+      assert.is_true(helpers.has_keymap(bufnr, 'dp', 'x'))
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
@@ -144,6 +148,8 @@ describe('ux', function()
       vim.keymap.set('n', ']c', '<Nop>', { buffer = bufnr, desc = 'user next' })
       vim.keymap.set('n', 'do', '<Nop>', { buffer = bufnr, desc = 'user obtain' })
       vim.keymap.set('n', 'dp', '<Nop>', { buffer = bufnr, desc = 'user put' })
+      vim.keymap.set('x', 'do', '<Nop>', { buffer = bufnr, desc = 'user visual obtain' })
+      vim.keymap.set('x', 'dp', '<Nop>', { buffer = bufnr, desc = 'user visual put' })
 
       commands.setup_diff_buf(bufnr)
 
@@ -151,6 +157,8 @@ describe('ux', function()
       assert.are.equal('user next', keymap_desc(bufnr, ']c'))
       assert.are.equal('user obtain', keymap_desc(bufnr, 'do'))
       assert.are.equal('user put', keymap_desc(bufnr, 'dp'))
+      assert.are.equal('user visual obtain', keymap_desc(bufnr, 'do', 'x'))
+      assert.are.equal('user visual put', keymap_desc(bufnr, 'dp', 'x'))
       assert.are.equal('Open source file', keymap_desc(bufnr, '<CR>'))
       assert.are.equal('Previous diff hunk', keymap_desc(bufnr, '[c'))
       vim.api.nvim_buf_delete(bufnr, { force = true })
@@ -160,20 +168,25 @@ describe('ux', function()
       local bufnr = create_diffs_buffer()
       add_hunk_metadata(bufnr)
       vim.keymap.set('n', 'o', '<Nop>', { buffer = bufnr, desc = 'user open' })
+      vim.keymap.set('x', 'do', '<Nop>', { buffer = bufnr, desc = 'user visual obtain' })
       commands.setup_diff_buf(bufnr)
 
       assert.are.equal('user open', keymap_desc(bufnr, 'o'))
+      assert.are.equal('user visual obtain', keymap_desc(bufnr, 'do', 'x'))
       assert.are.equal('Open source file', keymap_desc(bufnr, '<CR>'))
+      assert.are.equal('Stage selected Gdiff lines', keymap_desc(bufnr, 'dp', 'x'))
 
       vim.api.nvim_buf_del_var(bufnr, 'diffs_hunks')
       commands.setup_diff_buf(bufnr)
 
       assert.are.equal('user open', keymap_desc(bufnr, 'o'))
+      assert.are.equal('user visual obtain', keymap_desc(bufnr, 'do', 'x'))
       assert.is_nil(keymap_desc(bufnr, '<CR>'))
       assert.is_nil(keymap_desc(bufnr, ']c'))
       assert.is_nil(keymap_desc(bufnr, '[c'))
       assert.is_nil(keymap_desc(bufnr, 'do'))
       assert.is_nil(keymap_desc(bufnr, 'dp'))
+      assert.is_nil(keymap_desc(bufnr, 'dp', 'x'))
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
   end)


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #237.

## Solution

The solution adds Visual-mode `do`/`dp` for hunk-aware `diffs://` buffers without replacing existing user maps; stage or unstage selected changed lines with operation-specific partial patches and `git apply --recount`; and rejects cross-hunk selections, no-change selections, and partial replacement groups before mutating the index.
