### PR TITLE
Route direct Gdiff unmerged files

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -467,9 +467,12 @@ COMMANDS                                                 *diffs.nvim-commands*
                                                  explicit warning.
     Submodule         gitlink, not file content   Not supported. Shows an
                                                  explicit warning.
-    Merge stages      :1:/:2:/:3:                 Not supported by |:Gdiff|
-                                                 object parsing yet. Use the
-                                                 unmerged status-row action.
+    Unmerged file     :2: (ours) -> :3:          Plain |:Gdiff| opens a
+                      (theirs)                   generated merge diff. Native
+                                                 3-way `:Gdiffsplit!` windows
+                                                 are not emulated.
+    Merge-stage       :1:/:2:/:3: object         Not supported by |:Gdiff|
+    object                                       object parsing yet.
 
     Supported hunk actions run `git apply --cached --check` before mutating
     the index. Stale hunks, context drift, and index mismatches fail without
@@ -931,9 +934,10 @@ User events: ~
 ==============================================================================
 MERGE DIFF RESOLUTION                                       *diffs.nvim-merge*
 
-When pressing `du`/`dU` on an unmerged (`U`) file in the fugitive status
-buffer, diffs.nvim opens a unified diff of ours (`git show :2:path`) vs theirs
-(`git show :3:path`) with full treesitter and intra-line highlighting.
+When pressing `du`/`dU` on an unmerged (`U`) file in the fugitive status buffer,
+or running |:Gdiff| directly on an unmerged worktree file, diffs.nvim opens a
+unified diff of ours (`git show :2:path`) vs theirs (`git show :3:path`) with
+full treesitter and intra-line highlighting.
 
 The same conflict resolution keymaps (`co`/`ct`/`cb`/`c0`/`]c`/`[c`) are
 available on the diff buffer. They resolve conflicts in the working file by

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -585,6 +585,20 @@ function M.gdiff(args, vertical)
     return
   end
 
+  if
+    diff_spec.left.kind == diffspec.endpoint_kind.index
+    and diff_spec.right.kind == diffspec.endpoint_kind.worktree
+    and diff_spec.scope.kind == diffspec.scope_kind.file
+    and diff_path == rel_path
+    and git.is_unmerged(filepath)
+  then
+    M.gdiff_file(filepath, {
+      vertical = vertical,
+      unmerged = true,
+    })
+    return
+  end
+
   local diff_lines, render_err = render.file(diff_spec, repo_root, {
     worktree_lines = content.from_buffer(bufnr),
   })

--- a/lua/diffs/git.lua
+++ b/lua/diffs/git.lua
@@ -177,6 +177,24 @@ function M.file_exists_in_index(filepath)
   return vim.v.shell_error == 0 and #result > 0
 end
 
+---@param filepath string
+---@return boolean
+function M.is_unmerged(filepath)
+  local repo_root = M.get_repo_root(filepath)
+  if not repo_root then
+    return false
+  end
+
+  local rel_path = M.get_relative_path(filepath)
+  if not rel_path then
+    return false
+  end
+
+  local result =
+    vim.fn.systemlist({ 'git', '-C', repo_root, 'ls-files', '--unmerged', '--', rel_path })
+  return vim.v.shell_error == 0 and #result > 0
+end
+
 ---@param revision string
 ---@param filepath string
 ---@return boolean

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -7,6 +7,7 @@ local runtime = require('diffs.runtime')
 
 local saved_git = {}
 local saved_runtime_attach
+local saved_runtime_get_conflict_config
 local saved_schedule
 local saved_systemlist
 local saved_notify
@@ -38,6 +39,13 @@ local function mock_runtime_attach(fn)
   saved_schedule = vim.schedule
   vim.schedule = function(callback)
     callback()
+  end
+end
+
+local function mock_conflict_config(config)
+  saved_runtime_get_conflict_config = runtime.get_conflict_config
+  runtime.get_conflict_config = function()
+    return config
   end
 end
 
@@ -77,6 +85,27 @@ local function create_repo()
   return repo_root
 end
 
+local function create_conflicted_repo()
+  local repo_root = create_repo()
+  local filepath = repo_root .. '/file.txt'
+  local base = git_cmd(repo_root, { 'rev-parse', 'HEAD' })[1]
+
+  git_cmd(repo_root, { 'checkout', '-qb', 'ours' })
+  vim.fn.writefile({ 'line 1', 'line 2 ours' }, filepath)
+  git_cmd(repo_root, { 'add', 'file.txt' })
+  git_cmd(repo_root, { 'commit', '-qm', 'ours' })
+
+  git_cmd(repo_root, { 'checkout', '-qb', 'theirs', base })
+  vim.fn.writefile({ 'line 1', 'line 2 theirs' }, filepath)
+  git_cmd(repo_root, { 'add', 'file.txt' })
+  git_cmd(repo_root, { 'commit', '-qm', 'theirs' })
+
+  local output = vim.fn.systemlist({ 'git', '-C', repo_root, 'merge', 'ours' })
+  assert.are_not.equal(0, vim.v.shell_error, table.concat(output, '\n'))
+
+  return repo_root, filepath
+end
+
 local function edit_file(path)
   vim.cmd('edit ' .. vim.fn.fnameescape(path))
   local bufnr = vim.api.nvim_get_current_buf()
@@ -92,6 +121,10 @@ local function restore_mocks()
   if saved_runtime_attach then
     runtime.attach = saved_runtime_attach
     saved_runtime_attach = nil
+  end
+  if saved_runtime_get_conflict_config then
+    runtime.get_conflict_config = saved_runtime_get_conflict_config
+    saved_runtime_get_conflict_config = nil
   end
   if saved_schedule then
     vim.schedule = saved_schedule
@@ -472,6 +505,42 @@ describe('commands', function()
           true
         ) ~= nil
       )
+    end)
+
+    it('routes direct :Gdiff on unmerged files to the generated unmerged view', function()
+      local _, filepath = create_conflicted_repo()
+      edit_file(filepath)
+      mock_runtime_attach(function() end)
+      mock_conflict_config({
+        keymaps = helpers.default_conflict_keymaps(),
+        show_virtual_text = false,
+      })
+
+      assert.is_true(git.is_unmerged(filepath))
+
+      commands.gdiff(nil, false)
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+      local lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
+      local text = table.concat(lines, '\n')
+
+      assert.are.equal('diffs://unmerged:file.txt', vim.api.nvim_buf_get_name(diff_buf))
+      assert.is_false(text:find('new file mode', 1, true) ~= nil)
+      assert.is_false(text:find('--- /dev/null', 1, true) ~= nil)
+      assert.is_true(text:find('-line 2 theirs', 1, true) ~= nil)
+      assert.is_true(text:find('+line 2 ours', 1, true) ~= nil)
+      assert.is_true(vim.api.nvim_buf_get_var(diff_buf, 'diffs_unmerged'))
+      assert.are.equal(filepath, vim.api.nvim_buf_get_var(diff_buf, 'diffs_working_path'))
+      assert.are.same({
+        version = 1,
+        kind = 'unmerged',
+        repo_root = vim.fn.fnamemodify(filepath, ':h'),
+        path = 'file.txt',
+        working_path = filepath,
+      }, vim.api.nvim_buf_get_var(diff_buf, 'diffs_source'))
+      assert.is_true(helpers.has_keymap(diff_buf, 'go'))
+      assert.is_true(helpers.has_keymap(diff_buf, 'gt'))
     end)
   end)
 


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #272.

## Solution

The solution detects unmerged worktree files before direct index-to-worktree :Gdiff rendering; and routes that path to the existing generated :2: vs :3: unmerged diff view.
