### PR TITLE
Centralize notification prefix

### DIFF
--- a/lua/diffs/actions.lua
+++ b/lua/diffs/actions.lua
@@ -3,6 +3,7 @@ local M = {}
 local diffspec = require('diffs.spec')
 local git = require('diffs.git')
 local hunk_model = require('diffs.hunks')
+local notify = require('diffs.log').notify
 
 ---@param bufnr integer
 ---@param name string
@@ -297,12 +298,6 @@ local function range_action_context(bufnr, range_start, range_finish)
   end
 
   return start_hunk, spec, nil
-end
-
----@param message string
----@param level integer
-local function notify(message, level)
-  vim.notify('[diffs]: ' .. message, level)
 end
 
 ---@param bufnr integer

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -5,9 +5,12 @@ local diffspec = require('diffs.spec')
 local gdiff_parser = require('diffs.gdiff')
 local git = require('diffs.git')
 local hunk_model = require('diffs.hunks')
-local dbg = require('diffs.log').dbg
+local log = require('diffs.log')
 local render = require('diffs.render')
 local runtime = require('diffs.runtime')
+
+local dbg = log.dbg
+local notify = log.notify
 
 ---@class diffs.HunkKeymap
 ---@field mode string
@@ -381,13 +384,13 @@ function M.gdiff(args, vertical)
   local filepath = vim.api.nvim_buf_get_name(bufnr)
 
   if filepath == '' then
-    vim.notify('[diffs]: cannot diff unnamed buffer', vim.log.levels.ERROR)
+    notify('cannot diff unnamed buffer', vim.log.levels.ERROR)
     return
   end
 
   local rel_path = git.get_relative_path(filepath)
   if not rel_path then
-    vim.notify('[diffs]: not in a git repository', vim.log.levels.ERROR)
+    notify('not in a git repository', vim.log.levels.ERROR)
     return
   end
 
@@ -396,7 +399,7 @@ function M.gdiff(args, vertical)
     current = diffspec.worktree(),
   })
   if not parsed then
-    vim.notify('[diffs]: ' .. parse_err, vim.log.levels.ERROR)
+    notify(parse_err, vim.log.levels.ERROR)
     return
   end
 
@@ -409,7 +412,7 @@ function M.gdiff(args, vertical)
   local diff_path = diff_spec.scope.path
   local repo_root = git.get_repo_root(filepath)
   if not repo_root then
-    vim.notify('[diffs]: not in a git repository', vim.log.levels.ERROR)
+    notify('not in a git repository', vim.log.levels.ERROR)
     return
   end
 
@@ -417,12 +420,12 @@ function M.gdiff(args, vertical)
     worktree_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false),
   })
   if not diff_lines then
-    vim.notify('[diffs]: ' .. (render_err or 'unknown error'), vim.log.levels.ERROR)
+    notify(render_err or 'unknown error', vim.log.levels.ERROR)
     return
   end
 
   if #diff_lines == 0 then
-    vim.notify('[diffs]: no changes for ' .. diffspec.label(diff_spec), vim.log.levels.INFO)
+    notify('no changes for ' .. diffspec.label(diff_spec), vim.log.levels.INFO)
     return
   end
 
@@ -452,13 +455,13 @@ function M.gdiff_file(filepath, opts)
 
   local rel_path = git.get_relative_path(filepath)
   if not rel_path then
-    vim.notify('[diffs]: not in a git repository', vim.log.levels.ERROR)
+    notify('not in a git repository', vim.log.levels.ERROR)
     return
   end
 
   local repo_root = git.get_repo_root(filepath)
   if not repo_root then
-    vim.notify('[diffs]: not in a git repository', vim.log.levels.ERROR)
+    notify('not in a git repository', vim.log.levels.ERROR)
     return
   end
 
@@ -507,14 +510,14 @@ function M.gdiff_file(filepath, opts)
 
   if not diff_lines then
     if err then
-      vim.notify('[diffs]: ' .. err, vim.log.levels.ERROR)
+      notify(err, vim.log.levels.ERROR)
       return
     end
     diff_lines = render.unified_lines(old_lines or {}, new_lines or {}, old_rel_path, rel_path)
   end
 
   if #diff_lines == 0 then
-    vim.notify('[diffs]: no changes', vim.log.levels.INFO)
+    notify('no changes', vim.log.levels.INFO)
     return
   end
 
@@ -565,14 +568,14 @@ function M.gdiff_section(repo_root, opts)
 
   local result = vim.fn.systemlist(cmd)
   if vim.v.shell_error ~= 0 then
-    vim.notify('[diffs]: git diff failed', vim.log.levels.ERROR)
+    notify('git diff failed', vim.log.levels.ERROR)
     return
   end
 
   result = replace_combined_diffs(result, repo_root)
 
   if #result == 0 then
-    vim.notify('[diffs]: no changes in section', vim.log.levels.INFO)
+    notify('no changes in section', vim.log.levels.INFO)
     return
   end
 
@@ -856,7 +859,7 @@ end
 function M.greview(spec)
   local review, err = normalize_greview(spec)
   if not review then
-    vim.notify('[diffs]: ' .. err, vim.log.levels.ERROR)
+    notify(err, vim.log.levels.ERROR)
     return nil
   end
 
@@ -868,11 +871,11 @@ function M.greview(spec)
 
   local result, diff_err = run_review(review)
   if not result then
-    vim.notify('[diffs]: ' .. diff_err, vim.log.levels.ERROR)
+    notify(diff_err, vim.log.levels.ERROR)
     return nil
   end
   if #result == 0 then
-    vim.notify('[diffs]: no diff against ' .. review.display, vim.log.levels.INFO)
+    notify('no diff against ' .. review.display, vim.log.levels.INFO)
     return nil
   end
 
@@ -1014,17 +1017,14 @@ function M.read_buffer(bufnr)
 
   local repo_root = get_buf_var(bufnr, 'diffs_repo_root')
   if not repo_root then
-    vim.notify(
-      '[diffs]: cannot reload diffs:// buffer without diffs_repo_root',
-      vim.log.levels.WARN
-    )
+    notify('cannot reload diffs:// buffer without diffs_repo_root', vim.log.levels.WARN)
     return
   end
 
   local diff_lines
   local stored_spec, spec_err = get_diff_spec_var(bufnr)
   if spec_err then
-    vim.notify('[diffs]: invalid diffs_spec metadata: ' .. tostring(spec_err), vim.log.levels.WARN)
+    notify('invalid diffs_spec metadata: ' .. tostring(spec_err), vim.log.levels.WARN)
     return
   end
 
@@ -1033,13 +1033,13 @@ function M.read_buffer(bufnr)
     local read_err
     diff_lines, read_err = render.file(stored_spec, repo_root, { empty_on_missing = true })
     if not diff_lines then
-      vim.notify('[diffs]: ' .. read_err, vim.log.levels.WARN)
+      notify(read_err, vim.log.levels.WARN)
       return
     end
   else
     label, path = url_body:match('^([^:]+):(.+)$')
     if not label or not path then
-      vim.notify('[diffs]: cannot reload malformed diffs:// buffer: ' .. name, vim.log.levels.WARN)
+      notify('cannot reload malformed diffs:// buffer: ' .. name, vim.log.levels.WARN)
       return
     end
   end
@@ -1153,7 +1153,7 @@ function M.setup()
   vim.api.nvim_create_user_command('Greview', function(opts)
     local spec, err = parse_review_arg(opts.args ~= '' and opts.args or nil)
     if not spec then
-      vim.notify('[diffs]: ' .. err, vim.log.levels.ERROR)
+      notify(err, vim.log.levels.ERROR)
       return
     end
     M.greview(spec)

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local notify = require('diffs.log').notify
+
 ---@class diffs.TreesitterConfig
 ---@field enabled boolean
 ---@field max_lines integer
@@ -194,10 +196,7 @@ function M.migrate_integrations(opts)
     if #stale > 0 then
       local old = 'vim.g.diffs.{' .. table.concat(stale, ', ') .. '}'
       local new = 'vim.g.diffs.integrations.{' .. table.concat(stale, ', ') .. '}'
-      vim.notify(
-        '[diffs]: ignoring ' .. old .. '; move to ' .. new .. ' or remove',
-        vim.log.levels.WARN
-      )
+      notify('ignoring ' .. old .. '; move to ' .. new .. ' or remove', vim.log.levels.WARN)
     end
     return
   end

--- a/lua/diffs/conflict.lua
+++ b/lua/diffs/conflict.lua
@@ -13,6 +13,7 @@
 local M = {}
 
 local keymaps = require('diffs.keymaps')
+local notify = require('diffs.log').notify
 
 local ns = vim.api.nvim_create_namespace('diffs-conflict')
 
@@ -285,7 +286,7 @@ end
 ---@param config diffs.ConflictConfig
 function M.resolve_ours(bufnr, config)
   if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
-    vim.notify('[diffs]: buffer is not modifiable', vim.log.levels.WARN)
+    notify('buffer is not modifiable', vim.log.levels.WARN)
     return
   end
   local regions = parse_buffer(bufnr)
@@ -303,7 +304,7 @@ end
 ---@param config diffs.ConflictConfig
 function M.resolve_theirs(bufnr, config)
   if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
-    vim.notify('[diffs]: buffer is not modifiable', vim.log.levels.WARN)
+    notify('buffer is not modifiable', vim.log.levels.WARN)
     return
   end
   local regions = parse_buffer(bufnr)
@@ -321,7 +322,7 @@ end
 ---@param config diffs.ConflictConfig
 function M.resolve_both(bufnr, config)
   if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
-    vim.notify('[diffs]: buffer is not modifiable', vim.log.levels.WARN)
+    notify('buffer is not modifiable', vim.log.levels.WARN)
     return
   end
   local regions = parse_buffer(bufnr)
@@ -347,7 +348,7 @@ end
 ---@param config diffs.ConflictConfig
 function M.resolve_none(bufnr, config)
   if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
-    vim.notify('[diffs]: buffer is not modifiable', vim.log.levels.WARN)
+    notify('buffer is not modifiable', vim.log.levels.WARN)
     return
   end
   local regions = parse_buffer(bufnr)
@@ -374,7 +375,7 @@ function M.goto_next(bufnr)
       return
     end
   end
-  vim.notify('[diffs]: wrapped to first conflict', vim.log.levels.INFO)
+  notify('wrapped to first conflict', vim.log.levels.INFO)
   vim.api.nvim_win_set_cursor(0, { regions[1].marker_ours + 1, 0 })
 end
 
@@ -392,7 +393,7 @@ function M.goto_prev(bufnr)
       return
     end
   end
-  vim.notify('[diffs]: wrapped to last conflict', vim.log.levels.INFO)
+  notify('wrapped to last conflict', vim.log.levels.INFO)
   vim.api.nvim_win_set_cursor(0, { regions[#regions].marker_ours + 1, 0 })
 end
 

--- a/lua/diffs/debug.lua
+++ b/lua/diffs/debug.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local notify = require('diffs.log').notify
+
 local ns = vim.api.nvim_create_namespace('diffs')
 
 function M.dump()
@@ -63,7 +65,7 @@ function M.dump()
   if f then
     f:write(vim.json.encode(result))
     f:close()
-    vim.notify('[diffs]: debug dump: ' .. path, vim.log.levels.INFO)
+    notify('debug dump: ' .. path, vim.log.levels.INFO)
   end
 end
 

--- a/lua/diffs/fugitive.lua
+++ b/lua/diffs/fugitive.lua
@@ -2,7 +2,10 @@ local M = {}
 
 local commands = require('diffs.commands')
 local git = require('diffs.git')
-local dbg = require('diffs.log').dbg
+local log = require('diffs.log')
+
+local dbg = log.dbg
+local notify = log.notify
 
 ---@alias diffs.FugitiveSection 'staged' | 'unstaged' | 'untracked' | nil
 
@@ -199,15 +202,15 @@ function M.diff_file_under_cursor(vertical)
 
   local repo_root = get_repo_root_from_fugitive(bufnr)
   if not repo_root then
-    vim.notify('[diffs]: could not determine repository root', vim.log.levels.ERROR)
+    notify('could not determine repository root', vim.log.levels.ERROR)
     return
   end
 
   if is_header then
     dbg('diff_section: %s', section or 'unknown')
     if section == 'untracked' then
-      vim.notify(
-        '[diffs]: cannot diff untracked section; open an untracked file line instead',
+      notify(
+        'cannot diff untracked section; open an untracked file line instead',
         vim.log.levels.WARN
       )
       return
@@ -220,7 +223,7 @@ function M.diff_file_under_cursor(vertical)
   end
 
   if not filename then
-    vim.notify('[diffs]: no file under cursor', vim.log.levels.WARN)
+    notify('no file under cursor', vim.log.levels.WARN)
     return
   end
 

--- a/lua/diffs/hunks.lua
+++ b/lua/diffs/hunks.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local diffspec = require('diffs.spec')
+local notify = require('diffs.log').notify
 
 ---@class diffs.GdiffHunkRange
 ---@field start integer
@@ -452,7 +453,7 @@ end
 function M.open_source(bufnr)
   local source, err = M.source_at_cursor(bufnr)
   if not source then
-    vim.notify('[diffs]: ' .. err, vim.log.levels.WARN)
+    notify(err, vim.log.levels.WARN)
     return false
   end
 
@@ -479,7 +480,7 @@ function M.goto_next(bufnr)
   local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
   local next_hunk = M.next_hunk(parsed, cursor_line) or parsed[1]
   if next_hunk == parsed[1] and next_hunk.buffer_range.start <= cursor_line then
-    vim.notify('[diffs]: wrapped to first hunk', vim.log.levels.INFO)
+    notify('wrapped to first hunk', vim.log.levels.INFO)
   end
   vim.api.nvim_win_set_cursor(0, { next_hunk.buffer_range.start, 0 })
 end
@@ -494,7 +495,7 @@ function M.goto_prev(bufnr)
   local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
   local prev_hunk = M.prev_hunk(parsed, cursor_line) or parsed[#parsed]
   if prev_hunk == parsed[#parsed] and prev_hunk.buffer_range.start >= cursor_line then
-    vim.notify('[diffs]: wrapped to last hunk', vim.log.levels.INFO)
+    notify('wrapped to last hunk', vim.log.levels.INFO)
   end
   vim.api.nvim_win_set_cursor(0, { prev_hunk.buffer_range.start, 0 })
 end

--- a/lua/diffs/lib.lua
+++ b/lua/diffs/lib.lua
@@ -1,6 +1,9 @@
 local M = {}
 
-local dbg = require('diffs.log').dbg
+local log = require('diffs.log')
+
+local dbg = log.dbg
+local notify = log.notify
 
 ---@type table?
 local cached_handle = nil
@@ -189,7 +192,7 @@ function M.ensure(callback)
   )
 
   local dest = lib_path()
-  vim.notify('[diffs]: downloading libvscode_diff...', vim.log.levels.INFO)
+  notify('downloading libvscode_diff...', vim.log.levels.INFO)
 
   local cmd = { 'curl', '-fSL', '-o', dest, url }
 
@@ -198,7 +201,7 @@ function M.ensure(callback)
     vim.schedule(function()
       local handle = nil
       if result.code ~= 0 then
-        vim.notify('[diffs]: failed to download libvscode_diff', vim.log.levels.WARN)
+        notify('failed to download libvscode_diff', vim.log.levels.WARN)
         dbg('curl failed: %s', result.stderr or '')
       else
         local f = io.open(version_path(), 'w')
@@ -206,7 +209,7 @@ function M.ensure(callback)
           f:write(EXPECTED_VERSION)
           f:close()
         end
-        vim.notify('[diffs]: libvscode_diff downloaded', vim.log.levels.INFO)
+        notify('libvscode_diff downloaded', vim.log.levels.INFO)
         handle = M.load()
       end
 

--- a/lua/diffs/log.lua
+++ b/lua/diffs/log.lua
@@ -1,7 +1,22 @@
 local M = {}
 
+local prefix = '[diffs]: '
+
 local enabled = false
 local log_file = nil
+
+---@param message any
+---@return string
+local function format_message(message)
+  return prefix .. message
+end
+
+---@param message any
+---@param level integer
+---@param opts? table
+function M.notify(message, level, opts)
+  vim.notify(format_message(message), level, opts)
+end
 
 ---@param val boolean|string
 function M.set_enabled(val)
@@ -20,7 +35,7 @@ function M.dbg(msg, ...)
   if not enabled then
     return
   end
-  local formatted = '[diffs]: ' .. string.format(msg, ...)
+  local formatted = format_message(string.format(msg, ...))
   if log_file then
     local f = io.open(log_file, 'a')
     if f then

--- a/lua/diffs/merge.lua
+++ b/lua/diffs/merge.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local conflict = require('diffs.conflict')
 local keymaps = require('diffs.keymaps')
+local notify = require('diffs.log').notify
 
 local ns = vim.api.nvim_create_namespace('diffs-merge')
 
@@ -159,7 +160,7 @@ function M.resolve_ours(bufnr, config)
     return
   end
   if M.is_resolved(bufnr, hunk.index) then
-    vim.notify('[diffs]: hunk already resolved', vim.log.levels.INFO)
+    notify('hunk already resolved', vim.log.levels.INFO)
     return
   end
   local working_bufnr = M.get_or_load_working_buf(bufnr)
@@ -168,7 +169,7 @@ function M.resolve_ours(bufnr, config)
   end
   local region = M.match_hunk_to_conflict(hunk, working_bufnr)
   if not region then
-    vim.notify('[diffs]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
+    notify('hunk does not correspond to a conflict region', vim.log.levels.INFO)
     return
   end
   local lines = vim.api.nvim_buf_get_lines(working_bufnr, region.ours_start, region.ours_end, false)
@@ -186,7 +187,7 @@ function M.resolve_theirs(bufnr, config)
     return
   end
   if M.is_resolved(bufnr, hunk.index) then
-    vim.notify('[diffs]: hunk already resolved', vim.log.levels.INFO)
+    notify('hunk already resolved', vim.log.levels.INFO)
     return
   end
   local working_bufnr = M.get_or_load_working_buf(bufnr)
@@ -195,7 +196,7 @@ function M.resolve_theirs(bufnr, config)
   end
   local region = M.match_hunk_to_conflict(hunk, working_bufnr)
   if not region then
-    vim.notify('[diffs]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
+    notify('hunk does not correspond to a conflict region', vim.log.levels.INFO)
     return
   end
   local lines =
@@ -214,7 +215,7 @@ function M.resolve_both(bufnr, config)
     return
   end
   if M.is_resolved(bufnr, hunk.index) then
-    vim.notify('[diffs]: hunk already resolved', vim.log.levels.INFO)
+    notify('hunk already resolved', vim.log.levels.INFO)
     return
   end
   local working_bufnr = M.get_or_load_working_buf(bufnr)
@@ -223,7 +224,7 @@ function M.resolve_both(bufnr, config)
   end
   local region = M.match_hunk_to_conflict(hunk, working_bufnr)
   if not region then
-    vim.notify('[diffs]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
+    notify('hunk does not correspond to a conflict region', vim.log.levels.INFO)
     return
   end
   local ours = vim.api.nvim_buf_get_lines(working_bufnr, region.ours_start, region.ours_end, false)
@@ -250,7 +251,7 @@ function M.resolve_none(bufnr, config)
     return
   end
   if M.is_resolved(bufnr, hunk.index) then
-    vim.notify('[diffs]: hunk already resolved', vim.log.levels.INFO)
+    notify('hunk already resolved', vim.log.levels.INFO)
     return
   end
   local working_bufnr = M.get_or_load_working_buf(bufnr)
@@ -259,7 +260,7 @@ function M.resolve_none(bufnr, config)
   end
   local region = M.match_hunk_to_conflict(hunk, working_bufnr)
   if not region then
-    vim.notify('[diffs]: hunk does not correspond to a conflict region', vim.log.levels.INFO)
+    notify('hunk does not correspond to a conflict region', vim.log.levels.INFO)
     return
   end
   conflict.replace_region(working_bufnr, region, {})
@@ -302,7 +303,7 @@ function M.goto_next(bufnr)
     end
   end
 
-  vim.notify('[diffs]: wrapped to first hunk', vim.log.levels.INFO)
+  notify('wrapped to first hunk', vim.log.levels.INFO)
   vim.api.nvim_win_set_cursor(0, { candidates[1].start_line + 1, 0 })
 end
 
@@ -340,7 +341,7 @@ function M.goto_prev(bufnr)
     end
   end
 
-  vim.notify('[diffs]: wrapped to last hunk', vim.log.levels.INFO)
+  notify('wrapped to last hunk', vim.log.levels.INFO)
   vim.api.nvim_win_set_cursor(0, { candidates[#candidates].start_line + 1, 0 })
 end
 

--- a/lua/diffs/runtime/decorator.lua
+++ b/lua/diffs/runtime/decorator.lua
@@ -77,9 +77,9 @@ function M.setup(opts)
         entry.warned_max_lines = true
         local n = skipped_count
         vim.schedule(function()
-          vim.notify(
+          log.notify(
             (
-              '[diffs]: Syntax highlighting skipped for %d hunk(s) — too large.'
+              'Syntax highlighting skipped for %d hunk(s) — too large.'
               .. ' See :h diffs-max-lines to resolve or suppress this warning.'
             ):format(n),
             vim.log.levels.WARN


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #278.

## Solution

The solution adds a shared logger notification helper that owns the `[diffs]:` prefix; replaces plugin-owned prefixed `vim.notify` call sites with the helper; and preserves existing notification messages and log levels.
