### PR TITLE
Clarify generated Gdiff boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ luarocks install diffs.nvim
 :help diffs.nvim
 ```
 
+## Generated `:Gdiff`
+
+`:Gdiff` opens a generated unified `diffs://` buffer, not native Fugitive
+`:Gdiffsplit` windows. Plain `:Gdiff` from a worktree file shows the
+index-to-worktree edge, so staged-only changes report no unstaged changes. In a
+Fugitive status buffer, `du`/`dU` choose the edge from the row: staged rows show
+`HEAD -> index`, unstaged rows show `index -> worktree`, untracked rows show an
+all-added file, and unmerged rows show ours `:2:` vs theirs `:3:`.
+
+Generated hunk actions are capability-scoped: `dp` stages supported
+index-to-worktree hunks/ranges, and `do` unstages supported tree-to-index
+hunks/ranges. Native `:Gdiffsplit!`, 3-way `&diff` windows, writable Fugitive
+object buffers, and `dq` are outside this generated-buffer contract.
+
 ## FAQ
 
 **Q: Does diffs.nvim support

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -428,6 +428,21 @@ COMMANDS                                                 *diffs.nvim-commands*
     If a `diffs://` window already exists in the current tabpage, the new
     diff replaces its buffer instead of creating another split.
 
+    This is a generated unified diff workspace, not Fugitive `:Gdiffsplit`
+    parity. diffs.nvim owns the `diffs://` buffer, hunk metadata, and plugin
+    actions. It does not enter native Vim `&diff` mode, open writable Fugitive
+    object buffers, or emulate `:Gdiffsplit` window lifecycle.
+
+    Plain direct |:Gdiff| from a worktree file compares the index to the
+    worktree and shows only unstaged changes. Staged-only changes report no
+    changes for that edge. To view staged changes, use a staged Fugitive status
+    row with |diffs.nvim-du|/|diffs.nvim-dU| or an explicit supported object
+    form such as `:Gdiff :0:%`.
+
+    Fugitive does not provide a `--staged` `:Gdiffsplit` flag, so diffs.nvim
+    does not add one to |:Gdiff|. Endpoint selection is expressed through the
+    object argument and through Fugitive status-row context.
+
     Parameters: ~
         ++novertical (optional) Force a horizontal split. Useful with |:Gvdiff|
                     or command wrappers.
@@ -478,7 +493,15 @@ COMMANDS                                                 *diffs.nvim-commands*
 
     Supported hunk actions run `git apply --cached --check` before mutating
     the index. Stale hunks, context drift, and index mismatches fail without
-    applying a partial mutation.
+    applying a partial mutation. Mutation maps are capability-scoped: `dp`
+    appears only for supported index -> worktree hunks/ranges, and `do`
+    appears only for supported tree -> index hunks/ranges. Read-only and
+    unsupported generated buffers do not expose mutation maps.
+
+    Native paired-window expectations such as `:Gdiffsplit`, `:Gdiffsplit!`,
+    3-way `&diff` windows, writable Fugitive object buffers, and `dq` are
+    outside the generated-buffer contract. Track that product direction in
+    upstream issues #252 and #253.
 
 
 :Gvdiff [object]                                                     *:Gvdiff*
@@ -699,7 +722,9 @@ and intra-line diffs. |:Gdiff| opens a unified diff against any revision (see
 Fugitive status keymaps: ~
 
 When inside a `:Git` status buffer, diffs.nvim provides keymaps to open
-unified diffs for files or entire sections.
+generated unified diffs for files or entire sections. These keymaps reuse
+Fugitive status context for endpoint selection; they do not call
+`:Gdiffsplit` or open native Vim diff windows.
 
 Keymaps: ~
                                                *diffs.nvim-du* *diffs.nvim-dU*
@@ -727,6 +752,10 @@ staged) and displays all changes in that section as a single unified diff
 without hunk actions. Empty staged or unstaged sections report which section has
 no changes. Untracked section headers show a warning since there is no
 meaningful diff.
+
+This status-row behavior is intentionally narrower than Fugitive `:Gdiffsplit`.
+It preserves the useful edge selection model while keeping generated
+`diffs://` buffers read-only, explicit, and owned by diffs.nvim.
 
 Configuration: ~
                                                    *diffs.nvim.FugitiveConfig*


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #276.

## Solution

The solution documents that :Gdiff opens generated diffs:// buffers, not native Fugitive :Gdiffsplit windows; separates direct worktree-file behavior from Fugitive status-row edge selection; and clarifies capability-scoped do/dp maps and route paired-window expectations to #252/#253.
