### PR TITLE
docs: define generated workspace boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,6 @@ luarocks install diffs.nvim
 :help diffs.nvim
 ```
 
-## Generated `:Gdiff`
-
-`:Gdiff` opens a generated unified `diffs://` buffer, not native Fugitive
-`:Gdiffsplit` windows. Plain `:Gdiff` from a worktree file shows the
-index-to-worktree edge, so staged-only changes report no unstaged changes. In a
-Fugitive status buffer, `du`/`dU` choose the edge from the row: staged rows show
-`HEAD -> index`, unstaged rows show `index -> worktree`, untracked rows show an
-all-added file, and unmerged rows show ours `:2:` vs theirs `:3:`.
-
-Generated hunk actions are capability-scoped: `dp` stages supported
-index-to-worktree hunks/ranges, and `do` unstages supported tree-to-index
-hunks/ranges. Native `:Gdiffsplit!`, 3-way `&diff` windows, writable Fugitive
-object buffers, and `dq` are outside this generated-buffer contract.
-
 ## FAQ
 
 **Q: Does diffs.nvim support

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -417,6 +417,19 @@ syntax highlighting warning.
 ==============================================================================
 COMMANDS                                                 *diffs.nvim-commands*
 
+Generated workspace boundaries: ~
+
+diffs.nvim only replaces layout for buffers it creates and can model as
+explicit endpoints. Today that means generated |:Gdiff| buffers, |:Greview|
+buffers, and plugin-owned launches from integrations such as Fugitive status
+maps. Future generated commit or split views must follow the same rule: first
+model the source endpoints, then own the layout.
+
+Ordinary `git`, `gitcommit`, `diff`, `extra_filetypes`, picker previews, and
+third-party integration buffers remain highlight-only. diffs.nvim may attach
+syntax, backgrounds, and intra-line highlights to those buffers, but it must not
+replace their layout unless the user invoked a generated diffs.nvim view.
+
 :Gdiff [object]                                                       *:Gdiff*
     Open a unified diff of the current file against a Fugitive-style object.
     Displays in a horizontal split below the current window.


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #250.

## Solution

The solution defines generated workspace ownership boundaries in vimdoc; removes the generated `:Gdiff` section from the README so it stays product-level; and keeps arbitrary git/gitcommit/diff/preview buffers explicitly highlight-only.
