### PR TITLE
Add generated Gdiff lifecycle matrix

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -274,6 +274,81 @@ local function get_diff_spec_var(bufnr)
   return parsed, nil
 end
 
+---@class diffs.GeneratedBufferSource
+---@field version integer
+---@field kind "file"|"file_pair"|"section"|"review"|"unmerged"
+---@field repo_root string
+---@field spec? diffs.DiffSpec
+---@field edge? "staged"|"unstaged"
+---@field path? string
+---@field old_path? string
+---@field section? "staged"|"unstaged"
+---@field review? diffs.GreviewSpec
+---@field working_path? string
+
+---@param source table
+---@return diffs.GeneratedBufferSource?
+local function normalize_source(source)
+  if type(source) ~= 'table' then
+    error('expected table')
+  end
+  if source.version ~= 1 then
+    error('expected version 1')
+  end
+  if type(source.repo_root) ~= 'string' or source.repo_root == '' then
+    error('expected repo_root')
+  end
+
+  if source.kind == 'file' then
+    if source.spec == nil then
+      error('expected file spec')
+    end
+    source.spec = diffspec.new(source.spec)
+  elseif source.kind == 'file_pair' then
+    if source.edge ~= 'staged' and source.edge ~= 'unstaged' then
+      error('expected file_pair edge')
+    end
+    if type(source.path) ~= 'string' or source.path == '' then
+      error('expected file_pair path')
+    end
+    if type(source.old_path) ~= 'string' or source.old_path == '' then
+      error('expected file_pair old_path')
+    end
+  elseif source.kind == 'section' then
+    if source.section ~= 'staged' and source.section ~= 'unstaged' then
+      error('expected section')
+    end
+  elseif source.kind == 'review' then
+    if type(source.review) ~= 'table' then
+      error('expected review spec')
+    end
+  elseif source.kind == 'unmerged' then
+    if type(source.path) ~= 'string' or source.path == '' then
+      error('expected unmerged path')
+    end
+  else
+    error('unknown source kind')
+  end
+
+  return source
+end
+
+---@param bufnr integer
+---@return diffs.GeneratedBufferSource?, string?
+local function get_source_var(bufnr)
+  local raw = get_buf_var(bufnr, 'diffs_source')
+  if raw == nil then
+    return nil, nil
+  end
+
+  local ok, source = pcall(normalize_source, raw)
+  if not ok then
+    return nil, tostring(source)
+  end
+
+  return source, nil
+end
+
 ---@param bufnr integer
 local function set_generated_diff_buffer_options(bufnr)
   vim.api.nvim_set_option_value('buftype', 'nowrite', { buf = bufnr })
@@ -288,6 +363,7 @@ end
 ---@field lines string[]
 ---@field repo_root? string
 ---@field diff_spec? diffs.DiffSpec
+---@field source? diffs.GeneratedBufferSource
 ---@field vars? table<string, any>
 
 ---@param opts diffs.GeneratedDiffBufferOpts
@@ -304,6 +380,9 @@ local function create_generated_diff_buffer(opts)
   end
   if opts.repo_root then
     vim.api.nvim_buf_set_var(bufnr, 'diffs_repo_root', opts.repo_root)
+  end
+  if opts.source then
+    vim.api.nvim_buf_set_var(bufnr, 'diffs_source', opts.source)
   end
   for name, value in pairs(opts.vars or {}) do
     if value ~= nil then
@@ -388,6 +467,71 @@ local function review_deps()
   }
 end
 
+---@param repo_root string
+---@param section "staged"|"unstaged"
+---@return string[]
+local function render_section_source(repo_root, section)
+  local cmd = { 'git', '-C', repo_root, 'diff', '--no-ext-diff', '--no-color' }
+  if section == 'staged' then
+    table.insert(cmd, '--cached')
+  end
+
+  local diff_lines = vim.fn.systemlist(cmd)
+  if vim.v.shell_error ~= 0 then
+    diff_lines = {}
+  end
+
+  return replace_combined_diffs(diff_lines, repo_root)
+end
+
+---@param source diffs.GeneratedBufferSource
+---@return string[]?, diffs.DiffSpec?, string?
+local function render_source(source)
+  if source.kind == 'file' then
+    local diff_lines, read_err = render.file(source.spec, source.repo_root, {
+      empty_on_missing = true,
+    })
+    if not diff_lines then
+      return nil, nil, read_err
+    end
+    return diff_lines, source.spec, diffspec.label(source.spec)
+  end
+
+  if source.kind == 'file_pair' then
+    local abs_path = source.repo_root .. '/' .. source.path
+    local old_abs_path = source.repo_root .. '/' .. source.old_path
+    local old_lines, new_lines
+    if source.edge == 'staged' then
+      old_lines = git.get_file_content('HEAD', old_abs_path) or {}
+      new_lines = git.get_index_content(abs_path) or {}
+    else
+      old_lines = git.get_index_content(old_abs_path)
+      if not old_lines then
+        old_lines = git.get_file_content('HEAD', old_abs_path) or {}
+      end
+      new_lines = git.get_working_content(abs_path) or {}
+    end
+    return render.unified_lines(old_lines, new_lines, source.old_path, source.path),
+      nil,
+      source.edge .. ':' .. source.path
+  end
+
+  if source.kind == 'section' then
+    return render_section_source(source.repo_root, source.section), nil, source.section .. ':all'
+  end
+
+  if source.kind == 'review' then
+    return review.reload_source(source, review_deps()), nil, 'review'
+  end
+
+  local abs_path = source.repo_root .. '/' .. source.path
+  local old_lines = git.get_file_content(':2', abs_path) or {}
+  local new_lines = git.get_file_content(':3', abs_path) or {}
+  return render.unified_lines(old_lines, new_lines, source.path, source.path),
+    nil,
+    'unmerged:' .. source.path
+end
+
 ---@param spec? diffs.GreviewSpec
 ---@return integer?
 function M.greview(spec)
@@ -458,6 +602,12 @@ function M.gdiff(args, vertical)
     lines = diff_lines,
     repo_root = repo_root,
     diff_spec = diff_spec,
+    source = {
+      version = 1,
+      kind = 'file',
+      repo_root = repo_root,
+      spec = diff_spec,
+    },
   })
   show_generated_diff_buffer(diff_buf, vertical)
   attach_generated_diff_buffer(diff_buf)
@@ -545,11 +695,39 @@ function M.gdiff_file(filepath, opts)
     return
   end
 
+  local source
+  if diff_spec then
+    source = {
+      version = 1,
+      kind = 'file',
+      repo_root = repo_root,
+      spec = diff_spec,
+    }
+  elseif opts.unmerged then
+    source = {
+      version = 1,
+      kind = 'unmerged',
+      repo_root = repo_root,
+      path = rel_path,
+      working_path = filepath,
+    }
+  else
+    source = {
+      version = 1,
+      kind = 'file_pair',
+      repo_root = repo_root,
+      edge = diff_label,
+      path = rel_path,
+      old_path = old_rel_path,
+    }
+  end
+
   local diff_buf = create_generated_diff_buffer({
     name = 'diffs://' .. diff_label .. ':' .. rel_path,
     lines = diff_lines,
     repo_root = repo_root,
     diff_spec = diff_spec,
+    source = source,
     vars = {
       diffs_old_filepath = old_rel_path ~= rel_path and old_rel_path or nil,
     },
@@ -608,6 +786,12 @@ function M.gdiff_section(repo_root, opts)
     name = 'diffs://' .. diff_label .. ':all',
     lines = result,
     repo_root = repo_root,
+    source = {
+      version = 1,
+      kind = 'section',
+      repo_root = repo_root,
+      section = diff_label,
+    },
   })
   show_generated_diff_buffer(diff_buf, opts.vertical)
   attach_generated_diff_buffer(diff_buf)
@@ -622,85 +806,97 @@ function M.read_buffer(bufnr)
     return
   end
 
-  local repo_root = get_buf_var(bufnr, 'diffs_repo_root')
+  local source, source_err = get_source_var(bufnr)
+  if source_err then
+    notify('invalid diffs_source metadata: ' .. tostring(source_err), vim.log.levels.WARN)
+    return
+  end
+
+  local repo_root = source and source.repo_root or get_buf_var(bufnr, 'diffs_repo_root')
   if not repo_root then
     notify('cannot reload diffs:// buffer without diffs_repo_root', vim.log.levels.WARN)
     return
   end
 
   local diff_lines
-  local stored_spec, spec_err = get_diff_spec_var(bufnr)
-  if spec_err then
-    notify('invalid diffs_spec metadata: ' .. tostring(spec_err), vim.log.levels.WARN)
-    return
-  end
-
+  local stored_spec
+  local debug_label
   local label, path
-  if stored_spec then
-    local read_err
-    diff_lines, read_err = render.file(stored_spec, repo_root, { empty_on_missing = true })
+
+  if source then
+    local render_err
+    diff_lines, stored_spec, render_err = render_source(source)
     if not diff_lines then
-      notify(read_err, vim.log.levels.WARN)
+      notify(render_err or 'cannot reload diffs:// buffer', vim.log.levels.WARN)
       return
     end
+    debug_label = render_err
   else
-    label, path = url_body:match('^([^:]+):(.+)$')
-    if not label or not path then
-      notify('cannot reload malformed diffs:// buffer: ' .. name, vim.log.levels.WARN)
+    local spec_err
+    stored_spec, spec_err = get_diff_spec_var(bufnr)
+    if spec_err then
+      notify('invalid diffs_spec metadata: ' .. tostring(spec_err), vim.log.levels.WARN)
       return
     end
-  end
 
-  if not stored_spec and path == 'all' then
-    local cmd = { 'git', '-C', repo_root, 'diff', '--no-ext-diff', '--no-color' }
-    if label == 'staged' then
-      table.insert(cmd, '--cached')
-    end
-    diff_lines = vim.fn.systemlist(cmd)
-    if vim.v.shell_error ~= 0 then
-      diff_lines = {}
-    end
-
-    diff_lines = replace_combined_diffs(diff_lines, repo_root)
-  elseif not stored_spec and label == 'review' then
-    diff_lines = review.reload(bufnr, repo_root, path, review_deps())
-  elseif not stored_spec then
-    local abs_path = repo_root .. '/' .. path
-
-    local old_ok, old_rel_path = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_old_filepath')
-    local old_abs_path = old_ok and old_rel_path and (repo_root .. '/' .. old_rel_path) or abs_path
-    local old_name = old_ok and old_rel_path or path
-
-    local old_lines, new_lines
-
-    if label == 'unmerged' then
-      old_lines = git.get_file_content(':2', abs_path) or {}
-      new_lines = git.get_file_content(':3', abs_path) or {}
-    elseif label == 'untracked' then
-      old_lines = {}
-      new_lines = git.get_working_content(abs_path) or {}
-    elseif label == 'staged' then
-      old_lines = git.get_file_content('HEAD', old_abs_path) or {}
-      new_lines = git.get_index_content(abs_path) or {}
-    elseif label == 'unstaged' then
-      old_lines = git.get_index_content(old_abs_path)
-      if not old_lines then
-        old_lines = git.get_file_content('HEAD', old_abs_path) or {}
+    if stored_spec then
+      local read_err
+      diff_lines, read_err = render.file(stored_spec, repo_root, { empty_on_missing = true })
+      if not diff_lines then
+        notify(read_err, vim.log.levels.WARN)
+        return
       end
-      new_lines = git.get_working_content(abs_path) or {}
+      debug_label = diffspec.label(stored_spec)
     else
-      old_lines = git.get_file_content(label, abs_path) or {}
-      new_lines = git.get_working_content(abs_path) or {}
+      label, path = url_body:match('^([^:]+):(.+)$')
+      if not label or not path then
+        notify('cannot reload malformed diffs:// buffer: ' .. name, vim.log.levels.WARN)
+        return
+      end
     end
 
-    diff_lines = render.unified_lines(old_lines, new_lines, old_name, path)
+    if not stored_spec and path == 'all' then
+      diff_lines = render_section_source(repo_root, label)
+    elseif not stored_spec and label == 'review' then
+      diff_lines = review.reload(bufnr, repo_root, path, review_deps())
+    elseif not stored_spec then
+      local abs_path = repo_root .. '/' .. path
+
+      local old_ok, old_rel_path = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_old_filepath')
+      local old_abs_path = old_ok and old_rel_path and (repo_root .. '/' .. old_rel_path)
+        or abs_path
+      local old_name = old_ok and old_rel_path or path
+
+      local old_lines, new_lines
+
+      if label == 'unmerged' then
+        old_lines = git.get_file_content(':2', abs_path) or {}
+        new_lines = git.get_file_content(':3', abs_path) or {}
+      elseif label == 'untracked' then
+        old_lines = {}
+        new_lines = git.get_working_content(abs_path) or {}
+      elseif label == 'staged' then
+        old_lines = git.get_file_content('HEAD', old_abs_path) or {}
+        new_lines = git.get_index_content(abs_path) or {}
+      elseif label == 'unstaged' then
+        old_lines = git.get_index_content(old_abs_path)
+        if not old_lines then
+          old_lines = git.get_file_content('HEAD', old_abs_path) or {}
+        end
+        new_lines = git.get_working_content(abs_path) or {}
+      else
+        old_lines = git.get_file_content(label, abs_path) or {}
+        new_lines = git.get_working_content(abs_path) or {}
+      end
+
+      diff_lines = render.unified_lines(old_lines, new_lines, old_name, path)
+    end
+    debug_label = debug_label or ((label or '?') .. ':' .. (path or '?'))
   end
 
   replace_generated_diff_buffer_lines(bufnr, diff_lines, stored_spec)
   M.setup_diff_buf(bufnr)
 
-  local debug_label = stored_spec and diffspec.label(stored_spec)
-    or ((label or '?') .. ':' .. (path or '?'))
   dbg('reloaded diff buffer %d (%s)', bufnr, debug_label)
 
   runtime.attach(bufnr)

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -408,6 +408,16 @@ function M.greview(spec, deps)
     name = target_name,
     lines = result,
     repo_root = review.repo_root,
+    source = {
+      version = 1,
+      kind = 'review',
+      repo_root = review.repo_root,
+      review = {
+        base = review.base,
+        target = review.target,
+        mode = review.mode,
+      },
+    },
     vars = {
       diffs_review_base = review.base,
       diffs_review_target = review.target,
@@ -448,6 +458,19 @@ function M.file_at_line(buf, lnum)
     end
   end
   return nil
+end
+
+---@param source diffs.GeneratedBufferSource
+---@param deps diffs.ReviewDeps
+---@return string[]
+function M.reload_source(source, deps)
+  local normalized = select(1, M.normalize(source.review, source.repo_root))
+  if normalized then
+    local result = select(1, M.run(normalized, deps))
+    return result or {}
+  end
+
+  return {}
 end
 
 ---@param bufnr integer

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -557,6 +557,273 @@ describe('commands', function()
     end)
   end)
 
+  describe('generated buffer lifecycle matrix', function()
+    local section_lines = {
+      'diff --git a/lua/section.lua b/lua/section.lua',
+      '--- a/lua/section.lua',
+      '+++ b/lua/section.lua',
+      '@@ -1 +1 @@',
+      '-old section',
+      '+new section',
+    }
+
+    local review_lines = {
+      'diff --git a/lua/review.lua b/lua/review.lua',
+      '--- a/lua/review.lua',
+      '+++ b/lua/review.lua',
+      '@@ -1 +1 @@',
+      '-old review',
+      '+new review',
+    }
+
+    local file_content = {
+      ['/tmp/repo/lua/unstaged.lua'] = {
+        index = { 'local M = {}', 'return M' },
+        worktree = { 'local M = {}', 'local unstaged = true', 'return M' },
+      },
+      ['/tmp/repo/lua/staged.lua'] = {
+        head = { 'local M = {}', 'return M' },
+        index = { 'local M = {}', 'local staged = true', 'return M' },
+      },
+      ['/tmp/repo/lua/new.lua'] = {
+        worktree = { 'local M = {}', 'local new_file = true', 'return M' },
+      },
+    }
+
+    local function has_buf_var(bufnr, name)
+      local ok = pcall(vim.api.nvim_buf_get_var, bufnr, name)
+      return ok
+    end
+
+    local function contains_cmd_arg(cmd, arg)
+      for _, value in ipairs(cmd) do
+        if value == arg then
+          return true
+        end
+      end
+      return false
+    end
+
+    local function install_lifecycle_mocks()
+      mock_git_method('get_relative_path', function(filepath)
+        return filepath:match('^/tmp/repo/(.+)$')
+      end)
+      mock_repo_root(function()
+        return '/tmp/repo'
+      end)
+      mock_git_method('get_file_content', function(revision, filepath)
+        local entry = file_content[filepath]
+        if not entry or not entry.head then
+          return nil, 'file not in revision: ' .. revision
+        end
+        return entry.head
+      end)
+      mock_git_method('get_index_content', function(filepath)
+        local entry = file_content[filepath]
+        if not entry or not entry.index then
+          return nil, 'file not in index'
+        end
+        return entry.index
+      end)
+      mock_git_method('get_working_content', function(filepath)
+        local entry = file_content[filepath]
+        if not entry or not entry.worktree then
+          return nil, 'file not readable'
+        end
+        return entry.worktree
+      end)
+      mock_git_method('get_tree_mode', function()
+        return '100644'
+      end)
+      mock_git_method('get_index_mode', function(filepath)
+        local entry = file_content[filepath]
+        return entry and entry.index and '100644' or nil
+      end)
+      mock_git_method('get_working_mode', function(filepath)
+        local entry = file_content[filepath]
+        return entry and entry.worktree and '100644' or nil
+      end)
+      mock_systemlist(function(cmd)
+        if
+          contains_cmd_arg(cmd, '--name-status')
+          or contains_cmd_arg(cmd, '--numstat')
+          or contains_cmd_arg(cmd, '--raw')
+        then
+          return {}
+        end
+        if contains_cmd_arg(cmd, '--merge-base') then
+          return review_lines
+        end
+        return section_lines
+      end)
+      mock_runtime_attach(function() end)
+    end
+
+    local function set_stale_content(bufnr)
+      vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'stale lifecycle content' })
+      vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
+    end
+
+    local function assert_generated_options(bufnr)
+      assert.are.equal('nowrite', vim.api.nvim_get_option_value('buftype', { buf = bufnr }))
+      assert.are.equal('delete', vim.api.nvim_get_option_value('bufhidden', { buf = bufnr }))
+      assert.is_false(vim.api.nvim_get_option_value('swapfile', { buf = bufnr }))
+      assert.is_false(vim.api.nvim_get_option_value('modifiable', { buf = bufnr }))
+      assert.are.equal('diff', vim.api.nvim_get_option_value('filetype', { buf = bufnr }))
+    end
+
+    local function assert_no_hunk_maps(bufnr)
+      assert.is_false(helpers.has_keymap(bufnr, ']c'))
+      assert.is_false(helpers.has_keymap(bufnr, '[c'))
+      assert.is_false(helpers.has_keymap(bufnr, '<CR>'))
+      assert.is_false(helpers.has_keymap(bufnr, 'o'))
+      assert.is_false(helpers.has_keymap(bufnr, 'do'))
+      assert.is_false(helpers.has_keymap(bufnr, 'dp'))
+      assert.is_false(helpers.has_keymap(bufnr, 'do', 'x'))
+      assert.is_false(helpers.has_keymap(bufnr, 'dp', 'x'))
+    end
+
+    local function assert_hunk_maps(bufnr, hunk)
+      assert.is_true(helpers.has_keymap(bufnr, ']c'))
+      assert.is_true(helpers.has_keymap(bufnr, '[c'))
+      assert.is_true(helpers.has_keymap(bufnr, '<CR>'))
+      assert.is_true(helpers.has_keymap(bufnr, 'o'))
+      assert.are.equal(hunk.can_obtain, helpers.has_keymap(bufnr, 'do'))
+      assert.are.equal(hunk.can_put, helpers.has_keymap(bufnr, 'dp'))
+      assert.are.equal(hunk.can_obtain, helpers.has_keymap(bufnr, 'do', 'x'))
+      assert.are.equal(hunk.can_put, helpers.has_keymap(bufnr, 'dp', 'x'))
+    end
+
+    local function assert_lifecycle_state(bufnr, case)
+      assert.are.equal(case.buffer_name, vim.api.nvim_buf_get_name(bufnr))
+      assert.are.equal('/tmp/repo', vim.api.nvim_buf_get_var(bufnr, 'diffs_repo_root'))
+      assert_generated_options(bufnr)
+
+      if case.diff_spec then
+        assert.are.same(case.diff_spec, vim.api.nvim_buf_get_var(bufnr, 'diffs_spec'))
+      else
+        assert.is_false(has_buf_var(bufnr, 'diffs_spec'))
+      end
+
+      if case.review then
+        assert.are.equal(case.review.base, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_base'))
+        assert.are.equal(case.review.target, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_target'))
+        assert.are.equal(case.review.mode, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_mode'))
+      end
+
+      if case.hunk then
+        local diff_hunks = vim.api.nvim_buf_get_var(bufnr, 'diffs_hunks')
+        assert.are.equal(1, #diff_hunks)
+        assert.are.equal(case.hunk.file, diff_hunks[1].file)
+        assert.are.equal(case.hunk.mutation_target, diff_hunks[1].mutation_target)
+        assert.are.equal(case.hunk.can_put, diff_hunks[1].can_put)
+        assert.are.equal(case.hunk.can_obtain, diff_hunks[1].can_obtain)
+        assert.are.equal(case.hunk.can_put or case.hunk.can_obtain, diff_hunks[1].actionable)
+        assert_hunk_maps(bufnr, case.hunk)
+      else
+        assert.is_false(has_buf_var(bufnr, 'diffs_hunks'))
+        assert_no_hunk_maps(bufnr)
+      end
+
+      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      assert.are.equal(case.first_line, lines[1])
+      assert.is_false(vim.tbl_contains(lines, 'stale lifecycle content'))
+    end
+
+    it('preserves generated buffer metadata and action keymaps across reloads', function()
+      install_lifecycle_mocks()
+
+      local cases = {
+        {
+          label = 'unstaged file',
+          open = function()
+            commands.gdiff_file('/tmp/repo/lua/unstaged.lua')
+          end,
+          buffer_name = 'diffs://unstaged:lua/unstaged.lua',
+          diff_spec = diffspec.index_to_worktree('lua/unstaged.lua'),
+          hunk = {
+            file = 'lua/unstaged.lua',
+            mutation_target = 'worktree',
+            can_put = true,
+            can_obtain = false,
+          },
+          first_line = 'diff --git a/lua/unstaged.lua b/lua/unstaged.lua',
+        },
+        {
+          label = 'staged file',
+          open = function()
+            commands.gdiff_file('/tmp/repo/lua/staged.lua', { staged = true })
+          end,
+          buffer_name = 'diffs://staged:lua/staged.lua',
+          diff_spec = diffspec.head_to_index('lua/staged.lua'),
+          hunk = {
+            file = 'lua/staged.lua',
+            mutation_target = 'index',
+            can_put = false,
+            can_obtain = true,
+          },
+          first_line = 'diff --git a/lua/staged.lua b/lua/staged.lua',
+        },
+        {
+          label = 'untracked file',
+          open = function()
+            commands.gdiff_file('/tmp/repo/lua/new.lua', { untracked = true })
+          end,
+          buffer_name = 'diffs://untracked:lua/new.lua',
+          diff_spec = diffspec.index_to_worktree('lua/new.lua'),
+          hunk = {
+            file = 'lua/new.lua',
+            mutation_target = 'worktree',
+            can_put = true,
+            can_obtain = false,
+          },
+          first_line = 'diff --git a/lua/new.lua b/lua/new.lua',
+        },
+        {
+          label = 'unstaged section',
+          open = function()
+            commands.gdiff_section('/tmp/repo')
+          end,
+          buffer_name = 'diffs://unstaged:all',
+          first_line = 'diff --git a/lua/section.lua b/lua/section.lua',
+        },
+        {
+          label = 'review',
+          open = function()
+            commands.greview({
+              base = 'origin/main',
+              target = 'refs/forge/pr/42',
+              mode = 'merge-base',
+              repo = '/tmp/repo',
+            })
+          end,
+          buffer_name = 'diffs://review:origin/main...refs/forge/pr/42',
+          review = {
+            base = 'origin/main',
+            target = 'refs/forge/pr/42',
+            mode = 'merge-base',
+          },
+          first_line = 'diff --git a/lua/review.lua b/lua/review.lua',
+        },
+      }
+
+      for _, case in ipairs(cases) do
+        case.open()
+        local bufnr = vim.api.nvim_get_current_buf()
+        table.insert(test_buffers, bufnr)
+
+        assert_lifecycle_state(bufnr, case)
+        set_stale_content(bufnr)
+
+        assert.has_no.errors(function()
+          commands.read_buffer(bufnr)
+        end, case.label)
+        assert_lifecycle_state(bufnr, case)
+      end
+    end)
+  end)
+
   describe('setup registers Greview command', function()
     it('registers Greview command', function()
       commands.setup()

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -706,6 +706,8 @@ describe('commands', function()
         assert.is_false(has_buf_var(bufnr, 'diffs_spec'))
       end
 
+      assert.are.same(case.source, vim.api.nvim_buf_get_var(bufnr, 'diffs_source'))
+
       if case.review then
         assert.are.equal(case.review.base, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_base'))
         assert.are.equal(case.review.target, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_target'))
@@ -742,6 +744,12 @@ describe('commands', function()
           end,
           buffer_name = 'diffs://unstaged:lua/unstaged.lua',
           diff_spec = diffspec.index_to_worktree('lua/unstaged.lua'),
+          source = {
+            version = 1,
+            kind = 'file',
+            repo_root = '/tmp/repo',
+            spec = diffspec.index_to_worktree('lua/unstaged.lua'),
+          },
           hunk = {
             file = 'lua/unstaged.lua',
             mutation_target = 'worktree',
@@ -757,6 +765,12 @@ describe('commands', function()
           end,
           buffer_name = 'diffs://staged:lua/staged.lua',
           diff_spec = diffspec.head_to_index('lua/staged.lua'),
+          source = {
+            version = 1,
+            kind = 'file',
+            repo_root = '/tmp/repo',
+            spec = diffspec.head_to_index('lua/staged.lua'),
+          },
           hunk = {
             file = 'lua/staged.lua',
             mutation_target = 'index',
@@ -772,6 +786,12 @@ describe('commands', function()
           end,
           buffer_name = 'diffs://untracked:lua/new.lua',
           diff_spec = diffspec.index_to_worktree('lua/new.lua'),
+          source = {
+            version = 1,
+            kind = 'file',
+            repo_root = '/tmp/repo',
+            spec = diffspec.index_to_worktree('lua/new.lua'),
+          },
           hunk = {
             file = 'lua/new.lua',
             mutation_target = 'worktree',
@@ -786,6 +806,12 @@ describe('commands', function()
             commands.gdiff_section('/tmp/repo')
           end,
           buffer_name = 'diffs://unstaged:all',
+          source = {
+            version = 1,
+            kind = 'section',
+            repo_root = '/tmp/repo',
+            section = 'unstaged',
+          },
           first_line = 'diff --git a/lua/section.lua b/lua/section.lua',
         },
         {
@@ -799,6 +825,16 @@ describe('commands', function()
             })
           end,
           buffer_name = 'diffs://review:origin/main...refs/forge/pr/42',
+          source = {
+            version = 1,
+            kind = 'review',
+            repo_root = '/tmp/repo',
+            review = {
+              base = 'origin/main',
+              target = 'refs/forge/pr/42',
+              mode = 'merge-base',
+            },
+          },
           review = {
             base = 'origin/main',
             target = 'refs/forge/pr/42',

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -287,6 +287,46 @@ describe('read_buffer', function()
       assert.is_true(helpers.has_keymap(bufnr, 'dp'))
     end)
 
+    it('uses diffs_source metadata without parsing the display name', function()
+      local calls = {}
+      mock_git({
+        get_file_content = function(rev, filepath)
+          table.insert(calls, { 'file', rev, filepath })
+          return { 'tree' }
+        end,
+        get_index_content = function(filepath)
+          table.insert(calls, { 'index', filepath })
+          return { 'index' }
+        end,
+        get_working_content = function(filepath)
+          table.insert(calls, { 'worktree', filepath })
+          return { 'worktree' }
+        end,
+      })
+
+      local bufnr = create_diffs_buffer('diffs://metadata-only', {
+        diffs_repo_root = '/wrong',
+        diffs_source = {
+          version = 1,
+          kind = 'file',
+          repo_root = '/tmp',
+          spec = diffspec.index_to_worktree('source_meta.lua'),
+        },
+      })
+      commands.read_buffer(bufnr)
+
+      assert.are.same({
+        { 'index', '/tmp/source_meta.lua' },
+        { 'worktree', '/tmp/source_meta.lua' },
+      }, calls)
+      local diff_hunks = vim.api.nvim_buf_get_var(bufnr, 'diffs_hunks')
+      assert.are.equal(1, #diff_hunks)
+      assert.are.equal('source_meta.lua', diff_hunks[1].file)
+      assert.is_true(diff_hunks[1].can_put)
+      assert.is_false(diff_hunks[1].can_obtain)
+      assert.is_true(diff_hunks[1].actionable)
+    end)
+
     it('reloads untracked DiffSpec buffers with empty index content and hunk metadata', function()
       mock_git({
         get_index_content = function(filepath)
@@ -401,6 +441,29 @@ describe('read_buffer', function()
         { 'file', 'HEAD~3', '/tmp/meta_rev.lua' },
         { 'worktree', '/tmp/meta_rev.lua' },
       }, calls)
+    end)
+
+    it('warns and leaves content unchanged for invalid diffs_source metadata', function()
+      local notification
+      mock_notify(function(message, level)
+        notification = { message = message, level = level }
+      end)
+
+      local bufnr = create_diffs_buffer('diffs://unstaged:invalid_source.lua', {
+        diffs_source = {
+          version = 1,
+          kind = 'file',
+          repo_root = '/tmp',
+        },
+      })
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'stale content' })
+
+      commands.read_buffer(bufnr)
+
+      assert.is_not_nil(notification)
+      assert.are.equal(vim.log.levels.WARN, notification.level)
+      assert.is_true(notification.message:find('invalid diffs_source metadata', 1, true) ~= nil)
+      assert.are.same({ 'stale content' }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
     end)
 
     it('warns and leaves content unchanged for invalid diffs_spec metadata', function()


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This is related to #277.

## Solution

The solution adds a table-driven generated-buffer lifecycle matrix for Gdiff-related buffers.
