### PR TITLE
fix: normalize generated diff content lines

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local actions = require('diffs.actions')
+local content = require('diffs.content')
 local diffspec = require('diffs.spec')
 local gdiff_parser = require('diffs.gdiff')
 local git = require('diffs.git')
@@ -414,7 +415,7 @@ function M.gdiff(args, vertical)
   end
 
   local diff_lines, render_err = render.file(diff_spec, repo_root, {
-    worktree_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false),
+    worktree_lines = content.from_buffer(bufnr),
   })
   if not diff_lines then
     vim.notify('[diffs]: ' .. (render_err or 'unknown error'), vim.log.levels.ERROR)

--- a/lua/diffs/content.lua
+++ b/lua/diffs/content.lua
@@ -1,0 +1,86 @@
+local M = {}
+
+---@class diffs.ContentLines: string[]
+---@field _diffs_has_final_newline? boolean
+
+---@class diffs.ContentFromRawOpts
+---@field empty_is_empty? boolean
+
+---@param lines string[]
+---@param has_final_newline boolean?
+---@return diffs.ContentLines
+local function content_lines(lines, has_final_newline)
+  local result = {}
+  for i, line in ipairs(lines) do
+    result[i] = line
+  end
+  if has_final_newline then
+    result._diffs_has_final_newline = true
+  end
+  return result
+end
+
+---@param lines diffs.ContentLines|string[]?
+---@return boolean
+local function has_final_newline(lines)
+  return type(lines) == 'table' and lines._diffs_has_final_newline == true
+end
+
+---@param lines string[]
+---@param opts? diffs.ContentFromRawOpts
+---@return diffs.ContentLines
+function M.from_raw_lines(lines, opts)
+  opts = opts or {}
+  local result = {}
+  for i, line in ipairs(lines) do
+    result[i] = line
+  end
+
+  if opts.empty_is_empty and #result == 1 and result[1] == '' then
+    result = {}
+  end
+
+  local ends_with_final_newline = #result > 0 and result[#result] == ''
+  if ends_with_final_newline then
+    result[#result] = nil
+  end
+
+  return content_lines(result, ends_with_final_newline)
+end
+
+---@param bufnr integer
+---@param lines string[]
+---@return boolean
+local function buffer_has_final_newline(bufnr, lines)
+  if not vim.api.nvim_get_option_value('endofline', { buf = bufnr }) then
+    return false
+  end
+
+  if #lines == 1 and lines[1] == '' then
+    local byte_count = vim.api.nvim_buf_call(bufnr, function()
+      return vim.fn.wordcount().bytes
+    end)
+    return byte_count > 0
+  end
+
+  return true
+end
+
+---@param bufnr integer
+---@return diffs.ContentLines
+function M.from_buffer(bufnr)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  return content_lines(lines, buffer_has_final_newline(bufnr, lines))
+end
+
+---@param lines diffs.ContentLines|string[]
+---@return string
+function M.to_string(lines)
+  local text = table.concat(lines, '\n')
+  if has_final_newline(lines) then
+    text = text .. '\n'
+  end
+  return text
+end
+
+return M

--- a/lua/diffs/git.lua
+++ b/lua/diffs/git.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local content = require('diffs.content')
+
 local repo_root_cache = {}
 
 local function is_index_stage(revision)
@@ -33,7 +35,7 @@ end
 
 ---@param revision string
 ---@param filepath string
----@return string[]?, string?
+---@return diffs.ContentLines?, string?
 function M.get_file_content(revision, filepath)
   local repo_root = M.get_repo_root(filepath)
   if not repo_root then
@@ -54,7 +56,7 @@ function M.get_file_content(revision, filepath)
   if vim.v.shell_error ~= 0 then
     return nil, 'file not in revision: ' .. revision
   end
-  return result, nil
+  return content.from_raw_lines(result), nil
 end
 
 ---@param filepath string
@@ -68,7 +70,7 @@ function M.get_relative_path(filepath)
 end
 
 ---@param filepath string
----@return string[]?, string?
+---@return diffs.ContentLines?, string?
 function M.get_index_content(filepath)
   local repo_root = M.get_repo_root(filepath)
   if not repo_root then
@@ -84,17 +86,17 @@ function M.get_index_content(filepath)
   if vim.v.shell_error ~= 0 then
     return nil, 'file not in index'
   end
-  return result, nil
+  return content.from_raw_lines(result), nil
 end
 
 ---@param filepath string
----@return string[]?, string?
+---@return diffs.ContentLines?, string?
 function M.get_working_content(filepath)
   if vim.fn.filereadable(filepath) ~= 1 then
     return nil, 'file not readable'
   end
   local lines = vim.fn.readfile(filepath, 'b')
-  return lines, nil
+  return content.from_raw_lines(lines, { empty_is_empty = vim.fn.getfsize(filepath) == 0 }), nil
 end
 
 ---@param filepath string

--- a/lua/diffs/render.lua
+++ b/lua/diffs/render.lua
@@ -1,10 +1,11 @@
 local M = {}
 
+local content = require('diffs.content')
 local diffspec = require('diffs.spec')
 local git = require('diffs.git')
 
 ---@class diffs.RenderFileOpts
----@field worktree_lines? string[]
+---@field worktree_lines? diffs.ContentLines|string[]
 ---@field empty_on_missing? boolean
 ---@field old_path? string
 ---@field new_path? string
@@ -37,16 +38,16 @@ function M.has_binary_lines(lines)
   return false
 end
 
----@param old_lines string[]
----@param new_lines string[]
+---@param old_lines diffs.ContentLines|string[]
+---@param new_lines diffs.ContentLines|string[]
 ---@param old_name string
 ---@param new_name string
 ---@param opts? diffs.UnifiedLinesOpts
 ---@return string[]
 function M.unified_lines(old_lines, new_lines, old_name, new_name, opts)
   opts = opts or {}
-  local old_content = table.concat(old_lines, '\n')
-  local new_content = table.concat(new_lines, '\n')
+  local old_content = content.to_string(old_lines)
+  local new_content = content.to_string(new_lines)
 
   local diff_fn = vim.text and vim.text.diff or vim.diff
   local diff_output = diff_fn(old_content, new_content, {
@@ -118,7 +119,7 @@ end
 ---@param endpoint diffs.Endpoint
 ---@param filepath string
 ---@param opts? diffs.RenderFileOpts
----@return string[]?, string?, boolean
+---@return diffs.ContentLines|string[]?, string?, boolean
 function M.read_endpoint(endpoint, filepath, opts)
   endpoint = diffspec.endpoint(endpoint)
   opts = opts or {}

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -9,7 +9,9 @@ local saved_git = {}
 local saved_runtime_attach
 local saved_schedule
 local saved_systemlist
+local saved_notify
 local test_buffers = {}
+local test_repos = {}
 
 local function mock_repo_root(fn)
   saved_git.get_repo_root = git.get_repo_root
@@ -39,6 +41,49 @@ local function mock_runtime_attach(fn)
   end
 end
 
+local function capture_notifications()
+  local notifications = {}
+  saved_notify = vim.notify
+  vim.notify = function(message, level)
+    notifications[#notifications + 1] = { message = message, level = level }
+  end
+  return notifications
+end
+
+local function git_cmd(repo_root, args)
+  local cmd = { 'git', '-C', repo_root }
+  for _, arg in ipairs(args) do
+    cmd[#cmd + 1] = arg
+  end
+  local output = vim.fn.systemlist(cmd)
+  assert.are.equal(0, vim.v.shell_error, table.concat(output, '\n'))
+  return output
+end
+
+local function create_repo()
+  local repo_root = vim.fn.tempname()
+  vim.fn.mkdir(repo_root, 'p')
+  test_repos[#test_repos + 1] = repo_root
+
+  vim.fn.systemlist({ 'git', 'init', '-q', repo_root })
+  assert.are.equal(0, vim.v.shell_error)
+  git_cmd(repo_root, { 'config', 'user.email', 'test@example.com' })
+  git_cmd(repo_root, { 'config', 'user.name', 'Test' })
+  git_cmd(repo_root, { 'config', 'core.filemode', 'true' })
+  vim.fn.writefile({ 'line 1', 'line 2' }, repo_root .. '/file.txt')
+  git_cmd(repo_root, { 'add', 'file.txt' })
+  git_cmd(repo_root, { 'commit', '-qm', 'initial' })
+
+  return repo_root
+end
+
+local function edit_file(path)
+  vim.cmd('edit ' .. vim.fn.fnameescape(path))
+  local bufnr = vim.api.nvim_get_current_buf()
+  test_buffers[#test_buffers + 1] = bufnr
+  return bufnr
+end
+
 local function restore_mocks()
   for k, v in pairs(saved_git) do
     git[k] = v
@@ -56,6 +101,10 @@ local function restore_mocks()
     vim.fn.systemlist = saved_systemlist
     saved_systemlist = nil
   end
+  if saved_notify then
+    vim.notify = saved_notify
+    saved_notify = nil
+  end
 end
 
 local function cleanup_buffers()
@@ -67,10 +116,18 @@ local function cleanup_buffers()
   test_buffers = {}
 end
 
+local function cleanup_repos()
+  for _, repo_root in ipairs(test_repos) do
+    vim.fn.delete(repo_root, 'rf')
+  end
+  test_repos = {}
+end
+
 describe('commands', function()
   after_each(function()
     restore_mocks()
     cleanup_buffers()
+    cleanup_repos()
   end)
 
   describe('setup', function()
@@ -337,6 +394,84 @@ describe('commands', function()
       assert.are.equal('--- a/lua/foo.lua', lines[2])
       assert.are.equal('+++ b/lua/foo.lua', lines[3])
       assert.is_true(table.concat(lines, '\n'):find('+local x = 1', 1, true) ~= nil)
+    end)
+  end)
+
+  describe('Gdiff real repository rendering', function()
+    it('reports no unstaged changes for staged-only tracked files', function()
+      local repo_root = create_repo()
+      local filepath = repo_root .. '/file.txt'
+      vim.fn.writefile({ 'line 1', 'line 2 staged' }, filepath)
+      git_cmd(repo_root, { 'add', 'file.txt' })
+      local source_buf = edit_file(filepath)
+      local notifications = capture_notifications()
+      mock_runtime_attach(function() end)
+
+      commands.gdiff(nil, false)
+
+      assert.are.equal(source_buf, vim.api.nvim_get_current_buf())
+      assert.is_true(
+        notifications[#notifications].message:find('no changes for index -> worktree', 1, true)
+          ~= nil
+      )
+    end)
+
+    it('reports no unstaged changes for staged additions matching the worktree', function()
+      local repo_root = create_repo()
+      local filepath = repo_root .. '/new.txt'
+      vim.fn.writefile({ 'new line' }, filepath)
+      git_cmd(repo_root, { 'add', 'new.txt' })
+      local source_buf = edit_file(filepath)
+      local notifications = capture_notifications()
+      mock_runtime_attach(function() end)
+
+      commands.gdiff(nil, false)
+
+      assert.are.equal(source_buf, vim.api.nvim_get_current_buf())
+      assert.is_true(
+        notifications[#notifications].message:find('no changes for index -> worktree', 1, true)
+          ~= nil
+      )
+    end)
+
+    it('uses buffer EOF state for final-newline-only direct diffs', function()
+      local repo_root = create_repo()
+      local filepath = repo_root .. '/file.txt'
+      vim.fn.writefile({ 'line 1', 'line 2' }, filepath, 'b')
+      local source_buf = edit_file(filepath)
+      mock_runtime_attach(function() end)
+
+      assert.is_false(vim.bo[source_buf].endofline)
+
+      commands.gdiff(nil, false)
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+      local text = table.concat(vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false), '\n')
+      assert.is_true(text:find('-line 2', 1, true) ~= nil)
+      assert.is_true(text:find('+line 2', 1, true) ~= nil)
+      assert.is_true(text:find('\\ No newline at end of file', 1, true) ~= nil)
+    end)
+
+    it('reports mode-only direct changes instead of rendering fake text hunks', function()
+      local repo_root = create_repo()
+      local filepath = repo_root .. '/file.txt'
+      vim.fn.setfperm(filepath, 'rwxr-xr-x')
+      local source_buf = edit_file(filepath)
+      local notifications = capture_notifications()
+      mock_runtime_attach(function() end)
+
+      commands.gdiff(nil, false)
+
+      assert.are.equal(source_buf, vim.api.nvim_get_current_buf())
+      assert.are.equal(vim.log.levels.ERROR, notifications[#notifications].level)
+      assert.is_true(
+        notifications[#notifications].message:find(
+          'Gdiff does not support mode-only changes',
+          1,
+          true
+        ) ~= nil
+      )
     end)
   end)
 

--- a/spec/content_spec.lua
+++ b/spec/content_spec.lua
@@ -1,0 +1,71 @@
+require('spec.helpers')
+
+local content = require('diffs.content')
+
+local test_buffers = {}
+local test_files = {}
+
+local function edit_temp_file(lines, flags)
+  local path = vim.fn.tempname()
+  test_files[#test_files + 1] = path
+  vim.fn.writefile(lines, path, flags or '')
+  vim.cmd('edit ' .. vim.fn.fnameescape(path))
+  local bufnr = vim.api.nvim_get_current_buf()
+  test_buffers[#test_buffers + 1] = bufnr
+  return content.from_buffer(bufnr)
+end
+
+describe('diffs.content', function()
+  after_each(function()
+    for _, bufnr in ipairs(test_buffers) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+    test_buffers = {}
+    for _, path in ipairs(test_files) do
+      vim.fn.delete(path)
+    end
+    test_files = {}
+  end)
+
+  it('normalizes one final newline sentinel', function()
+    local lines = content.from_raw_lines({ 'a', '' })
+
+    assert.are.equal(1, #lines)
+    assert.are.equal('a', lines[1])
+    assert.are.equal('a\n', content.to_string(lines))
+  end)
+
+  it('preserves an intentional trailing blank line', function()
+    local lines = content.from_raw_lines({ 'a', '', '' })
+
+    assert.are.equal(2, #lines)
+    assert.are.equal('a', lines[1])
+    assert.are.equal('', lines[2])
+    assert.are.equal('a\n\n', content.to_string(lines))
+  end)
+
+  it('preserves content without a final newline', function()
+    local lines = content.from_raw_lines({ 'a' })
+
+    assert.are.equal(1, #lines)
+    assert.are.equal('a', lines[1])
+    assert.are.equal('a', content.to_string(lines))
+  end)
+
+  it('normalizes empty file reads separately from one-newline files', function()
+    local empty = content.from_raw_lines({ '' }, { empty_is_empty = true })
+    local newline = content.from_raw_lines({ '', '' })
+
+    assert.are.equal('', content.to_string(empty))
+    assert.are.equal('\n', content.to_string(newline))
+  end)
+
+  it('preserves buffer final-newline state', function()
+    assert.are.equal('', content.to_string(edit_temp_file({}, 'b')))
+    assert.are.equal('\n', content.to_string(edit_temp_file({ '' })))
+    assert.are.equal('a', content.to_string(edit_temp_file({ 'a' }, 'b')))
+    assert.are.equal('a\n', content.to_string(edit_temp_file({ 'a' })))
+  end)
+end)

--- a/spec/render_spec.lua
+++ b/spec/render_spec.lua
@@ -195,6 +195,48 @@ describe('diffs.render', function()
     assert.is_true(text:find('-line 1', 1, true) ~= nil)
   end)
 
+  it('renders clean index to worktree edges as empty diffs', function()
+    local repo_root = create_repo()
+
+    local lines, err = render.file(diffspec.index_to_worktree('file.txt'), repo_root)
+
+    assert.is_nil(err)
+    assert.are.same({}, lines)
+  end)
+
+  it('renders clean HEAD to index edges as empty diffs', function()
+    local repo_root = create_repo()
+
+    local lines, err = render.file(diffspec.head_to_index('file.txt'), repo_root)
+
+    assert.is_nil(err)
+    assert.are.same({}, lines)
+  end)
+
+  it('preserves real trailing blank line changes', function()
+    local repo_root = create_repo()
+    vim.fn.writefile({ 'line 1', 'line 2', '' }, repo_root .. '/file.txt')
+
+    local lines, err = render.file(diffspec.index_to_worktree('file.txt'), repo_root)
+
+    assert.is_nil(err)
+    local text = table.concat(lines, '\n')
+    assert.is_true(text:find('\n+\n', 1, true) ~= nil)
+  end)
+
+  it('renders final-newline-only changes with no-newline metadata', function()
+    local repo_root = create_repo()
+    vim.fn.writefile({ 'line 1', 'line 2' }, repo_root .. '/file.txt', 'b')
+
+    local lines, err = render.file(diffspec.index_to_worktree('file.txt'), repo_root)
+
+    assert.is_nil(err)
+    local text = table.concat(lines, '\n')
+    assert.is_true(text:find('-line 2', 1, true) ~= nil)
+    assert.is_true(text:find('+line 2', 1, true) ~= nil)
+    assert.is_true(text:find('\\ No newline at end of file', 1, true) ~= nil)
+  end)
+
   it('rejects same-path rename projections before rendering actionable hunks', function()
     local repo_root = create_repo()
     git_cmd(repo_root, { 'mv', 'file.txt', 'renamed.txt' })


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #271.

## Solution

The solution adds an EOF-aware content line helper for Git/blob/file/buffer reads; and uses the helper when rendering generated diffs so index/tree content compares correctly with current buffer lines.
