### PR TITLE
Clarify Gdiff help text

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -190,7 +190,8 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
 <
 
             {gitsigns}       (boolean|table, default: false)
-                             Enable gitsigns.nvim blame popup highlighting.
+                             Enable gitsigns.nvim popup integration for
+                             blame hunk previews.
                              See |diffs.nvim-gitsigns|. >lua
                                  integrations = { gitsigns = true }
 <
@@ -428,6 +429,8 @@ COMMANDS                                                 *diffs.nvim-commands*
     diff replaces its buffer instead of creating another split.
 
     Parameters: ~
+        ++novertical (optional) Force a horizontal split. Useful with |:Gvdiff|
+                    or command wrappers.
         {object}    (string, optional) Fugitive-style object to diff against.
                     Defaults to the current file in the index.
 
@@ -561,11 +564,11 @@ COMMANDS                                                 *diffs.nvim-commands*
 MAPPINGS                                                 *diffs.nvim-mappings*
 
                                                          *<Plug>(diffs-gdiff)*
-<Plug>(diffs-gdiff)     Show unified diff against HEAD in a horizontal
+<Plug>(diffs-gdiff)     Show index-to-worktree unified diff in a horizontal
                         split. Equivalent to |:Gdiff| with no arguments.
 
                                                         *<Plug>(diffs-gvdiff)*
-<Plug>(diffs-gvdiff)    Show unified diff against HEAD in a vertical
+<Plug>(diffs-gvdiff)    Show index-to-worktree unified diff in a vertical
                         split. Equivalent to |:Gvdiff| with no arguments.
 
 Example configuration: >lua
@@ -765,8 +768,8 @@ applies treesitter syntax highlighting and intra-line diffs to the hunk lines.
 ------------------------------------------------------------------------------
 GITSIGNS                                                 *diffs.nvim-gitsigns*
 
-Enable gitsigns.nvim (https://github.com/lewis6991/gitsigns.nvim) blame popup
-highlighting: >lua
+Enable gitsigns.nvim (https://github.com/lewis6991/gitsigns.nvim) popup
+integration for blame hunk previews: >lua
     vim.g.diffs = { integrations = { gitsigns = true } }
 <
 


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

## Solution

The solution clarifies gitsigns integration wording in vimdoc; documents `:Gdiff ++novertical`; and corrects `<Plug>(diffs-gdiff)` and `<Plug>(diffs-gvdiff)` descriptions to index-to-worktree diffs.
