### PR TITLE
Shorten notification prefix

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -396,7 +396,7 @@ threshold, diffs.nvim skips syntax highlighting for that hunk to avoid lag.
 Context lines (lines with a space prefix) are not counted toward the limit.
 
 A warning is shown when this happens: >
-    [diffs.nvim]: Syntax highlighting skipped for 1 hunk(s) — too large.
+    [diffs]: Syntax highlighting skipped for 1 hunk(s) — too large.
 <
 To increase the threshold: >lua
     vim.g.diffs = {

--- a/lua/diffs/actions.lua
+++ b/lua/diffs/actions.lua
@@ -316,7 +316,7 @@ end
 ---@param message string
 ---@param level integer
 local function notify(message, level)
-  vim.notify('[diffs.nvim]: ' .. message, level)
+  vim.notify('[diffs]: ' .. message, level)
 end
 
 ---@param bufnr integer

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -292,13 +292,13 @@ function M.gdiff(args, vertical)
   local filepath = vim.api.nvim_buf_get_name(bufnr)
 
   if filepath == '' then
-    vim.notify('[diffs.nvim]: cannot diff unnamed buffer', vim.log.levels.ERROR)
+    vim.notify('[diffs]: cannot diff unnamed buffer', vim.log.levels.ERROR)
     return
   end
 
   local rel_path = git.get_relative_path(filepath)
   if not rel_path then
-    vim.notify('[diffs.nvim]: not in a git repository', vim.log.levels.ERROR)
+    vim.notify('[diffs]: not in a git repository', vim.log.levels.ERROR)
     return
   end
 
@@ -307,7 +307,7 @@ function M.gdiff(args, vertical)
     current = diffspec.worktree(),
   })
   if not parsed then
-    vim.notify('[diffs.nvim]: ' .. parse_err, vim.log.levels.ERROR)
+    vim.notify('[diffs]: ' .. parse_err, vim.log.levels.ERROR)
     return
   end
 
@@ -320,7 +320,7 @@ function M.gdiff(args, vertical)
   local diff_path = diff_spec.scope.path
   local repo_root = git.get_repo_root(filepath)
   if not repo_root then
-    vim.notify('[diffs.nvim]: not in a git repository', vim.log.levels.ERROR)
+    vim.notify('[diffs]: not in a git repository', vim.log.levels.ERROR)
     return
   end
 
@@ -328,12 +328,12 @@ function M.gdiff(args, vertical)
     worktree_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false),
   })
   if not diff_lines then
-    vim.notify('[diffs.nvim]: ' .. (render_err or 'unknown error'), vim.log.levels.ERROR)
+    vim.notify('[diffs]: ' .. (render_err or 'unknown error'), vim.log.levels.ERROR)
     return
   end
 
   if #diff_lines == 0 then
-    vim.notify('[diffs.nvim]: no changes for ' .. diffspec.label(diff_spec), vim.log.levels.INFO)
+    vim.notify('[diffs]: no changes for ' .. diffspec.label(diff_spec), vim.log.levels.INFO)
     return
   end
 
@@ -383,13 +383,13 @@ function M.gdiff_file(filepath, opts)
 
   local rel_path = git.get_relative_path(filepath)
   if not rel_path then
-    vim.notify('[diffs.nvim]: not in a git repository', vim.log.levels.ERROR)
+    vim.notify('[diffs]: not in a git repository', vim.log.levels.ERROR)
     return
   end
 
   local repo_root = git.get_repo_root(filepath)
   if not repo_root then
-    vim.notify('[diffs.nvim]: not in a git repository', vim.log.levels.ERROR)
+    vim.notify('[diffs]: not in a git repository', vim.log.levels.ERROR)
     return
   end
 
@@ -438,14 +438,14 @@ function M.gdiff_file(filepath, opts)
 
   if not diff_lines then
     if err then
-      vim.notify('[diffs.nvim]: ' .. err, vim.log.levels.ERROR)
+      vim.notify('[diffs]: ' .. err, vim.log.levels.ERROR)
       return
     end
     diff_lines = render.unified_lines(old_lines or {}, new_lines or {}, old_rel_path, rel_path)
   end
 
   if #diff_lines == 0 then
-    vim.notify('[diffs.nvim]: no changes', vim.log.levels.INFO)
+    vim.notify('[diffs]: no changes', vim.log.levels.INFO)
     return
   end
 
@@ -517,14 +517,14 @@ function M.gdiff_section(repo_root, opts)
 
   local result = vim.fn.systemlist(cmd)
   if vim.v.shell_error ~= 0 then
-    vim.notify('[diffs.nvim]: git diff failed', vim.log.levels.ERROR)
+    vim.notify('[diffs]: git diff failed', vim.log.levels.ERROR)
     return
   end
 
   result = replace_combined_diffs(result, repo_root)
 
   if #result == 0 then
-    vim.notify('[diffs.nvim]: no changes in section', vim.log.levels.INFO)
+    vim.notify('[diffs]: no changes in section', vim.log.levels.INFO)
     return
   end
 
@@ -825,7 +825,7 @@ end
 function M.greview(spec)
   local review, err = normalize_greview(spec)
   if not review then
-    vim.notify('[diffs.nvim]: ' .. err, vim.log.levels.ERROR)
+    vim.notify('[diffs]: ' .. err, vim.log.levels.ERROR)
     return nil
   end
 
@@ -837,11 +837,11 @@ function M.greview(spec)
 
   local result, diff_err = run_review(review)
   if not result then
-    vim.notify('[diffs.nvim]: ' .. diff_err, vim.log.levels.ERROR)
+    vim.notify('[diffs]: ' .. diff_err, vim.log.levels.ERROR)
     return nil
   end
   if #result == 0 then
-    vim.notify('[diffs.nvim]: no diff against ' .. review.display, vim.log.levels.INFO)
+    vim.notify('[diffs]: no diff against ' .. review.display, vim.log.levels.INFO)
     return nil
   end
 
@@ -1001,7 +1001,7 @@ function M.read_buffer(bufnr)
   local repo_root = get_buf_var(bufnr, 'diffs_repo_root')
   if not repo_root then
     vim.notify(
-      '[diffs.nvim]: cannot reload diffs:// buffer without diffs_repo_root',
+      '[diffs]: cannot reload diffs:// buffer without diffs_repo_root',
       vim.log.levels.WARN
     )
     return
@@ -1011,7 +1011,7 @@ function M.read_buffer(bufnr)
   local stored_spec, spec_err = get_diff_spec_var(bufnr)
   if spec_err then
     vim.notify(
-      '[diffs.nvim]: invalid diffs_spec metadata: ' .. tostring(spec_err),
+      '[diffs]: invalid diffs_spec metadata: ' .. tostring(spec_err),
       vim.log.levels.WARN
     )
     return
@@ -1022,14 +1022,14 @@ function M.read_buffer(bufnr)
     local read_err
     diff_lines, read_err = render.file(stored_spec, repo_root, { empty_on_missing = true })
     if not diff_lines then
-      vim.notify('[diffs.nvim]: ' .. read_err, vim.log.levels.WARN)
+      vim.notify('[diffs]: ' .. read_err, vim.log.levels.WARN)
       return
     end
   else
     label, path = url_body:match('^([^:]+):(.+)$')
     if not label or not path then
       vim.notify(
-        '[diffs.nvim]: cannot reload malformed diffs:// buffer: ' .. name,
+        '[diffs]: cannot reload malformed diffs:// buffer: ' .. name,
         vim.log.levels.WARN
       )
       return
@@ -1156,7 +1156,7 @@ function M.setup()
   vim.api.nvim_create_user_command('Greview', function(opts)
     local spec, err = parse_review_arg(opts.args ~= '' and opts.args or nil)
     if not spec then
-      vim.notify('[diffs.nvim]: ' .. err, vim.log.levels.ERROR)
+      vim.notify('[diffs]: ' .. err, vim.log.levels.ERROR)
       return
     end
     M.greview(spec)

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -195,7 +195,7 @@ function M.migrate_integrations(opts)
       local old = 'vim.g.diffs.{' .. table.concat(stale, ', ') .. '}'
       local new = 'vim.g.diffs.integrations.{' .. table.concat(stale, ', ') .. '}'
       vim.notify(
-        '[diffs.nvim]: ignoring ' .. old .. '; move to ' .. new .. ' or remove',
+        '[diffs]: ignoring ' .. old .. '; move to ' .. new .. ' or remove',
         vim.log.levels.WARN
       )
     end

--- a/lua/diffs/conflict.lua
+++ b/lua/diffs/conflict.lua
@@ -285,7 +285,7 @@ end
 ---@param config diffs.ConflictConfig
 function M.resolve_ours(bufnr, config)
   if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
-    vim.notify('[diffs.nvim]: buffer is not modifiable', vim.log.levels.WARN)
+    vim.notify('[diffs]: buffer is not modifiable', vim.log.levels.WARN)
     return
   end
   local regions = parse_buffer(bufnr)
@@ -303,7 +303,7 @@ end
 ---@param config diffs.ConflictConfig
 function M.resolve_theirs(bufnr, config)
   if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
-    vim.notify('[diffs.nvim]: buffer is not modifiable', vim.log.levels.WARN)
+    vim.notify('[diffs]: buffer is not modifiable', vim.log.levels.WARN)
     return
   end
   local regions = parse_buffer(bufnr)
@@ -321,7 +321,7 @@ end
 ---@param config diffs.ConflictConfig
 function M.resolve_both(bufnr, config)
   if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
-    vim.notify('[diffs.nvim]: buffer is not modifiable', vim.log.levels.WARN)
+    vim.notify('[diffs]: buffer is not modifiable', vim.log.levels.WARN)
     return
   end
   local regions = parse_buffer(bufnr)
@@ -347,7 +347,7 @@ end
 ---@param config diffs.ConflictConfig
 function M.resolve_none(bufnr, config)
   if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
-    vim.notify('[diffs.nvim]: buffer is not modifiable', vim.log.levels.WARN)
+    vim.notify('[diffs]: buffer is not modifiable', vim.log.levels.WARN)
     return
   end
   local regions = parse_buffer(bufnr)
@@ -374,7 +374,7 @@ function M.goto_next(bufnr)
       return
     end
   end
-  vim.notify('[diffs.nvim]: wrapped to first conflict', vim.log.levels.INFO)
+  vim.notify('[diffs]: wrapped to first conflict', vim.log.levels.INFO)
   vim.api.nvim_win_set_cursor(0, { regions[1].marker_ours + 1, 0 })
 end
 
@@ -392,7 +392,7 @@ function M.goto_prev(bufnr)
       return
     end
   end
-  vim.notify('[diffs.nvim]: wrapped to last conflict', vim.log.levels.INFO)
+  vim.notify('[diffs]: wrapped to last conflict', vim.log.levels.INFO)
   vim.api.nvim_win_set_cursor(0, { regions[#regions].marker_ours + 1, 0 })
 end
 

--- a/lua/diffs/debug.lua
+++ b/lua/diffs/debug.lua
@@ -63,7 +63,7 @@ function M.dump()
   if f then
     f:write(vim.json.encode(result))
     f:close()
-    vim.notify('[diffs.nvim]: debug dump: ' .. path, vim.log.levels.INFO)
+    vim.notify('[diffs]: debug dump: ' .. path, vim.log.levels.INFO)
   end
 end
 

--- a/lua/diffs/fugitive.lua
+++ b/lua/diffs/fugitive.lua
@@ -199,7 +199,7 @@ function M.diff_file_under_cursor(vertical)
 
   local repo_root = get_repo_root_from_fugitive(bufnr)
   if not repo_root then
-    vim.notify('[diffs.nvim]: could not determine repository root', vim.log.levels.ERROR)
+    vim.notify('[diffs]: could not determine repository root', vim.log.levels.ERROR)
     return
   end
 
@@ -207,7 +207,7 @@ function M.diff_file_under_cursor(vertical)
     dbg('diff_section: %s', section or 'unknown')
     if section == 'untracked' then
       vim.notify(
-        '[diffs.nvim]: cannot diff untracked section; open an untracked file line instead',
+        '[diffs]: cannot diff untracked section; open an untracked file line instead',
         vim.log.levels.WARN
       )
       return
@@ -220,7 +220,7 @@ function M.diff_file_under_cursor(vertical)
   end
 
   if not filename then
-    vim.notify('[diffs.nvim]: no file under cursor', vim.log.levels.WARN)
+    vim.notify('[diffs]: no file under cursor', vim.log.levels.WARN)
     return
   end
 

--- a/lua/diffs/hunks.lua
+++ b/lua/diffs/hunks.lua
@@ -447,7 +447,7 @@ end
 function M.open_source(bufnr)
   local source, err = M.source_at_cursor(bufnr)
   if not source then
-    vim.notify('[diffs.nvim]: ' .. err, vim.log.levels.WARN)
+    vim.notify('[diffs]: ' .. err, vim.log.levels.WARN)
     return false
   end
 
@@ -474,7 +474,7 @@ function M.goto_next(bufnr)
   local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
   local next_hunk = M.next_hunk(parsed, cursor_line) or parsed[1]
   if next_hunk == parsed[1] and next_hunk.buffer_range.start <= cursor_line then
-    vim.notify('[diffs.nvim]: wrapped to first hunk', vim.log.levels.INFO)
+    vim.notify('[diffs]: wrapped to first hunk', vim.log.levels.INFO)
   end
   vim.api.nvim_win_set_cursor(0, { next_hunk.buffer_range.start, 0 })
 end
@@ -489,7 +489,7 @@ function M.goto_prev(bufnr)
   local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
   local prev_hunk = M.prev_hunk(parsed, cursor_line) or parsed[#parsed]
   if prev_hunk == parsed[#parsed] and prev_hunk.buffer_range.start >= cursor_line then
-    vim.notify('[diffs.nvim]: wrapped to last hunk', vim.log.levels.INFO)
+    vim.notify('[diffs]: wrapped to last hunk', vim.log.levels.INFO)
   end
   vim.api.nvim_win_set_cursor(0, { prev_hunk.buffer_range.start, 0 })
 end

--- a/lua/diffs/lib.lua
+++ b/lua/diffs/lib.lua
@@ -189,7 +189,7 @@ function M.ensure(callback)
   )
 
   local dest = lib_path()
-  vim.notify('[diffs.nvim]: downloading libvscode_diff...', vim.log.levels.INFO)
+  vim.notify('[diffs]: downloading libvscode_diff...', vim.log.levels.INFO)
 
   local cmd = { 'curl', '-fSL', '-o', dest, url }
 
@@ -198,7 +198,7 @@ function M.ensure(callback)
     vim.schedule(function()
       local handle = nil
       if result.code ~= 0 then
-        vim.notify('[diffs.nvim]: failed to download libvscode_diff', vim.log.levels.WARN)
+        vim.notify('[diffs]: failed to download libvscode_diff', vim.log.levels.WARN)
         dbg('curl failed: %s', result.stderr or '')
       else
         local f = io.open(version_path(), 'w')
@@ -206,7 +206,7 @@ function M.ensure(callback)
           f:write(EXPECTED_VERSION)
           f:close()
         end
-        vim.notify('[diffs.nvim]: libvscode_diff downloaded', vim.log.levels.INFO)
+        vim.notify('[diffs]: libvscode_diff downloaded', vim.log.levels.INFO)
         handle = M.load()
       end
 

--- a/lua/diffs/log.lua
+++ b/lua/diffs/log.lua
@@ -20,7 +20,7 @@ function M.dbg(msg, ...)
   if not enabled then
     return
   end
-  local formatted = '[diffs.nvim]: ' .. string.format(msg, ...)
+  local formatted = '[diffs]: ' .. string.format(msg, ...)
   if log_file then
     local f = io.open(log_file, 'a')
     if f then

--- a/lua/diffs/merge.lua
+++ b/lua/diffs/merge.lua
@@ -159,7 +159,7 @@ function M.resolve_ours(bufnr, config)
     return
   end
   if M.is_resolved(bufnr, hunk.index) then
-    vim.notify('[diffs.nvim]: hunk already resolved', vim.log.levels.INFO)
+    vim.notify('[diffs]: hunk already resolved', vim.log.levels.INFO)
     return
   end
   local working_bufnr = M.get_or_load_working_buf(bufnr)
@@ -168,7 +168,7 @@ function M.resolve_ours(bufnr, config)
   end
   local region = M.match_hunk_to_conflict(hunk, working_bufnr)
   if not region then
-    vim.notify('[diffs.nvim]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
+    vim.notify('[diffs]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
     return
   end
   local lines = vim.api.nvim_buf_get_lines(working_bufnr, region.ours_start, region.ours_end, false)
@@ -186,7 +186,7 @@ function M.resolve_theirs(bufnr, config)
     return
   end
   if M.is_resolved(bufnr, hunk.index) then
-    vim.notify('[diffs.nvim]: hunk already resolved', vim.log.levels.INFO)
+    vim.notify('[diffs]: hunk already resolved', vim.log.levels.INFO)
     return
   end
   local working_bufnr = M.get_or_load_working_buf(bufnr)
@@ -195,7 +195,7 @@ function M.resolve_theirs(bufnr, config)
   end
   local region = M.match_hunk_to_conflict(hunk, working_bufnr)
   if not region then
-    vim.notify('[diffs.nvim]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
+    vim.notify('[diffs]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
     return
   end
   local lines =
@@ -214,7 +214,7 @@ function M.resolve_both(bufnr, config)
     return
   end
   if M.is_resolved(bufnr, hunk.index) then
-    vim.notify('[diffs.nvim]: hunk already resolved', vim.log.levels.INFO)
+    vim.notify('[diffs]: hunk already resolved', vim.log.levels.INFO)
     return
   end
   local working_bufnr = M.get_or_load_working_buf(bufnr)
@@ -223,7 +223,7 @@ function M.resolve_both(bufnr, config)
   end
   local region = M.match_hunk_to_conflict(hunk, working_bufnr)
   if not region then
-    vim.notify('[diffs.nvim]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
+    vim.notify('[diffs]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
     return
   end
   local ours = vim.api.nvim_buf_get_lines(working_bufnr, region.ours_start, region.ours_end, false)
@@ -250,7 +250,7 @@ function M.resolve_none(bufnr, config)
     return
   end
   if M.is_resolved(bufnr, hunk.index) then
-    vim.notify('[diffs.nvim]: hunk already resolved', vim.log.levels.INFO)
+    vim.notify('[diffs]: hunk already resolved', vim.log.levels.INFO)
     return
   end
   local working_bufnr = M.get_or_load_working_buf(bufnr)
@@ -259,7 +259,7 @@ function M.resolve_none(bufnr, config)
   end
   local region = M.match_hunk_to_conflict(hunk, working_bufnr)
   if not region then
-    vim.notify('[diffs.nvim]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
+    vim.notify('[diffs]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
     return
   end
   conflict.replace_region(working_bufnr, region, {})
@@ -302,7 +302,7 @@ function M.goto_next(bufnr)
     end
   end
 
-  vim.notify('[diffs.nvim]: wrapped to first hunk', vim.log.levels.INFO)
+  vim.notify('[diffs]: wrapped to first hunk', vim.log.levels.INFO)
   vim.api.nvim_win_set_cursor(0, { candidates[1].start_line + 1, 0 })
 end
 
@@ -340,7 +340,7 @@ function M.goto_prev(bufnr)
     end
   end
 
-  vim.notify('[diffs.nvim]: wrapped to last hunk', vim.log.levels.INFO)
+  vim.notify('[diffs]: wrapped to last hunk', vim.log.levels.INFO)
   vim.api.nvim_win_set_cursor(0, { candidates[#candidates].start_line + 1, 0 })
 end
 

--- a/lua/diffs/runtime/decorator.lua
+++ b/lua/diffs/runtime/decorator.lua
@@ -79,7 +79,7 @@ function M.setup(opts)
         vim.schedule(function()
           vim.notify(
             (
-              '[diffs.nvim]: Syntax highlighting skipped for %d hunk(s) — too large.'
+              '[diffs]: Syntax highlighting skipped for %d hunk(s) — too large.'
               .. ' See :h diffs-max-lines to resolve or suppress this warning.'
             ):format(n),
             vim.log.levels.WARN


### PR DESCRIPTION
## Summary
- Change user-facing notification/log prefixes from `[diffs.nvim]:` to `[diffs]:`
- Update the vimdoc max-lines warning example to match

## Checks
- `just lint`
- `just test`
- `git diff --check`