### PR TITLE
Split Greview command implementation

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -275,6 +275,81 @@ local function get_diff_spec_var(bufnr)
   return parsed, nil
 end
 
+---@class diffs.GeneratedBufferSource
+---@field version integer
+---@field kind "file"|"file_pair"|"section"|"review"|"unmerged"
+---@field repo_root string
+---@field spec? diffs.DiffSpec
+---@field edge? "staged"|"unstaged"
+---@field path? string
+---@field old_path? string
+---@field section? "staged"|"unstaged"
+---@field review? diffs.GreviewSpec
+---@field working_path? string
+
+---@param source table
+---@return diffs.GeneratedBufferSource?
+local function normalize_source(source)
+  if type(source) ~= 'table' then
+    error('expected table')
+  end
+  if source.version ~= 1 then
+    error('expected version 1')
+  end
+  if type(source.repo_root) ~= 'string' or source.repo_root == '' then
+    error('expected repo_root')
+  end
+
+  if source.kind == 'file' then
+    if source.spec == nil then
+      error('expected file spec')
+    end
+    source.spec = diffspec.new(source.spec)
+  elseif source.kind == 'file_pair' then
+    if source.edge ~= 'staged' and source.edge ~= 'unstaged' then
+      error('expected file_pair edge')
+    end
+    if type(source.path) ~= 'string' or source.path == '' then
+      error('expected file_pair path')
+    end
+    if type(source.old_path) ~= 'string' or source.old_path == '' then
+      error('expected file_pair old_path')
+    end
+  elseif source.kind == 'section' then
+    if source.section ~= 'staged' and source.section ~= 'unstaged' then
+      error('expected section')
+    end
+  elseif source.kind == 'review' then
+    if type(source.review) ~= 'table' then
+      error('expected review spec')
+    end
+  elseif source.kind == 'unmerged' then
+    if type(source.path) ~= 'string' or source.path == '' then
+      error('expected unmerged path')
+    end
+  else
+    error('unknown source kind')
+  end
+
+  return source
+end
+
+---@param bufnr integer
+---@return diffs.GeneratedBufferSource?, string?
+local function get_source_var(bufnr)
+  local raw = get_buf_var(bufnr, 'diffs_source')
+  if raw == nil then
+    return nil, nil
+  end
+
+  local ok, source = pcall(normalize_source, raw)
+  if not ok then
+    return nil, tostring(source)
+  end
+
+  return source, nil
+end
+
 ---@param bufnr integer
 local function set_generated_diff_buffer_options(bufnr)
   vim.api.nvim_set_option_value('buftype', 'nowrite', { buf = bufnr })
@@ -289,6 +364,7 @@ end
 ---@field lines string[]
 ---@field repo_root? string
 ---@field diff_spec? diffs.DiffSpec
+---@field source? diffs.GeneratedBufferSource
 ---@field vars? table<string, any>
 
 ---@param opts diffs.GeneratedDiffBufferOpts
@@ -305,6 +381,9 @@ local function create_generated_diff_buffer(opts)
   end
   if opts.repo_root then
     vim.api.nvim_buf_set_var(bufnr, 'diffs_repo_root', opts.repo_root)
+  end
+  if opts.source then
+    vim.api.nvim_buf_set_var(bufnr, 'diffs_source', opts.source)
   end
   for name, value in pairs(opts.vars or {}) do
     if value ~= nil then
@@ -389,6 +468,71 @@ local function review_deps()
   }
 end
 
+---@param repo_root string
+---@param section "staged"|"unstaged"
+---@return string[]
+local function render_section_source(repo_root, section)
+  local cmd = { 'git', '-C', repo_root, 'diff', '--no-ext-diff', '--no-color' }
+  if section == 'staged' then
+    table.insert(cmd, '--cached')
+  end
+
+  local diff_lines = vim.fn.systemlist(cmd)
+  if vim.v.shell_error ~= 0 then
+    diff_lines = {}
+  end
+
+  return replace_combined_diffs(diff_lines, repo_root)
+end
+
+---@param source diffs.GeneratedBufferSource
+---@return string[]?, diffs.DiffSpec?, string?
+local function render_source(source)
+  if source.kind == 'file' then
+    local diff_lines, read_err = render.file(source.spec, source.repo_root, {
+      empty_on_missing = true,
+    })
+    if not diff_lines then
+      return nil, nil, read_err
+    end
+    return diff_lines, source.spec, diffspec.label(source.spec)
+  end
+
+  if source.kind == 'file_pair' then
+    local abs_path = source.repo_root .. '/' .. source.path
+    local old_abs_path = source.repo_root .. '/' .. source.old_path
+    local old_lines, new_lines
+    if source.edge == 'staged' then
+      old_lines = git.get_file_content('HEAD', old_abs_path) or {}
+      new_lines = git.get_index_content(abs_path) or {}
+    else
+      old_lines = git.get_index_content(old_abs_path)
+      if not old_lines then
+        old_lines = git.get_file_content('HEAD', old_abs_path) or {}
+      end
+      new_lines = git.get_working_content(abs_path) or {}
+    end
+    return render.unified_lines(old_lines, new_lines, source.old_path, source.path),
+      nil,
+      source.edge .. ':' .. source.path
+  end
+
+  if source.kind == 'section' then
+    return render_section_source(source.repo_root, source.section), nil, source.section .. ':all'
+  end
+
+  if source.kind == 'review' then
+    return review.reload_source(source, review_deps()), nil, 'review'
+  end
+
+  local abs_path = source.repo_root .. '/' .. source.path
+  local old_lines = git.get_file_content(':2', abs_path) or {}
+  local new_lines = git.get_file_content(':3', abs_path) or {}
+  return render.unified_lines(old_lines, new_lines, source.path, source.path),
+    nil,
+    'unmerged:' .. source.path
+end
+
 ---@param spec? diffs.GreviewSpec
 ---@return integer?
 function M.greview(spec)
@@ -459,6 +603,12 @@ function M.gdiff(args, vertical)
     lines = diff_lines,
     repo_root = repo_root,
     diff_spec = diff_spec,
+    source = {
+      version = 1,
+      kind = 'file',
+      repo_root = repo_root,
+      spec = diff_spec,
+    },
   })
   show_generated_diff_buffer(diff_buf, vertical)
   attach_generated_diff_buffer(diff_buf)
@@ -546,11 +696,39 @@ function M.gdiff_file(filepath, opts)
     return
   end
 
+  local source
+  if diff_spec then
+    source = {
+      version = 1,
+      kind = 'file',
+      repo_root = repo_root,
+      spec = diff_spec,
+    }
+  elseif opts.unmerged then
+    source = {
+      version = 1,
+      kind = 'unmerged',
+      repo_root = repo_root,
+      path = rel_path,
+      working_path = filepath,
+    }
+  else
+    source = {
+      version = 1,
+      kind = 'file_pair',
+      repo_root = repo_root,
+      edge = diff_label,
+      path = rel_path,
+      old_path = old_rel_path,
+    }
+  end
+
   local diff_buf = create_generated_diff_buffer({
     name = 'diffs://' .. diff_label .. ':' .. rel_path,
     lines = diff_lines,
     repo_root = repo_root,
     diff_spec = diff_spec,
+    source = source,
     vars = {
       diffs_old_filepath = old_rel_path ~= rel_path and old_rel_path or nil,
     },
@@ -609,6 +787,12 @@ function M.gdiff_section(repo_root, opts)
     name = 'diffs://' .. diff_label .. ':all',
     lines = result,
     repo_root = repo_root,
+    source = {
+      version = 1,
+      kind = 'section',
+      repo_root = repo_root,
+      section = diff_label,
+    },
   })
   show_generated_diff_buffer(diff_buf, opts.vertical)
   attach_generated_diff_buffer(diff_buf)
@@ -623,85 +807,97 @@ function M.read_buffer(bufnr)
     return
   end
 
-  local repo_root = get_buf_var(bufnr, 'diffs_repo_root')
+  local source, source_err = get_source_var(bufnr)
+  if source_err then
+    notify('invalid diffs_source metadata: ' .. tostring(source_err), vim.log.levels.WARN)
+    return
+  end
+
+  local repo_root = source and source.repo_root or get_buf_var(bufnr, 'diffs_repo_root')
   if not repo_root then
     notify('cannot reload diffs:// buffer without diffs_repo_root', vim.log.levels.WARN)
     return
   end
 
   local diff_lines
-  local stored_spec, spec_err = get_diff_spec_var(bufnr)
-  if spec_err then
-    notify('invalid diffs_spec metadata: ' .. tostring(spec_err), vim.log.levels.WARN)
-    return
-  end
-
+  local stored_spec
+  local debug_label
   local label, path
-  if stored_spec then
-    local read_err
-    diff_lines, read_err = render.file(stored_spec, repo_root, { empty_on_missing = true })
+
+  if source then
+    local render_err
+    diff_lines, stored_spec, render_err = render_source(source)
     if not diff_lines then
-      notify(read_err, vim.log.levels.WARN)
+      notify(render_err or 'cannot reload diffs:// buffer', vim.log.levels.WARN)
       return
     end
+    debug_label = render_err
   else
-    label, path = url_body:match('^([^:]+):(.+)$')
-    if not label or not path then
-      notify('cannot reload malformed diffs:// buffer: ' .. name, vim.log.levels.WARN)
+    local spec_err
+    stored_spec, spec_err = get_diff_spec_var(bufnr)
+    if spec_err then
+      notify('invalid diffs_spec metadata: ' .. tostring(spec_err), vim.log.levels.WARN)
       return
     end
-  end
 
-  if not stored_spec and path == 'all' then
-    local cmd = { 'git', '-C', repo_root, 'diff', '--no-ext-diff', '--no-color' }
-    if label == 'staged' then
-      table.insert(cmd, '--cached')
-    end
-    diff_lines = vim.fn.systemlist(cmd)
-    if vim.v.shell_error ~= 0 then
-      diff_lines = {}
-    end
-
-    diff_lines = replace_combined_diffs(diff_lines, repo_root)
-  elseif not stored_spec and label == 'review' then
-    diff_lines = review.reload(bufnr, repo_root, path, review_deps())
-  elseif not stored_spec then
-    local abs_path = repo_root .. '/' .. path
-
-    local old_ok, old_rel_path = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_old_filepath')
-    local old_abs_path = old_ok and old_rel_path and (repo_root .. '/' .. old_rel_path) or abs_path
-    local old_name = old_ok and old_rel_path or path
-
-    local old_lines, new_lines
-
-    if label == 'unmerged' then
-      old_lines = git.get_file_content(':2', abs_path) or {}
-      new_lines = git.get_file_content(':3', abs_path) or {}
-    elseif label == 'untracked' then
-      old_lines = {}
-      new_lines = git.get_working_content(abs_path) or {}
-    elseif label == 'staged' then
-      old_lines = git.get_file_content('HEAD', old_abs_path) or {}
-      new_lines = git.get_index_content(abs_path) or {}
-    elseif label == 'unstaged' then
-      old_lines = git.get_index_content(old_abs_path)
-      if not old_lines then
-        old_lines = git.get_file_content('HEAD', old_abs_path) or {}
+    if stored_spec then
+      local read_err
+      diff_lines, read_err = render.file(stored_spec, repo_root, { empty_on_missing = true })
+      if not diff_lines then
+        notify(read_err, vim.log.levels.WARN)
+        return
       end
-      new_lines = git.get_working_content(abs_path) or {}
+      debug_label = diffspec.label(stored_spec)
     else
-      old_lines = git.get_file_content(label, abs_path) or {}
-      new_lines = git.get_working_content(abs_path) or {}
+      label, path = url_body:match('^([^:]+):(.+)$')
+      if not label or not path then
+        notify('cannot reload malformed diffs:// buffer: ' .. name, vim.log.levels.WARN)
+        return
+      end
     end
 
-    diff_lines = render.unified_lines(old_lines, new_lines, old_name, path)
+    if not stored_spec and path == 'all' then
+      diff_lines = render_section_source(repo_root, label)
+    elseif not stored_spec and label == 'review' then
+      diff_lines = review.reload(bufnr, repo_root, path, review_deps())
+    elseif not stored_spec then
+      local abs_path = repo_root .. '/' .. path
+
+      local old_ok, old_rel_path = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_old_filepath')
+      local old_abs_path = old_ok and old_rel_path and (repo_root .. '/' .. old_rel_path)
+        or abs_path
+      local old_name = old_ok and old_rel_path or path
+
+      local old_lines, new_lines
+
+      if label == 'unmerged' then
+        old_lines = git.get_file_content(':2', abs_path) or {}
+        new_lines = git.get_file_content(':3', abs_path) or {}
+      elseif label == 'untracked' then
+        old_lines = {}
+        new_lines = git.get_working_content(abs_path) or {}
+      elseif label == 'staged' then
+        old_lines = git.get_file_content('HEAD', old_abs_path) or {}
+        new_lines = git.get_index_content(abs_path) or {}
+      elseif label == 'unstaged' then
+        old_lines = git.get_index_content(old_abs_path)
+        if not old_lines then
+          old_lines = git.get_file_content('HEAD', old_abs_path) or {}
+        end
+        new_lines = git.get_working_content(abs_path) or {}
+      else
+        old_lines = git.get_file_content(label, abs_path) or {}
+        new_lines = git.get_working_content(abs_path) or {}
+      end
+
+      diff_lines = render.unified_lines(old_lines, new_lines, old_name, path)
+    end
+    debug_label = debug_label or ((label or '?') .. ':' .. (path or '?'))
   end
 
   replace_generated_diff_buffer_lines(bufnr, diff_lines, stored_spec)
   M.setup_diff_buf(bufnr)
 
-  local debug_label = stored_spec and diffspec.label(stored_spec)
-    or ((label or '?') .. ':' .. (path or '?'))
   dbg('reloaded diff buffer %d (%s)', bufnr, debug_label)
 
   runtime.attach(bufnr)

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -8,6 +8,7 @@ local git = require('diffs.git')
 local hunk_model = require('diffs.hunks')
 local log = require('diffs.log')
 local render = require('diffs.render')
+local review = require('diffs.review')
 local runtime = require('diffs.runtime')
 
 local dbg = log.dbg
@@ -378,6 +379,29 @@ local function replace_combined_diffs(raw_lines, repo_root)
   return result
 end
 
+---@return diffs.ReviewDeps
+local function review_deps()
+  return {
+    create_generated_diff_buffer = create_generated_diff_buffer,
+    show_generated_diff_buffer = show_generated_diff_buffer,
+    attach_generated_diff_buffer = attach_generated_diff_buffer,
+    replace_combined_diffs = replace_combined_diffs,
+  }
+end
+
+---@param spec? diffs.GreviewSpec
+---@return integer?
+function M.greview(spec)
+  return review.greview(spec, review_deps())
+end
+
+---@param buf integer
+---@param lnum integer
+---@return string?
+function M.review_file_at_line(buf, lnum)
+  return review.file_at_line(buf, lnum)
+end
+
 ---@param args? string
 ---@param vertical? boolean
 function M.gdiff(args, vertical)
@@ -591,423 +615,6 @@ function M.gdiff_section(repo_root, opts)
   dbg('opened section diff buffer %d (%s)', diff_buf, diff_label)
 end
 
--- selene: allow(global_usage)
-function _G._diffs_qftf(info)
-  local items = info.quickfix == 1 and vim.fn.getqflist({ id = info.id, items = 0 }).items
-    or vim.fn.getloclist(0, { id = info.id, items = 0 }).items
-  local max_lnum = 0
-  for i = info.start_idx, info.end_idx do
-    local e = items[i]
-    if e.lnum > 0 then
-      max_lnum = math.max(max_lnum, #tostring(e.lnum))
-    end
-  end
-  local lnum_fmt = '%' .. math.max(max_lnum, 1) .. 'd'
-  local lines = {}
-  for i = info.start_idx, info.end_idx do
-    local e = items[i]
-    local text = e.text or ''
-    if max_lnum > 0 and e.lnum > 0 then
-      table.insert(lines, ('%s  %s'):format(lnum_fmt:format(e.lnum), text))
-    else
-      table.insert(lines, text)
-    end
-  end
-  return lines
-end
-
----@class diffs.GreviewSpec
----@field base? string
----@field target? string
----@field repo? string
----@field mode? string
----@field vertical? boolean
-
----@class diffs.NormalizedGreview
----@field base string
----@field target string?
----@field repo_root string
----@field mode string?
----@field vertical boolean
----@field display string
----@field exec_args string[]
-
----@param repo? string
----@return string?
-local function resolve_repo_root(repo)
-  if repo and repo ~= '' then
-    return git.get_repo_root(repo .. '/.')
-  end
-
-  local bufnr = vim.api.nvim_get_current_buf()
-  local filepath = vim.api.nvim_buf_get_name(bufnr)
-  local repo_root = git.get_repo_root(filepath ~= '' and filepath or nil)
-  if repo_root then
-    return repo_root
-  end
-
-  local cwd = vim.fn.getcwd()
-  return git.get_repo_root(cwd .. '/.')
-end
-
----@param repo_root string
----@return string?
-local function default_branch(repo_root)
-  local ref =
-    vim.fn.systemlist({ 'git', '-C', repo_root, 'symbolic-ref', 'refs/remotes/origin/HEAD' })
-  if vim.v.shell_error ~= 0 or not ref[1] or ref[1] == '' then
-    return nil
-  end
-  return ref[1]:gsub('^refs/remotes/', '')
-end
-
----@param arg? string
----@return diffs.GreviewSpec?, string?
-local function parse_review_arg(arg)
-  if not arg or arg == '' then
-    return {}, nil
-  end
-
-  local base, target = arg:match('^(.-)%.%.%.(.+)$')
-  if base then
-    if base == '' or target == '' then
-      return nil, 'invalid review spec'
-    end
-    return { base = base, target = target, mode = 'merge-base' }, nil
-  end
-
-  base, target = arg:match('^(.-)%.%.(.+)$')
-  if base then
-    if base == '' or target == '' then
-      return nil, 'invalid review spec'
-    end
-    return { base = base, target = target, mode = 'direct' }, nil
-  end
-
-  return { base = arg }, nil
-end
-
----@param spec? diffs.GreviewSpec
----@param repo_root_override? string
----@return diffs.NormalizedGreview?, string?
-local function normalize_greview(spec, repo_root_override)
-  spec = spec or {}
-  if type(spec) ~= 'table' then
-    error('diffs: greview() expects a table spec')
-  end
-  if spec.base ~= nil and type(spec.base) ~= 'string' then
-    error('diffs: greview.base must be a string')
-  end
-  if spec.target ~= nil and type(spec.target) ~= 'string' then
-    error('diffs: greview.target must be a string')
-  end
-  if spec.repo ~= nil and type(spec.repo) ~= 'string' then
-    error('diffs: greview.repo must be a string')
-  end
-  if spec.mode ~= nil and type(spec.mode) ~= 'string' then
-    error('diffs: greview.mode must be a string')
-  end
-  if spec.vertical ~= nil and type(spec.vertical) ~= 'boolean' then
-    error('diffs: greview.vertical must be a boolean')
-  end
-
-  local repo_root = repo_root_override or resolve_repo_root(spec.repo)
-  if not repo_root then
-    return nil, 'not in a git repository'
-  end
-
-  local base = spec.base
-  if not base or base == '' then
-    base = default_branch(repo_root)
-    if not base then
-      return nil, 'cannot detect default branch (try: git remote set-head origin -a)'
-    end
-  end
-
-  local target = spec.target
-  if target == '' then
-    error('diffs: greview.target must be a non-empty string')
-  end
-
-  local mode = spec.mode
-  if target then
-    if mode == nil then
-      mode = 'merge-base'
-    elseif mode ~= 'merge-base' and mode ~= 'direct' then
-      error('diffs: greview.mode must be "merge-base" or "direct"')
-    end
-  elseif mode ~= nil then
-    error('diffs: greview.mode requires greview.target')
-  end
-
-  local display = base
-  local exec_args = { base }
-  if target then
-    if mode == 'merge-base' then
-      display = base .. '...' .. target
-      exec_args = { '--merge-base', base, target }
-    else
-      display = base .. '..' .. target
-      exec_args = { base, target }
-    end
-  end
-
-  return {
-    base = base,
-    target = target,
-    repo_root = repo_root,
-    mode = mode,
-    vertical = spec.vertical or false,
-    display = display,
-    exec_args = exec_args,
-  },
-    nil
-end
-
----@param review diffs.NormalizedGreview
----@return string[]
-local function build_review_cmd(review)
-  local cmd = { 'git', '-C', review.repo_root, 'diff', '--no-ext-diff', '--no-color' }
-  vim.list_extend(cmd, review.exec_args)
-  return cmd
-end
-
----@param review diffs.NormalizedGreview
----@return string
-local function review_buffer_name(review)
-  return 'diffs://review:' .. review.display
-end
-
----@param repo_root? string
----@return string[]
-local function list_refs(repo_root)
-  local cmd = { 'git' }
-  if repo_root then
-    table.insert(cmd, '-C')
-    table.insert(cmd, repo_root)
-  end
-  vim.list_extend(cmd, {
-    'for-each-ref',
-    '--format=%(refname:short)',
-    'refs/heads/',
-    'refs/remotes/',
-    'refs/tags/',
-  })
-  local refs = vim.fn.systemlist(cmd)
-  if vim.v.shell_error ~= 0 then
-    return {}
-  end
-  return refs
-end
-
----@param arglead string
----@return string[]
-local function complete_greview(arglead)
-  local refs = list_refs(resolve_repo_root(nil))
-  if arglead == '' then
-    return refs
-  end
-
-  local base, tail = arglead:match('^(.-)%.%.%.(.*)$')
-  if base then
-    if base == '' then
-      return {}
-    end
-    local matches = {}
-    for _, ref in ipairs(refs) do
-      if ref:find(tail, 1, true) == 1 then
-        table.insert(matches, base .. '...' .. ref)
-      end
-    end
-    return matches
-  end
-
-  base, tail = arglead:match('^(.-)%.%.(.*)$')
-  if base then
-    if base == '' then
-      return {}
-    end
-    local matches = {}
-    for _, ref in ipairs(refs) do
-      if ref:find(tail, 1, true) == 1 then
-        table.insert(matches, base .. '..' .. ref)
-      end
-    end
-    return matches
-  end
-
-  local matches = {}
-  for _, ref in ipairs(refs) do
-    if ref:find(arglead, 1, true) == 1 then
-      table.insert(matches, ref)
-    end
-  end
-  return matches
-end
-
----@param review diffs.NormalizedGreview
----@return string[]?, string?
-local function run_review(review)
-  local result = vim.fn.systemlist(build_review_cmd(review))
-  if vim.v.shell_error ~= 0 then
-    return nil, 'git diff failed'
-  end
-  return replace_combined_diffs(result, review.repo_root), nil
-end
-
----@param spec? diffs.GreviewSpec
----@return integer?
-function M.greview(spec)
-  local review, err = normalize_greview(spec)
-  if not review then
-    notify(err, vim.log.levels.ERROR)
-    return nil
-  end
-
-  local target_name = review_buffer_name(review)
-  local existing_buf = vim.fn.bufnr(target_name)
-  if existing_buf ~= -1 then
-    pcall(vim.api.nvim_buf_delete, existing_buf, { force = true })
-  end
-
-  local result, diff_err = run_review(review)
-  if not result then
-    notify(diff_err, vim.log.levels.ERROR)
-    return nil
-  end
-  if #result == 0 then
-    notify('no diff against ' .. review.display, vim.log.levels.INFO)
-    return nil
-  end
-
-  local diff_buf = create_generated_diff_buffer({
-    name = target_name,
-    lines = result,
-    repo_root = review.repo_root,
-    vars = {
-      diffs_review_base = review.base,
-      diffs_review_target = review.target,
-      diffs_review_mode = review.mode,
-    },
-  })
-
-  local qf_items = {}
-  local loc_items = {}
-  local current_file = nil
-  local file_adds, file_dels = {}, {}
-  local file_hunk_count = {}
-
-  for i, line in ipairs(result) do
-    local file = line:match('^diff %-%-git a/.+ b/(.+)$')
-    if file then
-      current_file = file
-      file_adds[file] = 0
-      file_dels[file] = 0
-      file_hunk_count[file] = 0
-      table.insert(qf_items, {
-        bufnr = diff_buf,
-        lnum = i,
-        text = file,
-      })
-    elseif current_file and line:match('^@@') then
-      file_hunk_count[current_file] = file_hunk_count[current_file] + 1
-      table.insert(loc_items, {
-        bufnr = diff_buf,
-        lnum = i,
-        text = current_file,
-        _hunk = file_hunk_count[current_file],
-        _header = line:match('^(@@.-@@)') or '',
-      })
-    elseif current_file then
-      local ch = line:sub(1, 1)
-      if ch == '+' and not line:match('^%+%+%+') then
-        file_adds[current_file] = file_adds[current_file] + 1
-      elseif ch == '-' and not line:match('^%-%-%-') then
-        file_dels[current_file] = file_dels[current_file] + 1
-      end
-    end
-  end
-
-  local max_fname = 0
-  local max_add, max_del = 0, 0
-  for _, item in ipairs(qf_items) do
-    max_fname = math.max(max_fname, #item.text)
-    local a = file_adds[item.text] or 0
-    local d = file_dels[item.text] or 0
-    if a > 0 then
-      max_add = math.max(max_add, #tostring(a) + 1)
-    end
-    if d > 0 then
-      max_del = math.max(max_del, #tostring(d) + 1)
-    end
-  end
-
-  for _, item in ipairs(qf_items) do
-    local file = item.text
-    local a = file_adds[file] or 0
-    local d = file_dels[file] or 0
-    local padded = file .. string.rep(' ', max_fname - #file)
-    local parts = { padded }
-    if max_add > 0 then
-      parts[#parts + 1] = a > 0 and string.format('%' .. max_add .. 's', '+' .. a)
-        or string.rep(' ', max_add)
-    end
-    if max_del > 0 then
-      parts[#parts + 1] = d > 0 and string.format('%' .. max_del .. 's', '-' .. d)
-        or string.rep(' ', max_del)
-    end
-    item.text = table.concat(parts, '  '):gsub('%s+$', '')
-  end
-
-  local max_loc_fname = 0
-  for _, item in ipairs(loc_items) do
-    max_loc_fname = math.max(max_loc_fname, #item.text)
-  end
-  for _, item in ipairs(loc_items) do
-    item.text = item.text
-      .. string.rep(' ', max_loc_fname - #item.text)
-      .. '  (hunk '
-      .. item._hunk
-      .. ') '
-      .. item._header
-    item._hunk = nil
-    item._header = nil
-  end
-
-  vim.fn.setqflist({}, ' ', {
-    title = 'review: ' .. review.display,
-    items = qf_items,
-    quickfixtextfunc = 'v:lua._diffs_qftf',
-  })
-
-  show_generated_diff_buffer(diff_buf, review.vertical)
-
-  vim.fn.setloclist(0, {}, ' ', {
-    title = 'review hunks: ' .. review.display,
-    items = loc_items,
-    quickfixtextfunc = 'v:lua._diffs_qftf',
-  })
-
-  attach_generated_diff_buffer(diff_buf)
-  dbg('opened review buffer %d (%s)', diff_buf, review.display)
-
-  return diff_buf
-end
-
----@param buf integer
----@param lnum integer
----@return string?
-function M.review_file_at_line(buf, lnum)
-  local lines = vim.api.nvim_buf_get_lines(buf, 0, lnum, false)
-  for i = #lines, 1, -1 do
-    local file = lines[i]:match('^diff %-%-git a/.+ b/(.+)$')
-    if file then
-      return file
-    end
-  end
-  return nil
-end
-
 ---@param bufnr integer
 function M.read_buffer(bufnr)
   local name = vim.api.nvim_buf_get_name(bufnr)
@@ -1057,36 +664,7 @@ function M.read_buffer(bufnr)
 
     diff_lines = replace_combined_diffs(diff_lines, repo_root)
   elseif not stored_spec and label == 'review' then
-    local stored_base = get_buf_var(bufnr, 'diffs_review_base')
-    local stored_target = get_buf_var(bufnr, 'diffs_review_target')
-    local stored_mode = get_buf_var(bufnr, 'diffs_review_mode')
-
-    local review_spec
-    if stored_base then
-      review_spec = {
-        base = stored_base,
-        target = stored_target,
-        mode = stored_mode,
-      }
-    else
-      review_spec = select(1, parse_review_arg(path))
-    end
-
-    if review_spec then
-      local review = select(1, normalize_greview(review_spec, repo_root))
-      if review then
-        diff_lines = vim.fn.systemlist(build_review_cmd(review))
-        if vim.v.shell_error ~= 0 then
-          diff_lines = {}
-        else
-          diff_lines = replace_combined_diffs(diff_lines, repo_root)
-        end
-      else
-        diff_lines = {}
-      end
-    else
-      diff_lines = {}
-    end
+    diff_lines = review.reload(bufnr, repo_root, path, review_deps())
   elseif not stored_spec then
     local abs_path = repo_root .. '/' .. path
 
@@ -1152,7 +730,7 @@ function M.setup()
   })
 
   vim.api.nvim_create_user_command('Greview', function(opts)
-    local spec, err = parse_review_arg(opts.args ~= '' and opts.args or nil)
+    local spec, err = review.parse_arg(opts.args ~= '' and opts.args or nil)
     if not spec then
       notify(err, vim.log.levels.ERROR)
       return
@@ -1160,16 +738,16 @@ function M.setup()
     M.greview(spec)
   end, {
     nargs = '?',
-    complete = complete_greview,
+    complete = review.complete,
     desc = 'Review the repo against the default branch or a git review spec',
   })
 end
 
 M._test = {
-  complete_greview = complete_greview,
+  complete_greview = review.complete,
   gdiff_buffer_label = gdiff_buffer_label,
-  normalize_greview = normalize_greview,
-  parse_review_arg = parse_review_arg,
+  normalize_greview = review.normalize,
+  parse_review_arg = review.parse_arg,
 }
 
 return M

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -408,6 +408,16 @@ function M.greview(spec, deps)
     name = target_name,
     lines = result,
     repo_root = review.repo_root,
+    source = {
+      version = 1,
+      kind = 'review',
+      repo_root = review.repo_root,
+      review = {
+        base = review.base,
+        target = review.target,
+        mode = review.mode,
+      },
+    },
     vars = {
       diffs_review_base = review.base,
       diffs_review_target = review.target,
@@ -448,6 +458,19 @@ function M.file_at_line(buf, lnum)
     end
   end
   return nil
+end
+
+---@param source diffs.GeneratedBufferSource
+---@param deps diffs.ReviewDeps
+---@return string[]
+function M.reload_source(source, deps)
+  local normalized = select(1, M.normalize(source.review, source.repo_root))
+  if normalized then
+    local result = select(1, M.run(normalized, deps))
+    return result or {}
+  end
+
+  return {}
 end
 
 ---@param bufnr integer

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -1,0 +1,485 @@
+local M = {}
+
+local git = require('diffs.git')
+local log = require('diffs.log')
+
+local dbg = log.dbg
+local notify = log.notify
+
+---@class diffs.GreviewSpec
+---@field base? string
+---@field target? string
+---@field repo? string
+---@field mode? string
+---@field vertical? boolean
+
+---@class diffs.NormalizedGreview
+---@field base string
+---@field target string?
+---@field repo_root string
+---@field mode string?
+---@field vertical boolean
+---@field display string
+---@field exec_args string[]
+
+---@class diffs.ReviewDeps
+---@field create_generated_diff_buffer fun(opts: diffs.GeneratedDiffBufferOpts): integer
+---@field show_generated_diff_buffer fun(bufnr: integer, vertical?: boolean)
+---@field attach_generated_diff_buffer fun(bufnr: integer)
+---@field replace_combined_diffs fun(lines: string[], repo_root: string): string[]
+
+---@param bufnr integer
+---@param name string
+---@return any
+local function get_buf_var(bufnr, name)
+  local ok, value = pcall(vim.api.nvim_buf_get_var, bufnr, name)
+  if ok then
+    return value
+  end
+  return nil
+end
+
+---@param repo? string
+---@return string?
+local function resolve_repo_root(repo)
+  if repo and repo ~= '' then
+    return git.get_repo_root(repo .. '/.')
+  end
+
+  local bufnr = vim.api.nvim_get_current_buf()
+  local filepath = vim.api.nvim_buf_get_name(bufnr)
+  local repo_root = git.get_repo_root(filepath ~= '' and filepath or nil)
+  if repo_root then
+    return repo_root
+  end
+
+  local cwd = vim.fn.getcwd()
+  return git.get_repo_root(cwd .. '/.')
+end
+
+---@param repo_root string
+---@return string?
+local function default_branch(repo_root)
+  local ref =
+    vim.fn.systemlist({ 'git', '-C', repo_root, 'symbolic-ref', 'refs/remotes/origin/HEAD' })
+  if vim.v.shell_error ~= 0 or not ref[1] or ref[1] == '' then
+    return nil
+  end
+  return ref[1]:gsub('^refs/remotes/', '')
+end
+
+---@param arg? string
+---@return diffs.GreviewSpec?, string?
+function M.parse_arg(arg)
+  if not arg or arg == '' then
+    return {}, nil
+  end
+
+  local base, target = arg:match('^(.-)%.%.%.(.+)$')
+  if base then
+    if base == '' or target == '' then
+      return nil, 'invalid review spec'
+    end
+    return { base = base, target = target, mode = 'merge-base' }, nil
+  end
+
+  base, target = arg:match('^(.-)%.%.(.+)$')
+  if base then
+    if base == '' or target == '' then
+      return nil, 'invalid review spec'
+    end
+    return { base = base, target = target, mode = 'direct' }, nil
+  end
+
+  return { base = arg }, nil
+end
+
+---@param spec? diffs.GreviewSpec
+---@param repo_root_override? string
+---@return diffs.NormalizedGreview?, string?
+function M.normalize(spec, repo_root_override)
+  spec = spec or {}
+  if type(spec) ~= 'table' then
+    error('diffs: greview() expects a table spec')
+  end
+  if spec.base ~= nil and type(spec.base) ~= 'string' then
+    error('diffs: greview.base must be a string')
+  end
+  if spec.target ~= nil and type(spec.target) ~= 'string' then
+    error('diffs: greview.target must be a string')
+  end
+  if spec.repo ~= nil and type(spec.repo) ~= 'string' then
+    error('diffs: greview.repo must be a string')
+  end
+  if spec.mode ~= nil and type(spec.mode) ~= 'string' then
+    error('diffs: greview.mode must be a string')
+  end
+  if spec.vertical ~= nil and type(spec.vertical) ~= 'boolean' then
+    error('diffs: greview.vertical must be a boolean')
+  end
+
+  local repo_root = repo_root_override or resolve_repo_root(spec.repo)
+  if not repo_root then
+    return nil, 'not in a git repository'
+  end
+
+  local base = spec.base
+  if not base or base == '' then
+    base = default_branch(repo_root)
+    if not base then
+      return nil, 'cannot detect default branch (try: git remote set-head origin -a)'
+    end
+  end
+
+  local target = spec.target
+  if target == '' then
+    error('diffs: greview.target must be a non-empty string')
+  end
+
+  local mode = spec.mode
+  if target then
+    if mode == nil then
+      mode = 'merge-base'
+    elseif mode ~= 'merge-base' and mode ~= 'direct' then
+      error('diffs: greview.mode must be "merge-base" or "direct"')
+    end
+  elseif mode ~= nil then
+    error('diffs: greview.mode requires greview.target')
+  end
+
+  local display = base
+  local exec_args = { base }
+  if target then
+    if mode == 'merge-base' then
+      display = base .. '...' .. target
+      exec_args = { '--merge-base', base, target }
+    else
+      display = base .. '..' .. target
+      exec_args = { base, target }
+    end
+  end
+
+  return {
+    base = base,
+    target = target,
+    repo_root = repo_root,
+    mode = mode,
+    vertical = spec.vertical or false,
+    display = display,
+    exec_args = exec_args,
+  },
+    nil
+end
+
+---@param review diffs.NormalizedGreview
+---@return string[]
+function M.build_cmd(review)
+  local cmd = { 'git', '-C', review.repo_root, 'diff', '--no-ext-diff', '--no-color' }
+  vim.list_extend(cmd, review.exec_args)
+  return cmd
+end
+
+---@param review diffs.NormalizedGreview
+---@return string
+function M.buffer_name(review)
+  return 'diffs://review:' .. review.display
+end
+
+---@param repo_root? string
+---@return string[]
+local function list_refs(repo_root)
+  local cmd = { 'git' }
+  if repo_root then
+    table.insert(cmd, '-C')
+    table.insert(cmd, repo_root)
+  end
+  vim.list_extend(cmd, {
+    'for-each-ref',
+    '--format=%(refname:short)',
+    'refs/heads/',
+    'refs/remotes/',
+    'refs/tags/',
+  })
+  local refs = vim.fn.systemlist(cmd)
+  if vim.v.shell_error ~= 0 then
+    return {}
+  end
+  return refs
+end
+
+---@param arglead string
+---@return string[]
+function M.complete(arglead)
+  local refs = list_refs(resolve_repo_root(nil))
+  if arglead == '' then
+    return refs
+  end
+
+  local base, tail = arglead:match('^(.-)%.%.%.(.*)$')
+  if base then
+    if base == '' then
+      return {}
+    end
+    local matches = {}
+    for _, ref in ipairs(refs) do
+      if ref:find(tail, 1, true) == 1 then
+        table.insert(matches, base .. '...' .. ref)
+      end
+    end
+    return matches
+  end
+
+  base, tail = arglead:match('^(.-)%.%.(.*)$')
+  if base then
+    if base == '' then
+      return {}
+    end
+    local matches = {}
+    for _, ref in ipairs(refs) do
+      if ref:find(tail, 1, true) == 1 then
+        table.insert(matches, base .. '..' .. ref)
+      end
+    end
+    return matches
+  end
+
+  local matches = {}
+  for _, ref in ipairs(refs) do
+    if ref:find(arglead, 1, true) == 1 then
+      table.insert(matches, ref)
+    end
+  end
+  return matches
+end
+
+---@param review diffs.NormalizedGreview
+---@param deps diffs.ReviewDeps
+---@return string[]?, string?
+function M.run(review, deps)
+  local result = vim.fn.systemlist(M.build_cmd(review))
+  if vim.v.shell_error ~= 0 then
+    return nil, 'git diff failed'
+  end
+  return deps.replace_combined_diffs(result, review.repo_root), nil
+end
+
+-- selene: allow(global_usage)
+function _G._diffs_qftf(info)
+  local items = info.quickfix == 1 and vim.fn.getqflist({ id = info.id, items = 0 }).items
+    or vim.fn.getloclist(0, { id = info.id, items = 0 }).items
+  local max_lnum = 0
+  for i = info.start_idx, info.end_idx do
+    local e = items[i]
+    if e.lnum > 0 then
+      max_lnum = math.max(max_lnum, #tostring(e.lnum))
+    end
+  end
+  local lnum_fmt = '%' .. math.max(max_lnum, 1) .. 'd'
+  local lines = {}
+  for i = info.start_idx, info.end_idx do
+    local e = items[i]
+    local text = e.text or ''
+    if max_lnum > 0 and e.lnum > 0 then
+      table.insert(lines, ('%s  %s'):format(lnum_fmt:format(e.lnum), text))
+    else
+      table.insert(lines, text)
+    end
+  end
+  return lines
+end
+
+---@param diff_buf integer
+---@param result string[]
+---@return table[], table[]
+function M.list_items(diff_buf, result)
+  local qf_items = {}
+  local loc_items = {}
+  local current_file = nil
+  local file_adds, file_dels = {}, {}
+  local file_hunk_count = {}
+
+  for i, line in ipairs(result) do
+    local file = line:match('^diff %-%-git a/.+ b/(.+)$')
+    if file then
+      current_file = file
+      file_adds[file] = 0
+      file_dels[file] = 0
+      file_hunk_count[file] = 0
+      table.insert(qf_items, {
+        bufnr = diff_buf,
+        lnum = i,
+        text = file,
+      })
+    elseif current_file and line:match('^@@') then
+      file_hunk_count[current_file] = file_hunk_count[current_file] + 1
+      table.insert(loc_items, {
+        bufnr = diff_buf,
+        lnum = i,
+        text = current_file,
+        _hunk = file_hunk_count[current_file],
+        _header = line:match('^(@@.-@@)') or '',
+      })
+    elseif current_file then
+      local ch = line:sub(1, 1)
+      if ch == '+' and not line:match('^%+%+%+') then
+        file_adds[current_file] = file_adds[current_file] + 1
+      elseif ch == '-' and not line:match('^%-%-%-') then
+        file_dels[current_file] = file_dels[current_file] + 1
+      end
+    end
+  end
+
+  local max_fname = 0
+  local max_add, max_del = 0, 0
+  for _, item in ipairs(qf_items) do
+    max_fname = math.max(max_fname, #item.text)
+    local a = file_adds[item.text] or 0
+    local d = file_dels[item.text] or 0
+    if a > 0 then
+      max_add = math.max(max_add, #tostring(a) + 1)
+    end
+    if d > 0 then
+      max_del = math.max(max_del, #tostring(d) + 1)
+    end
+  end
+
+  for _, item in ipairs(qf_items) do
+    local file = item.text
+    local a = file_adds[file] or 0
+    local d = file_dels[file] or 0
+    local padded = file .. string.rep(' ', max_fname - #file)
+    local parts = { padded }
+    if max_add > 0 then
+      parts[#parts + 1] = a > 0 and string.format('%' .. max_add .. 's', '+' .. a)
+        or string.rep(' ', max_add)
+    end
+    if max_del > 0 then
+      parts[#parts + 1] = d > 0 and string.format('%' .. max_del .. 's', '-' .. d)
+        or string.rep(' ', max_del)
+    end
+    item.text = table.concat(parts, '  '):gsub('%s+$', '')
+  end
+
+  local max_loc_fname = 0
+  for _, item in ipairs(loc_items) do
+    max_loc_fname = math.max(max_loc_fname, #item.text)
+  end
+  for _, item in ipairs(loc_items) do
+    item.text = item.text
+      .. string.rep(' ', max_loc_fname - #item.text)
+      .. '  (hunk '
+      .. item._hunk
+      .. ') '
+      .. item._header
+    item._hunk = nil
+    item._header = nil
+  end
+
+  return qf_items, loc_items
+end
+
+---@param spec? diffs.GreviewSpec
+---@param deps diffs.ReviewDeps
+---@return integer?
+function M.greview(spec, deps)
+  local review, err = M.normalize(spec)
+  if not review then
+    notify(err, vim.log.levels.ERROR)
+    return nil
+  end
+
+  local target_name = M.buffer_name(review)
+  local existing_buf = vim.fn.bufnr(target_name)
+  if existing_buf ~= -1 then
+    pcall(vim.api.nvim_buf_delete, existing_buf, { force = true })
+  end
+
+  local result, diff_err = M.run(review, deps)
+  if not result then
+    notify(diff_err, vim.log.levels.ERROR)
+    return nil
+  end
+  if #result == 0 then
+    notify('no diff against ' .. review.display, vim.log.levels.INFO)
+    return nil
+  end
+
+  local diff_buf = deps.create_generated_diff_buffer({
+    name = target_name,
+    lines = result,
+    repo_root = review.repo_root,
+    vars = {
+      diffs_review_base = review.base,
+      diffs_review_target = review.target,
+      diffs_review_mode = review.mode,
+    },
+  })
+
+  local qf_items, loc_items = M.list_items(diff_buf, result)
+  vim.fn.setqflist({}, ' ', {
+    title = 'review: ' .. review.display,
+    items = qf_items,
+    quickfixtextfunc = 'v:lua._diffs_qftf',
+  })
+
+  deps.show_generated_diff_buffer(diff_buf, review.vertical)
+
+  vim.fn.setloclist(0, {}, ' ', {
+    title = 'review hunks: ' .. review.display,
+    items = loc_items,
+    quickfixtextfunc = 'v:lua._diffs_qftf',
+  })
+
+  deps.attach_generated_diff_buffer(diff_buf)
+  dbg('opened review buffer %d (%s)', diff_buf, review.display)
+
+  return diff_buf
+end
+
+---@param buf integer
+---@param lnum integer
+---@return string?
+function M.file_at_line(buf, lnum)
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, lnum, false)
+  for i = #lines, 1, -1 do
+    local file = lines[i]:match('^diff %-%-git a/.+ b/(.+)$')
+    if file then
+      return file
+    end
+  end
+  return nil
+end
+
+---@param bufnr integer
+---@param repo_root string
+---@param path string
+---@param deps diffs.ReviewDeps
+---@return string[]
+function M.reload(bufnr, repo_root, path, deps)
+  local stored_base = get_buf_var(bufnr, 'diffs_review_base')
+  local stored_target = get_buf_var(bufnr, 'diffs_review_target')
+  local stored_mode = get_buf_var(bufnr, 'diffs_review_mode')
+
+  local review_spec
+  if stored_base then
+    review_spec = {
+      base = stored_base,
+      target = stored_target,
+      mode = stored_mode,
+    }
+  else
+    review_spec = select(1, M.parse_arg(path))
+  end
+
+  if review_spec then
+    local normalized = select(1, M.normalize(review_spec, repo_root))
+    if normalized then
+      local result = select(1, M.run(normalized, deps))
+      return result or {}
+    end
+  end
+
+  return {}
+end
+
+return M

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -692,6 +692,309 @@ describe('commands', function()
     end)
   end)
 
+  describe('generated buffer lifecycle matrix', function()
+    local section_lines = {
+      'diff --git a/lua/section.lua b/lua/section.lua',
+      '--- a/lua/section.lua',
+      '+++ b/lua/section.lua',
+      '@@ -1 +1 @@',
+      '-old section',
+      '+new section',
+    }
+
+    local review_lines = {
+      'diff --git a/lua/review.lua b/lua/review.lua',
+      '--- a/lua/review.lua',
+      '+++ b/lua/review.lua',
+      '@@ -1 +1 @@',
+      '-old review',
+      '+new review',
+    }
+
+    local file_content = {
+      ['/tmp/repo/lua/unstaged.lua'] = {
+        index = { 'local M = {}', 'return M' },
+        worktree = { 'local M = {}', 'local unstaged = true', 'return M' },
+      },
+      ['/tmp/repo/lua/staged.lua'] = {
+        head = { 'local M = {}', 'return M' },
+        index = { 'local M = {}', 'local staged = true', 'return M' },
+      },
+      ['/tmp/repo/lua/new.lua'] = {
+        worktree = { 'local M = {}', 'local new_file = true', 'return M' },
+      },
+    }
+
+    local function has_buf_var(bufnr, name)
+      local ok = pcall(vim.api.nvim_buf_get_var, bufnr, name)
+      return ok
+    end
+
+    local function contains_cmd_arg(cmd, arg)
+      for _, value in ipairs(cmd) do
+        if value == arg then
+          return true
+        end
+      end
+      return false
+    end
+
+    local function install_lifecycle_mocks()
+      mock_git_method('get_relative_path', function(filepath)
+        return filepath:match('^/tmp/repo/(.+)$')
+      end)
+      mock_repo_root(function()
+        return '/tmp/repo'
+      end)
+      mock_git_method('get_file_content', function(revision, filepath)
+        local entry = file_content[filepath]
+        if not entry or not entry.head then
+          return nil, 'file not in revision: ' .. revision
+        end
+        return entry.head
+      end)
+      mock_git_method('get_index_content', function(filepath)
+        local entry = file_content[filepath]
+        if not entry or not entry.index then
+          return nil, 'file not in index'
+        end
+        return entry.index
+      end)
+      mock_git_method('get_working_content', function(filepath)
+        local entry = file_content[filepath]
+        if not entry or not entry.worktree then
+          return nil, 'file not readable'
+        end
+        return entry.worktree
+      end)
+      mock_git_method('get_tree_mode', function()
+        return '100644'
+      end)
+      mock_git_method('get_index_mode', function(filepath)
+        local entry = file_content[filepath]
+        return entry and entry.index and '100644' or nil
+      end)
+      mock_git_method('get_working_mode', function(filepath)
+        local entry = file_content[filepath]
+        return entry and entry.worktree and '100644' or nil
+      end)
+      mock_systemlist(function(cmd)
+        if
+          contains_cmd_arg(cmd, '--name-status')
+          or contains_cmd_arg(cmd, '--numstat')
+          or contains_cmd_arg(cmd, '--raw')
+        then
+          return {}
+        end
+        if contains_cmd_arg(cmd, '--merge-base') then
+          return review_lines
+        end
+        return section_lines
+      end)
+      mock_runtime_attach(function() end)
+    end
+
+    local function set_stale_content(bufnr)
+      vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'stale lifecycle content' })
+      vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
+    end
+
+    local function assert_generated_options(bufnr)
+      assert.are.equal('nowrite', vim.api.nvim_get_option_value('buftype', { buf = bufnr }))
+      assert.are.equal('delete', vim.api.nvim_get_option_value('bufhidden', { buf = bufnr }))
+      assert.is_false(vim.api.nvim_get_option_value('swapfile', { buf = bufnr }))
+      assert.is_false(vim.api.nvim_get_option_value('modifiable', { buf = bufnr }))
+      assert.are.equal('diff', vim.api.nvim_get_option_value('filetype', { buf = bufnr }))
+    end
+
+    local function assert_no_hunk_maps(bufnr)
+      assert.is_false(helpers.has_keymap(bufnr, ']c'))
+      assert.is_false(helpers.has_keymap(bufnr, '[c'))
+      assert.is_false(helpers.has_keymap(bufnr, '<CR>'))
+      assert.is_false(helpers.has_keymap(bufnr, 'o'))
+      assert.is_false(helpers.has_keymap(bufnr, 'do'))
+      assert.is_false(helpers.has_keymap(bufnr, 'dp'))
+      assert.is_false(helpers.has_keymap(bufnr, 'do', 'x'))
+      assert.is_false(helpers.has_keymap(bufnr, 'dp', 'x'))
+    end
+
+    local function assert_hunk_maps(bufnr, hunk)
+      assert.is_true(helpers.has_keymap(bufnr, ']c'))
+      assert.is_true(helpers.has_keymap(bufnr, '[c'))
+      assert.is_true(helpers.has_keymap(bufnr, '<CR>'))
+      assert.is_true(helpers.has_keymap(bufnr, 'o'))
+      assert.are.equal(hunk.can_obtain, helpers.has_keymap(bufnr, 'do'))
+      assert.are.equal(hunk.can_put, helpers.has_keymap(bufnr, 'dp'))
+      assert.are.equal(hunk.can_obtain, helpers.has_keymap(bufnr, 'do', 'x'))
+      assert.are.equal(hunk.can_put, helpers.has_keymap(bufnr, 'dp', 'x'))
+    end
+
+    local function assert_lifecycle_state(bufnr, case)
+      assert.are.equal(case.buffer_name, vim.api.nvim_buf_get_name(bufnr))
+      assert.are.equal('/tmp/repo', vim.api.nvim_buf_get_var(bufnr, 'diffs_repo_root'))
+      assert_generated_options(bufnr)
+
+      if case.diff_spec then
+        assert.are.same(case.diff_spec, vim.api.nvim_buf_get_var(bufnr, 'diffs_spec'))
+      else
+        assert.is_false(has_buf_var(bufnr, 'diffs_spec'))
+      end
+
+      assert.are.same(case.source, vim.api.nvim_buf_get_var(bufnr, 'diffs_source'))
+
+      if case.review then
+        assert.are.equal(case.review.base, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_base'))
+        assert.are.equal(case.review.target, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_target'))
+        assert.are.equal(case.review.mode, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_mode'))
+      end
+
+      if case.hunk then
+        local diff_hunks = vim.api.nvim_buf_get_var(bufnr, 'diffs_hunks')
+        assert.are.equal(1, #diff_hunks)
+        assert.are.equal(case.hunk.file, diff_hunks[1].file)
+        assert.are.equal(case.hunk.mutation_target, diff_hunks[1].mutation_target)
+        assert.are.equal(case.hunk.can_put, diff_hunks[1].can_put)
+        assert.are.equal(case.hunk.can_obtain, diff_hunks[1].can_obtain)
+        assert.are.equal(case.hunk.can_put or case.hunk.can_obtain, diff_hunks[1].actionable)
+        assert_hunk_maps(bufnr, case.hunk)
+      else
+        assert.is_false(has_buf_var(bufnr, 'diffs_hunks'))
+        assert_no_hunk_maps(bufnr)
+      end
+
+      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      assert.are.equal(case.first_line, lines[1])
+      assert.is_false(vim.tbl_contains(lines, 'stale lifecycle content'))
+    end
+
+    it('preserves generated buffer metadata and action keymaps across reloads', function()
+      install_lifecycle_mocks()
+
+      local cases = {
+        {
+          label = 'unstaged file',
+          open = function()
+            commands.gdiff_file('/tmp/repo/lua/unstaged.lua')
+          end,
+          buffer_name = 'diffs://unstaged:lua/unstaged.lua',
+          diff_spec = diffspec.index_to_worktree('lua/unstaged.lua'),
+          source = {
+            version = 1,
+            kind = 'file',
+            repo_root = '/tmp/repo',
+            spec = diffspec.index_to_worktree('lua/unstaged.lua'),
+          },
+          hunk = {
+            file = 'lua/unstaged.lua',
+            mutation_target = 'worktree',
+            can_put = true,
+            can_obtain = false,
+          },
+          first_line = 'diff --git a/lua/unstaged.lua b/lua/unstaged.lua',
+        },
+        {
+          label = 'staged file',
+          open = function()
+            commands.gdiff_file('/tmp/repo/lua/staged.lua', { staged = true })
+          end,
+          buffer_name = 'diffs://staged:lua/staged.lua',
+          diff_spec = diffspec.head_to_index('lua/staged.lua'),
+          source = {
+            version = 1,
+            kind = 'file',
+            repo_root = '/tmp/repo',
+            spec = diffspec.head_to_index('lua/staged.lua'),
+          },
+          hunk = {
+            file = 'lua/staged.lua',
+            mutation_target = 'index',
+            can_put = false,
+            can_obtain = true,
+          },
+          first_line = 'diff --git a/lua/staged.lua b/lua/staged.lua',
+        },
+        {
+          label = 'untracked file',
+          open = function()
+            commands.gdiff_file('/tmp/repo/lua/new.lua', { untracked = true })
+          end,
+          buffer_name = 'diffs://untracked:lua/new.lua',
+          diff_spec = diffspec.index_to_worktree('lua/new.lua'),
+          source = {
+            version = 1,
+            kind = 'file',
+            repo_root = '/tmp/repo',
+            spec = diffspec.index_to_worktree('lua/new.lua'),
+          },
+          hunk = {
+            file = 'lua/new.lua',
+            mutation_target = 'worktree',
+            can_put = true,
+            can_obtain = false,
+          },
+          first_line = 'diff --git a/lua/new.lua b/lua/new.lua',
+        },
+        {
+          label = 'unstaged section',
+          open = function()
+            commands.gdiff_section('/tmp/repo')
+          end,
+          buffer_name = 'diffs://unstaged:all',
+          source = {
+            version = 1,
+            kind = 'section',
+            repo_root = '/tmp/repo',
+            section = 'unstaged',
+          },
+          first_line = 'diff --git a/lua/section.lua b/lua/section.lua',
+        },
+        {
+          label = 'review',
+          open = function()
+            commands.greview({
+              base = 'origin/main',
+              target = 'refs/forge/pr/42',
+              mode = 'merge-base',
+              repo = '/tmp/repo',
+            })
+          end,
+          buffer_name = 'diffs://review:origin/main...refs/forge/pr/42',
+          source = {
+            version = 1,
+            kind = 'review',
+            repo_root = '/tmp/repo',
+            review = {
+              base = 'origin/main',
+              target = 'refs/forge/pr/42',
+              mode = 'merge-base',
+            },
+          },
+          review = {
+            base = 'origin/main',
+            target = 'refs/forge/pr/42',
+            mode = 'merge-base',
+          },
+          first_line = 'diff --git a/lua/review.lua b/lua/review.lua',
+        },
+      }
+
+      for _, case in ipairs(cases) do
+        case.open()
+        local bufnr = vim.api.nvim_get_current_buf()
+        table.insert(test_buffers, bufnr)
+
+        assert_lifecycle_state(bufnr, case)
+        set_stale_content(bufnr)
+
+        assert.has_no.errors(function()
+          commands.read_buffer(bufnr)
+        end, case.label)
+        assert_lifecycle_state(bufnr, case)
+      end
+    end)
+  end)
+
   describe('setup registers Greview command', function()
     it('registers Greview command', function()
       commands.setup()

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -287,6 +287,46 @@ describe('read_buffer', function()
       assert.is_true(helpers.has_keymap(bufnr, 'dp'))
     end)
 
+    it('uses diffs_source metadata without parsing the display name', function()
+      local calls = {}
+      mock_git({
+        get_file_content = function(rev, filepath)
+          table.insert(calls, { 'file', rev, filepath })
+          return { 'tree' }
+        end,
+        get_index_content = function(filepath)
+          table.insert(calls, { 'index', filepath })
+          return { 'index' }
+        end,
+        get_working_content = function(filepath)
+          table.insert(calls, { 'worktree', filepath })
+          return { 'worktree' }
+        end,
+      })
+
+      local bufnr = create_diffs_buffer('diffs://metadata-only', {
+        diffs_repo_root = '/wrong',
+        diffs_source = {
+          version = 1,
+          kind = 'file',
+          repo_root = '/tmp',
+          spec = diffspec.index_to_worktree('source_meta.lua'),
+        },
+      })
+      commands.read_buffer(bufnr)
+
+      assert.are.same({
+        { 'index', '/tmp/source_meta.lua' },
+        { 'worktree', '/tmp/source_meta.lua' },
+      }, calls)
+      local diff_hunks = vim.api.nvim_buf_get_var(bufnr, 'diffs_hunks')
+      assert.are.equal(1, #diff_hunks)
+      assert.are.equal('source_meta.lua', diff_hunks[1].file)
+      assert.is_true(diff_hunks[1].can_put)
+      assert.is_false(diff_hunks[1].can_obtain)
+      assert.is_true(diff_hunks[1].actionable)
+    end)
+
     it('reloads untracked DiffSpec buffers with empty index content and hunk metadata', function()
       mock_git({
         get_index_content = function(filepath)
@@ -401,6 +441,29 @@ describe('read_buffer', function()
         { 'file', 'HEAD~3', '/tmp/meta_rev.lua' },
         { 'worktree', '/tmp/meta_rev.lua' },
       }, calls)
+    end)
+
+    it('warns and leaves content unchanged for invalid diffs_source metadata', function()
+      local notification
+      mock_notify(function(message, level)
+        notification = { message = message, level = level }
+      end)
+
+      local bufnr = create_diffs_buffer('diffs://unstaged:invalid_source.lua', {
+        diffs_source = {
+          version = 1,
+          kind = 'file',
+          repo_root = '/tmp',
+        },
+      })
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'stale content' })
+
+      commands.read_buffer(bufnr)
+
+      assert.is_not_nil(notification)
+      assert.are.equal(vim.log.levels.WARN, notification.level)
+      assert.is_true(notification.message:find('invalid diffs_source metadata', 1, true) ~= nil)
+      assert.are.same({ 'stale content' }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
     end)
 
     it('warns and leaves content unchanged for invalid diffs_spec metadata', function()


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #279.

## Solution

The solution moves Greview parsing, normalization, execution, completion, and qf/loclist construction into `lua/diffs/review.lua`; keeps `commands.lua` responsible for command registration, generated-buffer plumbing, and thin Greview shims; and stacks on #281 so the new module uses the centralized logger notification helper.
