### PR TITLE
fix: harden Gdiff edge cases

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -432,6 +432,40 @@ COMMANDS                                                 *diffs.nvim-commands*
         :Gdiff :0:%     " diff against the index explicitly
         :Gdiff abc123   " diff against specific commit
 <
+    Edge-case behavior: ~
+
+    Case              Endpoint model              Behavior ~
+    Untracked file    index -> working tree       Renders as a new file.
+                                                 `dp` stages the file.
+    Added file        HEAD -> index               Renders as a new file.
+                                                 `do` unstages the file.
+    Deleted file      index -> working tree or    Renders as a deleted
+                      HEAD -> index               file. `dp` stages an
+                                                 unstaged deletion; `do`
+                                                 unstages a staged deletion.
+    Both staged and   one view per edge           Plain |:Gdiff| shows
+    unstaged changes                              index -> working tree.
+                                                 Staged status rows show
+                                                 HEAD -> index.
+    Rename or copy    requires old and new paths  Not supported by the
+                                                 same-path DiffSpec model.
+                                                 Status-row views may render
+                                                 content-only old/new diffs,
+                                                 but hunk actions are disabled.
+    Mode-only change  no text hunk                Not supported. Shows an
+                                                 explicit warning.
+    Binary file       no text hunk                Not supported. Shows an
+                                                 explicit warning.
+    Submodule         gitlink, not file content   Not supported. Shows an
+                                                 explicit warning.
+    Merge stages      :1:/:2:/:3:                 Not supported by |:Gdiff|
+                                                 object parsing yet. Use the
+                                                 unmerged status-row action.
+
+    Supported hunk actions run `git apply --cached --check` before mutating
+    the index. Stale hunks, context drift, and index mismatches fail without
+    applying a partial mutation.
+
 
 :Gvdiff [object]                                                     *:Gvdiff*
     Like |:Gdiff| but opens in a vertical split.

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -387,9 +387,15 @@ function M.gdiff_file(filepath, opts)
     return
   end
 
+  local repo_root = git.get_repo_root(filepath)
+  if not repo_root then
+    vim.notify('[diffs.nvim]: not in a git repository', vim.log.levels.ERROR)
+    return
+  end
+
   local old_rel_path = opts.old_filepath and git.get_relative_path(opts.old_filepath) or rel_path
 
-  local old_lines, new_lines, err
+  local old_lines, new_lines, err, diff_lines
   local diff_label
   local diff_spec
 
@@ -404,56 +410,44 @@ function M.gdiff_file(filepath, opts)
     end
     diff_label = 'unmerged'
   elseif opts.untracked then
-    old_lines = {}
-    new_lines, err = git.get_working_content(filepath)
-    if not new_lines then
-      vim.notify('[diffs.nvim]: ' .. (err or 'cannot read file'), vim.log.levels.ERROR)
-      return
-    end
+    diff_spec = diffspec.index_to_worktree(rel_path)
     diff_label = 'untracked'
+    diff_lines, err = render.file(diff_spec, repo_root)
   elseif opts.staged then
-    old_lines, err = git.get_file_content('HEAD', opts.old_filepath or filepath)
-    if not old_lines then
-      old_lines = {}
-    end
-    new_lines, err = git.get_index_content(filepath)
-    if not new_lines then
-      new_lines = {}
-    end
     diff_label = 'staged'
     if old_rel_path == rel_path then
       diff_spec = diffspec.head_to_index(rel_path)
+      diff_lines, err = render.file(diff_spec, repo_root)
+    else
+      old_lines = git.get_file_content('HEAD', opts.old_filepath or filepath) or {}
+      new_lines = git.get_index_content(filepath) or {}
     end
   else
-    old_lines, err = git.get_index_content(opts.old_filepath or filepath)
-    if not old_lines then
-      old_lines, err = git.get_file_content('HEAD', opts.old_filepath or filepath)
-      if not old_lines then
-        old_lines = {}
-        diff_label = 'untracked'
-      else
-        diff_label = 'unstaged'
-      end
+    diff_label = 'unstaged'
+    if old_rel_path == rel_path then
+      diff_spec = diffspec.index_to_worktree(rel_path)
+      diff_lines, err = render.file(diff_spec, repo_root)
     else
-      diff_label = 'unstaged'
-      if old_rel_path == rel_path then
-        diff_spec = diffspec.index_to_worktree(rel_path)
+      old_lines = git.get_index_content(opts.old_filepath or filepath)
+      if not old_lines then
+        old_lines = git.get_file_content('HEAD', opts.old_filepath or filepath) or {}
       end
-    end
-    new_lines, err = git.get_working_content(filepath)
-    if not new_lines then
-      new_lines = {}
+      new_lines = git.get_working_content(filepath) or {}
     end
   end
 
-  local diff_lines = render.unified_lines(old_lines, new_lines, old_rel_path, rel_path)
+  if not diff_lines then
+    if err then
+      vim.notify('[diffs.nvim]: ' .. err, vim.log.levels.ERROR)
+      return
+    end
+    diff_lines = render.unified_lines(old_lines or {}, new_lines or {}, old_rel_path, rel_path)
+  end
 
   if #diff_lines == 0 then
     vim.notify('[diffs.nvim]: no changes', vim.log.levels.INFO)
     return
   end
-
-  local repo_root = git.get_repo_root(filepath)
 
   local diff_buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(diff_buf, 0, -1, false, diff_lines)

--- a/lua/diffs/fugitive.lua
+++ b/lua/diffs/fugitive.lua
@@ -74,9 +74,9 @@ end
 ---@param line string
 ---@return string?, string?, string?
 local function parse_file_line(line)
-  local old, new = line:match('^R%d*%s+(.-)%s+->%s+(.+)$')
+  local rename_status, old, new = line:match('^([RC])%d*%s+(.-)%s+->%s+(.+)$')
   if old and new then
-    return unquote(vim.trim(new)), unquote(vim.trim(old)), 'R'
+    return unquote(vim.trim(new)), unquote(vim.trim(old)), rename_status
   end
 
   local status, filename = line:match('^([MADRCU?])[MADRCU%s]*%s+(.+)$')
@@ -206,7 +206,10 @@ function M.diff_file_under_cursor(vertical)
   if is_header then
     dbg('diff_section: %s', section or 'unknown')
     if section == 'untracked' then
-      vim.notify('[diffs.nvim]: cannot diff untracked section', vim.log.levels.WARN)
+      vim.notify(
+        '[diffs.nvim]: cannot diff untracked section; open an untracked file line instead',
+        vim.log.levels.WARN
+      )
       return
     end
     commands.gdiff_section(repo_root, {

--- a/lua/diffs/git.lua
+++ b/lua/diffs/git.lua
@@ -2,6 +2,10 @@ local M = {}
 
 local repo_root_cache = {}
 
+local function is_index_stage(revision)
+  return type(revision) == 'string' and revision:match('^:%d$') ~= nil
+end
+
 ---@param filepath? string
 ---@return string?
 function M.get_repo_root(filepath)
@@ -17,6 +21,16 @@ function M.get_repo_root(filepath)
   return result[1]
 end
 
+---@param repo_root string
+---@param filepath string
+---@return string?
+local function relative_path(repo_root, filepath)
+  if vim.startswith(filepath, repo_root) then
+    return filepath:sub(#repo_root + 2)
+  end
+  return vim.fn.fnamemodify(filepath, ':.')
+end
+
 ---@param revision string
 ---@param filepath string
 ---@return string[]?, string?
@@ -26,14 +40,19 @@ function M.get_file_content(revision, filepath)
     return nil, 'not in a git repository'
   end
 
-  local rel_path = vim.fn.fnamemodify(filepath, ':.')
-  if vim.startswith(filepath, repo_root) then
-    rel_path = filepath:sub(#repo_root + 2)
+  local rel_path = relative_path(repo_root, filepath)
+
+  if not is_index_stage(revision) then
+    vim.fn.system({ 'git', '-C', repo_root, 'rev-parse', '--verify', revision .. '^{tree}' })
+    if vim.v.shell_error ~= 0 then
+      return nil, 'failed to resolve revision: ' .. revision
+    end
   end
 
-  local result = vim.fn.systemlist({ 'git', '-C', repo_root, 'show', revision .. ':' .. rel_path })
+  local result =
+    vim.fn.systemlist({ 'git', '-C', repo_root, 'show', revision .. ':' .. rel_path }, nil, true)
   if vim.v.shell_error ~= 0 then
-    return nil, 'failed to get file at revision: ' .. revision
+    return nil, 'file not in revision: ' .. revision
   end
   return result, nil
 end
@@ -45,10 +64,7 @@ function M.get_relative_path(filepath)
   if not repo_root then
     return nil
   end
-  if vim.startswith(filepath, repo_root) then
-    return filepath:sub(#repo_root + 2)
-  end
-  return vim.fn.fnamemodify(filepath, ':.')
+  return relative_path(repo_root, filepath)
 end
 
 ---@param filepath string
@@ -64,7 +80,7 @@ function M.get_index_content(filepath)
     return nil, 'could not determine relative path'
   end
 
-  local result = vim.fn.systemlist({ 'git', '-C', repo_root, 'show', ':0:' .. rel_path })
+  local result = vim.fn.systemlist({ 'git', '-C', repo_root, 'show', ':0:' .. rel_path }, nil, true)
   if vim.v.shell_error ~= 0 then
     return nil, 'file not in index'
   end
@@ -77,8 +93,68 @@ function M.get_working_content(filepath)
   if vim.fn.filereadable(filepath) ~= 1 then
     return nil, 'file not readable'
   end
-  local lines = vim.fn.readfile(filepath)
+  local lines = vim.fn.readfile(filepath, 'b')
   return lines, nil
+end
+
+---@param filepath string
+---@return string?
+function M.get_index_mode(filepath)
+  local repo_root = M.get_repo_root(filepath)
+  if not repo_root then
+    return nil
+  end
+
+  local rel_path = M.get_relative_path(filepath)
+  if not rel_path then
+    return nil
+  end
+
+  local result =
+    vim.fn.systemlist({ 'git', '-C', repo_root, 'ls-files', '--stage', '--', rel_path })
+  if vim.v.shell_error ~= 0 or #result == 0 then
+    return nil
+  end
+  return result[1]:match('^(%d+)')
+end
+
+---@param revision string
+---@param filepath string
+---@return string?
+function M.get_tree_mode(revision, filepath)
+  if is_index_stage(revision) then
+    return nil
+  end
+
+  local repo_root = M.get_repo_root(filepath)
+  if not repo_root then
+    return nil
+  end
+
+  local rel_path = M.get_relative_path(filepath)
+  if not rel_path then
+    return nil
+  end
+
+  local result = vim.fn.systemlist({ 'git', '-C', repo_root, 'ls-tree', revision, '--', rel_path })
+  if vim.v.shell_error ~= 0 or #result == 0 then
+    return nil
+  end
+  return result[1]:match('^(%d+)')
+end
+
+---@param filepath string
+---@return string?
+function M.get_working_mode(filepath)
+  if vim.fn.filereadable(filepath) ~= 1 then
+    return nil
+  end
+
+  local perm = vim.fn.getfperm(filepath)
+  if perm:sub(3, 3) == 'x' then
+    return '100755'
+  end
+  return '100644'
 end
 
 ---@param filepath string
@@ -94,8 +170,9 @@ function M.file_exists_in_index(filepath)
     return false
   end
 
-  vim.fn.system({ 'git', '-C', repo_root, 'ls-files', '--stage', '--', rel_path })
-  return vim.v.shell_error == 0
+  local result =
+    vim.fn.systemlist({ 'git', '-C', repo_root, 'ls-files', '--stage', '--', rel_path })
+  return vim.v.shell_error == 0 and #result > 0
 end
 
 ---@param revision string

--- a/lua/diffs/render.lua
+++ b/lua/diffs/render.lua
@@ -9,12 +9,42 @@ local git = require('diffs.git')
 ---@field old_path? string
 ---@field new_path? string
 
+---@class diffs.UnifiedLinesOpts
+---@field old_missing? boolean
+---@field new_missing? boolean
+---@field new_mode? string
+---@field deleted_mode? string
+
+local missing_errors = {
+  ['file not in index'] = true,
+  ['file not readable'] = true,
+}
+
+---@param err string?
+---@return boolean
+local function is_missing_error(err)
+  return err ~= nil and (missing_errors[err] or err:match('^file not in revision: ') ~= nil)
+end
+
+---@param lines string[]?
+---@return boolean
+function M.has_binary_lines(lines)
+  for _, line in ipairs(lines or {}) do
+    if line:find('\0', 1, true) then
+      return true
+    end
+  end
+  return false
+end
+
 ---@param old_lines string[]
 ---@param new_lines string[]
 ---@param old_name string
 ---@param new_name string
+---@param opts? diffs.UnifiedLinesOpts
 ---@return string[]
-function M.unified_lines(old_lines, new_lines, old_name, new_name)
+function M.unified_lines(old_lines, new_lines, old_name, new_name, opts)
+  opts = opts or {}
   local old_content = table.concat(old_lines, '\n')
   local new_content = table.concat(new_lines, '\n')
 
@@ -32,9 +62,24 @@ function M.unified_lines(old_lines, new_lines, old_name, new_name)
 
   local result = {
     'diff --git a/' .. old_name .. ' b/' .. new_name,
-    '--- a/' .. old_name,
-    '+++ b/' .. new_name,
   }
+
+  if opts.old_missing then
+    result[#result + 1] = 'new file mode ' .. (opts.new_mode or '100644')
+    result[#result + 1] = '--- /dev/null'
+  else
+    result[#result + 1] = '--- a/' .. old_name
+  end
+
+  if opts.new_missing then
+    if not opts.old_missing then
+      table.insert(result, 2, 'deleted file mode ' .. (opts.deleted_mode or '100644'))
+    end
+    result[#result + 1] = '+++ /dev/null'
+  else
+    result[#result + 1] = '+++ b/' .. new_name
+  end
+
   for _, line in ipairs(diff_lines) do
     table.insert(result, line)
   end
@@ -51,8 +96,29 @@ end
 
 ---@param endpoint diffs.Endpoint
 ---@param filepath string
+---@return string?
+local function file_mode(endpoint, filepath)
+  endpoint = diffspec.endpoint(endpoint)
+
+  if endpoint.kind == diffspec.endpoint_kind.tree then
+    return git.get_tree_mode(endpoint.rev, filepath)
+  end
+
+  if endpoint.kind == diffspec.endpoint_kind.index then
+    return git.get_index_mode(filepath)
+  end
+
+  if endpoint.kind == diffspec.endpoint_kind.worktree then
+    return git.get_working_mode(filepath)
+  end
+
+  return nil
+end
+
+---@param endpoint diffs.Endpoint
+---@param filepath string
 ---@param opts? diffs.RenderFileOpts
----@return string[]?, string?
+---@return string[]?, string?, boolean
 function M.read_endpoint(endpoint, filepath, opts)
   endpoint = diffspec.endpoint(endpoint)
   opts = opts or {}
@@ -68,14 +134,124 @@ function M.read_endpoint(endpoint, filepath, opts)
       lines, err = git.get_working_content(filepath)
     end
   else
-    return nil, 'unsupported endpoint: ' .. tostring(endpoint.kind)
+    return nil, 'unsupported endpoint: ' .. tostring(endpoint.kind), false
   end
 
-  if not lines and opts.empty_on_missing then
-    return {}, nil
+  if not lines and opts.empty_on_missing and is_missing_error(err) then
+    return {}, nil, true
   end
 
-  return lines, err
+  return lines, err, false
+end
+
+---@param diff_spec diffs.DiffSpec
+---@param repo_root string
+---@param args string[]
+---@return string[]?
+local function build_git_diff_cmd(diff_spec, repo_root, args)
+  local cmd = { 'git', '-C', repo_root, 'diff', '--no-ext-diff', '--no-color' }
+  for _, arg in ipairs(args) do
+    table.insert(cmd, arg)
+  end
+
+  local left = diff_spec.left
+  local right = diff_spec.right
+
+  if
+    left.kind == diffspec.endpoint_kind.index and right.kind == diffspec.endpoint_kind.worktree
+  then
+    return cmd
+  end
+
+  if left.kind == diffspec.endpoint_kind.tree and right.kind == diffspec.endpoint_kind.index then
+    table.insert(cmd, '--cached')
+    table.insert(cmd, left.rev)
+    return cmd
+  end
+
+  if left.kind == diffspec.endpoint_kind.tree and right.kind == diffspec.endpoint_kind.worktree then
+    table.insert(cmd, left.rev)
+    return cmd
+  end
+
+  if left.kind == diffspec.endpoint_kind.tree and right.kind == diffspec.endpoint_kind.tree then
+    table.insert(cmd, left.rev)
+    table.insert(cmd, right.rev)
+    return cmd
+  end
+
+  return nil
+end
+
+---@param diff_spec diffs.DiffSpec
+---@param repo_root string
+---@param path string
+---@param flag string
+---@return string[]
+local function git_diff_lines(diff_spec, repo_root, path, flag)
+  local cmd = build_git_diff_cmd(diff_spec, repo_root, { flag })
+  if not cmd then
+    return {}
+  end
+
+  table.insert(cmd, '--')
+  table.insert(cmd, path)
+  local result = vim.fn.systemlist(cmd)
+  if vim.v.shell_error ~= 0 then
+    return {}
+  end
+  return result
+end
+
+---@param diff_spec diffs.DiffSpec
+---@param repo_root string
+---@param path string
+---@return boolean
+local function has_raw_changes(diff_spec, repo_root, path)
+  return #git_diff_lines(diff_spec, repo_root, path, '--raw') > 0
+end
+
+---@param diff_spec diffs.DiffSpec
+---@param repo_root string
+---@param path string
+---@return boolean
+local function has_binary_changes(diff_spec, repo_root, path)
+  for _, line in ipairs(git_diff_lines(diff_spec, repo_root, path, '--numstat')) do
+    if line:match('^%-%s+%-%s+') then
+      return true
+    end
+  end
+  return false
+end
+
+---@param diff_spec diffs.DiffSpec
+---@param repo_root string
+---@param path string
+---@return boolean
+local function has_renamed_or_copied_path(diff_spec, repo_root, path)
+  local cmd = build_git_diff_cmd(diff_spec, repo_root, { '--name-status', '-M', '-C' })
+  if not cmd then
+    return false
+  end
+
+  local result = vim.fn.systemlist(cmd)
+  if vim.v.shell_error ~= 0 then
+    return false
+  end
+
+  for _, line in ipairs(result) do
+    local status = line:match('^([RC]%d*)%s')
+    if status then
+      local fields = vim.split(line, '\t', { plain = true })
+      for i = 2, #fields do
+        if fields[i] == path then
+          return true
+        end
+      end
+    end
+  end
+
+  return false
 end
 
 ---@param diff_spec diffs.DiffSpec
@@ -93,18 +269,54 @@ function M.file(diff_spec, repo_root, opts)
   local path = diff_spec.scope.path
   local old_path = opts.old_path or path
   local new_path = opts.new_path or path
+  local old_filepath = abs_path(repo_root, old_path)
+  local new_filepath = abs_path(repo_root, new_path)
 
-  local old_lines, old_err = M.read_endpoint(diff_spec.left, abs_path(repo_root, old_path), opts)
+  local old_mode = file_mode(diff_spec.left, old_filepath)
+  local new_mode = file_mode(diff_spec.right, new_filepath)
+  if old_mode == '160000' or new_mode == '160000' then
+    return nil, 'Gdiff does not support submodule changes'
+  end
+
+  if has_renamed_or_copied_path(diff_spec, repo_root, path) then
+    return nil, 'Gdiff does not support rename or copy changes'
+  end
+
+  if has_binary_changes(diff_spec, repo_root, path) then
+    return nil, 'Gdiff does not support binary files'
+  end
+
+  local old_lines, old_err, old_missing = M.read_endpoint(diff_spec.left, old_filepath, {
+    worktree_lines = opts.worktree_lines,
+    empty_on_missing = true,
+  })
   if not old_lines then
     return nil, old_err or 'could not read left endpoint'
   end
 
-  local new_lines, new_err = M.read_endpoint(diff_spec.right, abs_path(repo_root, new_path), opts)
+  local new_lines, new_err, new_missing = M.read_endpoint(diff_spec.right, new_filepath, {
+    worktree_lines = opts.worktree_lines,
+    empty_on_missing = true,
+  })
   if not new_lines then
     return nil, new_err or 'could not read right endpoint'
   end
 
-  return M.unified_lines(old_lines, new_lines, old_path, new_path), nil
+  if M.has_binary_lines(old_lines) or M.has_binary_lines(new_lines) then
+    return nil, 'Gdiff does not support binary files'
+  end
+
+  local diff_lines = M.unified_lines(old_lines, new_lines, old_path, new_path, {
+    old_missing = old_missing,
+    new_missing = new_missing,
+    new_mode = new_mode,
+    deleted_mode = old_mode,
+  })
+  if #diff_lines == 0 and has_raw_changes(diff_spec, repo_root, path) then
+    return nil, 'Gdiff does not support mode-only changes'
+  end
+
+  return diff_lines, nil
 end
 
 return M

--- a/spec/actions_spec.lua
+++ b/spec/actions_spec.lua
@@ -323,6 +323,25 @@ describe('diffs.actions', function()
     assert.is_true(buffer_text(bufnr):find('+line 22 changed', 1, true) ~= nil)
   end)
 
+  it('stages an untracked file hunk as a new file', function()
+    local repo_root = create_repo()
+    vim.fn.writefile({ 'new file line' }, repo_root .. '/new.txt')
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.index_to_worktree('new.txt'))
+    move_to_hunk(bufnr, 1)
+
+    assert.is_true(actions.put_hunk(bufnr))
+
+    local cached =
+      git_text(repo_root, { 'diff', '--cached', '--no-ext-diff', '--no-color', '--', 'new.txt' })
+    local worktree = git_text(repo_root, { 'diff', '--no-ext-diff', '--no-color', '--', 'new.txt' })
+
+    assert.is_true(cached:find('new file mode 100644', 1, true) ~= nil)
+    assert.is_true(cached:find('--- /dev/null', 1, true) ~= nil)
+    assert.is_true(cached:find('+new file line', 1, true) ~= nil)
+    assert.are.equal('', worktree)
+  end)
+
   it('stages only selected added lines from a visual range', function()
     local repo_root = create_repo()
     write_repo_file(
@@ -430,6 +449,65 @@ describe('diffs.actions', function()
     assert.is_true(worktree:find('+line 2 changed', 1, true) ~= nil)
     assert.is_true(worktree:find('+line 22 changed', 1, true) ~= nil)
     assert.are.equal(0, #vim.api.nvim_buf_get_var(bufnr, 'diffs_hunks'))
+  end)
+
+  it('unstages a staged added-file hunk back to an untracked file', function()
+    local repo_root = create_repo()
+    vim.fn.writefile({ 'new file line' }, repo_root .. '/new.txt')
+    git_cmd(repo_root, { 'add', 'new.txt' })
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.head_to_index('new.txt'))
+    move_to_hunk(bufnr, 1)
+
+    assert.is_true(actions.obtain_hunk(bufnr))
+
+    local cached =
+      git_text(repo_root, { 'diff', '--cached', '--no-ext-diff', '--no-color', '--', 'new.txt' })
+    vim.fn.systemlist({ 'git', '-C', repo_root, 'ls-files', '--error-unmatch', 'new.txt' })
+
+    assert.are.equal('', cached)
+    assert.is_not.equal(0, vim.v.shell_error)
+  end)
+
+  it('stages an unstaged deletion hunk', function()
+    local repo_root = create_repo()
+    vim.fn.delete(repo_root .. '/file.txt')
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.index_to_worktree('file.txt'))
+    move_to_hunk(bufnr, 1)
+
+    assert.is_true(actions.put_hunk(bufnr))
+
+    local cached =
+      git_text(repo_root, { 'diff', '--cached', '--no-ext-diff', '--no-color', '--', 'file.txt' })
+    local worktree =
+      git_text(repo_root, { 'diff', '--no-ext-diff', '--no-color', '--', 'file.txt' })
+
+    assert.is_true(cached:find('deleted file mode 100644', 1, true) ~= nil)
+    assert.is_true(cached:find('+++ /dev/null', 1, true) ~= nil)
+    assert.is_true(cached:find('-line 1', 1, true) ~= nil)
+    assert.are.equal('', worktree)
+  end)
+
+  it('unstages a staged deletion hunk back to an unstaged deletion', function()
+    local repo_root = create_repo()
+    vim.fn.delete(repo_root .. '/file.txt')
+    git_cmd(repo_root, { 'add', '-u', 'file.txt' })
+
+    local bufnr = create_diff_buffer(repo_root, diffspec.head_to_index('file.txt'))
+    move_to_hunk(bufnr, 1)
+
+    assert.is_true(actions.obtain_hunk(bufnr))
+
+    local cached =
+      git_text(repo_root, { 'diff', '--cached', '--no-ext-diff', '--no-color', '--', 'file.txt' })
+    local worktree =
+      git_text(repo_root, { 'diff', '--no-ext-diff', '--no-color', '--', 'file.txt' })
+
+    assert.are.equal('', cached)
+    assert.is_true(worktree:find('deleted file mode 100644', 1, true) ~= nil)
+    assert.is_true(worktree:find('+++ /dev/null', 1, true) ~= nil)
+    assert.is_true(worktree:find('-line 1', 1, true) ~= nil)
   end)
 
   it('unstages only selected added lines from a visual range', function()

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -243,6 +243,47 @@ describe('commands', function()
       assert.is_true(table.concat(lines, '\n'):find('+local x = 1', 1, true) ~= nil)
     end)
 
+    it('opens default :Gdiff for untracked files as index to worktree additions', function()
+      local source_buf = vim.api.nvim_create_buf(false, true)
+      table.insert(test_buffers, source_buf)
+      vim.api.nvim_buf_set_name(source_buf, '/tmp/repo/lua/new.lua')
+      vim.api.nvim_buf_set_lines(source_buf, 0, -1, false, {
+        'local M = {}',
+        'return M',
+      })
+      vim.api.nvim_set_current_buf(source_buf)
+
+      mock_git_method('get_relative_path', function(filepath)
+        assert.are.equal('/tmp/repo/lua/new.lua', filepath)
+        return 'lua/new.lua'
+      end)
+      mock_git_method('get_index_content', function(filepath)
+        assert.are.equal('/tmp/repo/lua/new.lua', filepath)
+        return nil, 'file not in index'
+      end)
+      mock_repo_root(function(filepath)
+        assert.are.equal('/tmp/repo/lua/new.lua', filepath)
+        return '/tmp/repo'
+      end)
+      mock_runtime_attach(function() end)
+
+      commands.gdiff(nil, false)
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+      local lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
+
+      assert.are.equal('diffs://unstaged:lua/new.lua', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.same(
+        diffspec.index_to_worktree('lua/new.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      local text = table.concat(lines, '\n')
+      assert.is_true(text:find('new file mode 100644', 1, true) ~= nil)
+      assert.is_true(text:find('--- /dev/null', 1, true) ~= nil)
+      assert.is_true(text:find('+local M = {}', 1, true) ~= nil)
+    end)
+
     it('preserves the explicit revision generated buffer surface', function()
       local source_buf = vim.api.nvim_create_buf(false, true)
       table.insert(test_buffers, source_buf)
@@ -370,6 +411,121 @@ describe('commands', function()
       assert.are.equal('worktree', diff_hunks[1].mutation_target)
       assert.is_true(helpers.has_keymap(diff_buf, 'do'))
       assert.is_true(helpers.has_keymap(diff_buf, 'dp'))
+    end)
+
+    it('marks fugitive-style untracked file diffs as index to worktree buffers', function()
+      mock_git_method('get_relative_path', function(filepath)
+        if filepath == '/tmp/repo/lua/new.lua' then
+          return 'lua/new.lua'
+        end
+        return nil
+      end)
+      mock_git_method('get_index_content', function(filepath)
+        assert.are.equal('/tmp/repo/lua/new.lua', filepath)
+        return nil, 'file not in index'
+      end)
+      mock_git_method('get_working_content', function(filepath)
+        assert.are.equal('/tmp/repo/lua/new.lua', filepath)
+        return { 'local M = {}', 'return M' }
+      end)
+      mock_repo_root(function(filepath)
+        assert.are.equal('/tmp/repo/lua/new.lua', filepath)
+        return '/tmp/repo'
+      end)
+      mock_runtime_attach(function() end)
+
+      commands.gdiff_file('/tmp/repo/lua/new.lua', { untracked = true })
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+
+      assert.are.equal('diffs://untracked:lua/new.lua', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.same(
+        diffspec.index_to_worktree('lua/new.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      local text = table.concat(vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false), '\n')
+      assert.is_true(text:find('new file mode 100644', 1, true) ~= nil)
+      assert.is_true(text:find('--- /dev/null', 1, true) ~= nil)
+      local diff_hunks = vim.api.nvim_buf_get_var(diff_buf, 'diffs_hunks')
+      assert.are.equal(1, #diff_hunks)
+      assert.are.equal('worktree', diff_hunks[1].mutation_target)
+      assert.is_true(helpers.has_keymap(diff_buf, 'do'))
+      assert.is_true(helpers.has_keymap(diff_buf, 'dp'))
+    end)
+
+    it('marks fugitive-style staged additions as HEAD to index buffers', function()
+      mock_git_method('get_relative_path', function(filepath)
+        if filepath == '/tmp/repo/lua/new.lua' then
+          return 'lua/new.lua'
+        end
+        return nil
+      end)
+      mock_git_method('get_file_content', function(revision, filepath)
+        assert.are.equal('HEAD', revision)
+        assert.are.equal('/tmp/repo/lua/new.lua', filepath)
+        return nil, 'file not in revision: HEAD'
+      end)
+      mock_git_method('get_index_content', function(filepath)
+        assert.are.equal('/tmp/repo/lua/new.lua', filepath)
+        return { 'local M = {}', 'return M' }
+      end)
+      mock_repo_root(function(filepath)
+        assert.are.equal('/tmp/repo/lua/new.lua', filepath)
+        return '/tmp/repo'
+      end)
+      mock_runtime_attach(function() end)
+
+      commands.gdiff_file('/tmp/repo/lua/new.lua', { staged = true })
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+
+      assert.are.equal('diffs://staged:lua/new.lua', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.same(
+        diffspec.head_to_index('lua/new.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      local text = table.concat(vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false), '\n')
+      assert.is_true(text:find('new file mode 100644', 1, true) ~= nil)
+      assert.is_true(text:find('--- /dev/null', 1, true) ~= nil)
+    end)
+
+    it('marks fugitive-style staged deletions as HEAD to index buffers', function()
+      mock_git_method('get_relative_path', function(filepath)
+        if filepath == '/tmp/repo/lua/deleted.lua' then
+          return 'lua/deleted.lua'
+        end
+        return nil
+      end)
+      mock_git_method('get_file_content', function(revision, filepath)
+        assert.are.equal('HEAD', revision)
+        assert.are.equal('/tmp/repo/lua/deleted.lua', filepath)
+        return { 'local M = {}', 'return M' }
+      end)
+      mock_git_method('get_index_content', function(filepath)
+        assert.are.equal('/tmp/repo/lua/deleted.lua', filepath)
+        return nil, 'file not in index'
+      end)
+      mock_repo_root(function(filepath)
+        assert.are.equal('/tmp/repo/lua/deleted.lua', filepath)
+        return '/tmp/repo'
+      end)
+      mock_runtime_attach(function() end)
+
+      commands.gdiff_file('/tmp/repo/lua/deleted.lua', { staged = true })
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+
+      assert.are.equal('diffs://staged:lua/deleted.lua', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.same(
+        diffspec.head_to_index('lua/deleted.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      local text = table.concat(vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false), '\n')
+      assert.is_true(text:find('deleted file mode 100644', 1, true) ~= nil)
+      assert.is_true(text:find('+++ /dev/null', 1, true) ~= nil)
     end)
   end)
 

--- a/spec/fugitive_spec.lua
+++ b/spec/fugitive_spec.lua
@@ -112,6 +112,19 @@ describe('fugitive', function()
       vim.api.nvim_buf_delete(buf, { force = true })
     end)
 
+    it('parses copied file with similarity index and returns both names', function()
+      local buf = create_status_buffer({
+        'Staged (1)',
+        'C100  old.lua -> copy.lua',
+      })
+      local filename, section, _, old_filename, status = fugitive.get_file_at_line(buf, 2)
+      assert.equals('copy.lua', filename)
+      assert.equals('staged', section)
+      assert.equals('old.lua', old_filename)
+      assert.equals('C', status)
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+
     it('returns nil old_filename for non-renames', function()
       local buf = create_status_buffer({
         'Staged (1)',

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -285,6 +285,64 @@ describe('read_buffer', function()
       assert.is_true(helpers.has_keymap(bufnr, 'dp'))
     end)
 
+    it('reloads untracked DiffSpec buffers with empty index content and hunk metadata', function()
+      mock_git({
+        get_index_content = function(filepath)
+          assert.are.equal('/tmp/new.lua', filepath)
+          return nil, 'file not in index'
+        end,
+        get_working_content = function(filepath)
+          assert.are.equal('/tmp/new.lua', filepath)
+          return { 'local M = {}', 'return M' }
+        end,
+      })
+
+      local bufnr = create_diffs_buffer('diffs://untracked:new.lua', {
+        diffs_repo_root = '/tmp',
+        diffs_spec = diffspec.index_to_worktree('new.lua'),
+      })
+      commands.read_buffer(bufnr)
+
+      local text = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), '\n')
+      assert.is_true(text:find('new file mode 100644', 1, true) ~= nil)
+      assert.is_true(text:find('--- /dev/null', 1, true) ~= nil)
+      local diff_hunks = vim.api.nvim_buf_get_var(bufnr, 'diffs_hunks')
+      assert.are.equal(1, #diff_hunks)
+      assert.are.equal('new.lua', diff_hunks[1].file)
+      assert.is_true(diff_hunks[1].actionable)
+    end)
+
+    it(
+      'reloads staged deletion DiffSpec buffers with empty index content and hunk metadata',
+      function()
+        mock_git({
+          get_file_content = function(rev, filepath)
+            assert.are.equal('HEAD', rev)
+            assert.are.equal('/tmp/deleted.lua', filepath)
+            return { 'local M = {}', 'return M' }
+          end,
+          get_index_content = function(filepath)
+            assert.are.equal('/tmp/deleted.lua', filepath)
+            return nil, 'file not in index'
+          end,
+        })
+
+        local bufnr = create_diffs_buffer('diffs://staged:deleted.lua', {
+          diffs_repo_root = '/tmp',
+          diffs_spec = diffspec.head_to_index('deleted.lua'),
+        })
+        commands.read_buffer(bufnr)
+
+        local text = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), '\n')
+        assert.is_true(text:find('deleted file mode 100644', 1, true) ~= nil)
+        assert.is_true(text:find('+++ /dev/null', 1, true) ~= nil)
+        local diff_hunks = vim.api.nvim_buf_get_var(bufnr, 'diffs_hunks')
+        assert.are.equal(1, #diff_hunks)
+        assert.are.equal('deleted.lua', diff_hunks[1].file)
+        assert.are.equal('index', diff_hunks[1].mutation_target)
+      end
+    )
+
     it('prefers diffs_spec metadata for HEAD to index reloads', function()
       local calls = {}
       mock_git({

--- a/spec/render_spec.lua
+++ b/spec/render_spec.lua
@@ -5,6 +5,38 @@ local git = require('diffs.git')
 local render = require('diffs.render')
 
 local saved_git = {}
+local test_repos = {}
+
+local function git_cmd(repo_root, args)
+  local cmd = { 'git', '-C', repo_root }
+  for _, arg in ipairs(args) do
+    cmd[#cmd + 1] = arg
+  end
+  local output = vim.fn.systemlist(cmd)
+  assert.are.equal(0, vim.v.shell_error, table.concat(output, '\n'))
+  return output
+end
+
+local function create_repo()
+  local repo_root = vim.fn.tempname()
+  vim.fn.mkdir(repo_root, 'p')
+  test_repos[#test_repos + 1] = repo_root
+
+  vim.fn.systemlist({ 'git', 'init', '-q', repo_root })
+  assert.are.equal(0, vim.v.shell_error)
+  git_cmd(repo_root, { 'config', 'user.email', 'test@example.com' })
+  git_cmd(repo_root, { 'config', 'user.name', 'Test' })
+  vim.fn.writefile({ 'line 1', 'line 2' }, repo_root .. '/file.txt')
+  git_cmd(repo_root, { 'add', 'file.txt' })
+  git_cmd(repo_root, { 'commit', '-qm', 'initial' })
+
+  return repo_root
+end
+
+local function write_binary_file(path, text)
+  vim.fn.system({ 'sh', '-c', 'printf "$1" > "$2"', 'sh', text, path })
+  assert.are.equal(0, vim.v.shell_error)
+end
 
 local function mock_git_content()
   saved_git.get_file_content = git.get_file_content
@@ -41,6 +73,10 @@ local function restore_mocks()
     git[k] = v
   end
   saved_git = {}
+  for _, repo_root in ipairs(test_repos) do
+    vim.fn.delete(repo_root, 'rf')
+  end
+  test_repos = {}
 end
 
 local function render_text(spec)
@@ -130,5 +166,80 @@ describe('diffs.render', function()
     assert.is_true(text:find('-return "head"', 1, true) ~= nil)
     assert.is_true(text:find('+return "buffer"', 1, true) ~= nil)
     assert.is_false(text:find('return "worktree"', 1, true) ~= nil)
+  end)
+
+  it('renders untracked files as index to worktree additions', function()
+    local repo_root = create_repo()
+    vim.fn.writefile({ 'new file' }, repo_root .. '/new.txt')
+
+    local lines, err = render.file(diffspec.index_to_worktree('new.txt'), repo_root)
+
+    assert.is_nil(err)
+    local text = table.concat(lines, '\n')
+    assert.is_true(text:find('new file mode 100644', 1, true) ~= nil)
+    assert.is_true(text:find('--- /dev/null', 1, true) ~= nil)
+    assert.is_true(text:find('+new file', 1, true) ~= nil)
+  end)
+
+  it('renders staged deletions as HEAD to index deletions', function()
+    local repo_root = create_repo()
+    vim.fn.delete(repo_root .. '/file.txt')
+    git_cmd(repo_root, { 'add', '-u', 'file.txt' })
+
+    local lines, err = render.file(diffspec.head_to_index('file.txt'), repo_root)
+
+    assert.is_nil(err)
+    local text = table.concat(lines, '\n')
+    assert.is_true(text:find('deleted file mode 100644', 1, true) ~= nil)
+    assert.is_true(text:find('+++ /dev/null', 1, true) ~= nil)
+    assert.is_true(text:find('-line 1', 1, true) ~= nil)
+  end)
+
+  it('rejects same-path rename projections before rendering actionable hunks', function()
+    local repo_root = create_repo()
+    git_cmd(repo_root, { 'mv', 'file.txt', 'renamed.txt' })
+
+    local lines, err = render.file(diffspec.head_to_index('renamed.txt'), repo_root)
+
+    assert.is_nil(lines)
+    assert.are.equal('Gdiff does not support rename or copy changes', err)
+  end)
+
+  it('rejects mode-only changes because there are no text hunks to apply', function()
+    local repo_root = create_repo()
+    vim.fn.setfperm(repo_root .. '/file.txt', 'rwxr-xr-x')
+
+    local lines, err = render.file(diffspec.index_to_worktree('file.txt'), repo_root)
+
+    assert.is_nil(lines)
+    assert.are.equal('Gdiff does not support mode-only changes', err)
+  end)
+
+  it('rejects binary files before treating bytes as text hunks', function()
+    local repo_root = create_repo()
+    write_binary_file(repo_root .. '/bin.dat', 'binary\\000old')
+    git_cmd(repo_root, { 'add', 'bin.dat' })
+    git_cmd(repo_root, { 'commit', '-qm', 'binary' })
+    write_binary_file(repo_root .. '/bin.dat', 'binary\\000new')
+
+    local lines, err = render.file(diffspec.index_to_worktree('bin.dat'), repo_root)
+
+    assert.is_nil(lines)
+    assert.are.equal('Gdiff does not support binary files', err)
+  end)
+
+  it('rejects submodule gitlinks before rendering pseudo text hunks', function()
+    local repo_root = create_repo()
+    git_cmd(repo_root, {
+      'update-index',
+      '--add',
+      '--cacheinfo',
+      '160000,0123456789012345678901234567890123456789,submodule',
+    })
+
+    local lines, err = render.file(diffspec.head_to_index('submodule'), repo_root)
+
+    assert.is_nil(lines)
+    assert.are.equal('Gdiff does not support submodule changes', err)
   end)
 end)


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #238.

## Solution

The solution renders missing Git endpoints as explicit add/delete DiffSpec file edges so untracked, added, and deleted files keep hunk metadata and actions; rejects same-path rename/copy projections, mode-only changes, binary files, submodules, and unsupported merge-stage objects with clear behavior; preserves trailing newline state from Git/worktree content so add/delete patches apply cleanly; and documents the edge-case behavior table for `:Gdiff`.
