### PR TITLE
test: extend unmerged Gdiff coverage

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -484,8 +484,9 @@ COMMANDS                                                 *diffs.nvim-commands*
                                                  explicit warning.
     Submodule         gitlink, not file content   Not supported. Shows an
                                                  explicit warning.
-    Unmerged file     :2: (ours) -> :3:          Plain |:Gdiff| opens a
-                      (theirs)                   generated merge diff. Native
+    Unmerged file     :2: (ours) -> :3:          Plain |:Gdiff|, or an
+                      (theirs)                   explicit index object, opens
+                                                 a generated merge diff. Native
                                                  3-way `:Gdiffsplit!` windows
                                                  are not emulated.
     Merge-stage       :1:/:2:/:3: object         Not supported by |:Gdiff|
@@ -967,10 +968,13 @@ User events: ~
 ==============================================================================
 MERGE DIFF RESOLUTION                                       *diffs.nvim-merge*
 
-When pressing `du`/`dU` on an unmerged (`U`) file in the fugitive status buffer,
-or running |:Gdiff| directly on an unmerged worktree file, diffs.nvim opens a
-unified diff of ours (`git show :2:path`) vs theirs (`git show :3:path`) with
-full treesitter and intra-line highlighting.
+When running plain |:Gdiff| or an explicit index-object comparison (for example
+`:Gdiff :%`) on an unmerged worktree file, or pressing `du`/`dU` on an
+unmerged (`U`) file in the fugitive status buffer, diffs.nvim opens a unified
+diff of ours (`git show :2:path`) vs theirs (`git show :3:path`) with full
+treesitter and intra-line highlighting. Revision comparisons such as
+`:Gdiff HEAD` keep rendering that revision against the conflicted worktree
+buffer.
 
 The same conflict resolution keymaps (`co`/`ct`/`cb`/`c0`/`]c`/`[c`) are
 available on the diff buffer. They resolve conflicts in the working file by

--- a/lua/diffs/git.lua
+++ b/lua/diffs/git.lua
@@ -167,10 +167,7 @@ function M.file_exists_in_index(filepath)
     return false
   end
 
-  local rel_path = M.get_relative_path(filepath)
-  if not rel_path then
-    return false
-  end
+  local rel_path = relative_path(repo_root, filepath)
 
   local result =
     vim.fn.systemlist({ 'git', '-C', repo_root, 'ls-files', '--stage', '--', rel_path })
@@ -185,11 +182,7 @@ function M.is_unmerged(filepath)
     return false
   end
 
-  local rel_path = M.get_relative_path(filepath)
-  if not rel_path then
-    return false
-  end
-
+  local rel_path = relative_path(repo_root, filepath)
   local result =
     vim.fn.systemlist({ 'git', '-C', repo_root, 'ls-files', '--unmerged', '--', rel_path })
   return vim.v.shell_error == 0 and #result > 0

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -714,8 +714,9 @@ describe('commands', function()
     end)
 
     it('routes direct :Gdiff on unmerged files to the generated unmerged view', function()
-      local _, filepath = create_conflicted_repo()
+      local repo_root, filepath = create_conflicted_repo()
       edit_file(filepath)
+      local source_win = vim.api.nvim_get_current_win()
       mock_runtime_attach(function() end)
       mock_conflict_config({
         keymaps = helpers.default_conflict_keymaps(),
@@ -728,25 +729,75 @@ describe('commands', function()
 
       local diff_buf = vim.api.nvim_get_current_buf()
       table.insert(test_buffers, diff_buf)
-      local lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
-      local text = table.concat(lines, '\n')
 
-      assert.are.equal('diffs://unmerged:file.txt', vim.api.nvim_buf_get_name(diff_buf))
-      assert.is_false(text:find('new file mode', 1, true) ~= nil)
-      assert.is_false(text:find('--- /dev/null', 1, true) ~= nil)
-      assert.is_true(text:find('-line 2 theirs', 1, true) ~= nil)
-      assert.is_true(text:find('+line 2 ours', 1, true) ~= nil)
-      assert.is_true(vim.api.nvim_buf_get_var(diff_buf, 'diffs_unmerged'))
-      assert.are.equal(filepath, vim.api.nvim_buf_get_var(diff_buf, 'diffs_working_path'))
+      local function assert_unmerged_view(bufnr)
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        local text = table.concat(lines, '\n')
+
+        assert.are.equal('diffs://unmerged:file.txt', vim.api.nvim_buf_get_name(bufnr))
+        assert.are.equal(repo_root, vim.api.nvim_buf_get_var(bufnr, 'diffs_repo_root'))
+        assert.are.same({
+          version = 1,
+          kind = 'unmerged',
+          repo_root = repo_root,
+          path = 'file.txt',
+          working_path = filepath,
+        }, vim.api.nvim_buf_get_var(bufnr, 'diffs_source'))
+        assert.is_true(vim.api.nvim_buf_get_var(bufnr, 'diffs_unmerged'))
+        assert.are.equal(filepath, vim.api.nvim_buf_get_var(bufnr, 'diffs_working_path'))
+        assert.is_false(has_buf_var(bufnr, 'diffs_spec'))
+        assert.is_false(has_buf_var(bufnr, 'diffs_hunks'))
+        assert.are.equal('diff --git a/file.txt b/file.txt', lines[1])
+        assert.is_true(text:find('-line 2 theirs', 1, true) ~= nil)
+        assert.is_true(text:find('+line 2 ours', 1, true) ~= nil)
+        assert.is_true(text:find('--- /dev/null', 1, true) == nil)
+        assert.is_true(text:find('new file mode', 1, true) == nil)
+        assert.is_true(text:find('<<<<<<<', 1, true) == nil)
+        assert.is_true(helpers.has_keymap(bufnr, 'go'))
+        assert.is_true(helpers.has_keymap(bufnr, 'gt'))
+      end
+
+      assert_unmerged_view(diff_buf)
+
+      vim.api.nvim_set_option_value('modifiable', true, { buf = diff_buf })
+      vim.api.nvim_buf_set_lines(diff_buf, 0, -1, false, { 'stale unmerged content' })
+      vim.api.nvim_set_option_value('modifiable', false, { buf = diff_buf })
+
+      commands.read_buffer(diff_buf)
+
+      assert_unmerged_view(diff_buf)
+      helpers.delete_buffer(diff_buf)
+
+      for _, object in ipairs({ ':%', ':0:%' }) do
+        vim.api.nvim_set_current_win(source_win)
+        commands.gdiff(object, false)
+
+        local explicit_index_buf = vim.api.nvim_get_current_buf()
+        table.insert(test_buffers, explicit_index_buf)
+        assert_unmerged_view(explicit_index_buf)
+        helpers.delete_buffer(explicit_index_buf)
+      end
+
+      vim.api.nvim_set_current_win(source_win)
+      commands.gdiff('HEAD', false)
+
+      local revision_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, revision_buf)
+      local revision_text = buffer_text(revision_buf)
+
+      assert.are.equal('diffs://HEAD:file.txt', vim.api.nvim_buf_get_name(revision_buf))
+      assert.are.same(
+        diffspec.rev_to_worktree('HEAD', 'file.txt'),
+        vim.api.nvim_buf_get_var(revision_buf, 'diffs_spec')
+      )
       assert.are.same({
         version = 1,
-        kind = 'unmerged',
-        repo_root = vim.fn.fnamemodify(filepath, ':h'),
-        path = 'file.txt',
-        working_path = filepath,
-      }, vim.api.nvim_buf_get_var(diff_buf, 'diffs_source'))
-      assert.is_true(helpers.has_keymap(diff_buf, 'go'))
-      assert.is_true(helpers.has_keymap(diff_buf, 'gt'))
+        kind = 'file',
+        repo_root = repo_root,
+        spec = diffspec.rev_to_worktree('HEAD', 'file.txt'),
+      }, vim.api.nvim_buf_get_var(revision_buf, 'diffs_source'))
+      assert.is_false(has_buf_var(revision_buf, 'diffs_unmerged'))
+      assert.is_true(revision_text:find('+<<<<<<<', 1, true) ~= nil)
     end)
   end)
 

--- a/spec/git_spec.lua
+++ b/spec/git_spec.lua
@@ -1,7 +1,42 @@
 require('spec.helpers')
 local git = require('diffs.git')
 
+local test_repos = {}
+
+local function git_cmd(repo_root, args)
+  local cmd = { 'git', '-C', repo_root }
+  for _, arg in ipairs(args) do
+    cmd[#cmd + 1] = arg
+  end
+  local output = vim.fn.systemlist(cmd)
+  assert.are.equal(0, vim.v.shell_error, table.concat(output, '\n'))
+  return output
+end
+
+local function create_repo()
+  local repo_root = vim.fn.tempname()
+  vim.fn.mkdir(repo_root, 'p')
+  test_repos[#test_repos + 1] = repo_root
+
+  vim.fn.systemlist({ 'git', 'init', '-q', repo_root })
+  assert.are.equal(0, vim.v.shell_error)
+  git_cmd(repo_root, { 'config', 'user.email', 'test@example.com' })
+  git_cmd(repo_root, { 'config', 'user.name', 'Test' })
+  vim.fn.writefile({ 'line 1', 'line 2' }, repo_root .. '/file.txt')
+  git_cmd(repo_root, { 'add', 'file.txt' })
+  git_cmd(repo_root, { 'commit', '-qm', 'initial' })
+
+  return repo_root
+end
+
 describe('git', function()
+  after_each(function()
+    for _, repo_root in ipairs(test_repos) do
+      vim.fn.delete(repo_root, 'rf')
+    end
+    test_repos = {}
+  end)
+
   describe('get_repo_root', function()
     it('returns repo root for current repo', function()
       local cwd = vim.fn.getcwd()
@@ -49,6 +84,32 @@ describe('git', function()
     it('returns nil for non-git directory', function()
       local rel = git.get_relative_path('/tmp/some_file.txt')
       assert.is_nil(rel)
+    end)
+  end)
+
+  describe('is_unmerged', function()
+    it('detects paths with unmerged index stages', function()
+      local repo_root = create_repo()
+      local filepath = repo_root .. '/file.txt'
+
+      git_cmd(repo_root, { 'checkout', '-qb', 'ours' })
+      vim.fn.writefile({ 'line 1', 'line 2 ours' }, filepath)
+      git_cmd(repo_root, { 'commit', '-am', 'ours' })
+      git_cmd(repo_root, { 'checkout', '-qb', 'theirs', 'HEAD~1' })
+      vim.fn.writefile({ 'line 1', 'line 2 theirs' }, filepath)
+      git_cmd(repo_root, { 'commit', '-am', 'theirs' })
+
+      local merge_output = vim.fn.systemlist({ 'git', '-C', repo_root, 'merge', 'ours' })
+      assert.are_not.equal(0, vim.v.shell_error, table.concat(merge_output, '\n'))
+
+      assert.is_true(git.is_unmerged(filepath))
+    end)
+
+    it('returns false outside an unmerged path', function()
+      local repo_root = create_repo()
+
+      assert.is_false(git.is_unmerged(repo_root .. '/file.txt'))
+      assert.is_false(git.is_unmerged('/tmp/not-a-diffs-repo-file.txt'))
     end)
   end)
 end)


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This is related to #286.

## Solution

The solution keeps revision comparisons such as `:Gdiff HEAD` keep rendering against the conflicted worktree buffer; and clarifies docs for explicit index-object unmerged behavior.
