### PR TITLE
ci: enforce conventional commit subjects

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+exec "$repo_root/scripts/check-commit-subject" --message-file "$1"

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -4,10 +4,40 @@ on:
   workflow_call:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, edited]
   push:
     branches: [main]
 
 jobs:
+  commit-subjects:
+    name: Commit subjects
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Check commit subjects
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            scripts/check-commit-subject --subject "$PR_TITLE" --source "pull request title"
+            range="origin/${{ github.base_ref }}..HEAD"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            before="${{ github.event.before }}"
+            if [[ "$before" =~ ^0+$ ]]; then
+              range="${{ github.sha }}^!"
+            else
+              range="$before..${{ github.sha }}"
+            fi
+          else
+            exit 0
+          fi
+
+          scripts/check-commit-subject --range "$range"
+
   format:
     name: Format
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -6,6 +6,12 @@ format:
     stylua --check .
     biome format .
 
+commitlint range="origin/main..HEAD":
+    scripts/check-commit-subject --range "{{range}}"
+
+install-hooks:
+    git config core.hooksPath .githooks
+
 lint:
     git ls-files '*.lua' | xargs selene --display-style quiet
     lua-language-server --check lua --configpath "$(pwd)/.luarc.json" --checklevel=Warning
@@ -14,5 +20,5 @@ lint:
 test:
     busted
 
-ci: format lint test
+ci: commitlint format lint test
     @:

--- a/scripts/check-commit-subject
+++ b/scripts/check-commit-subject
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Validate Conventional Commit subjects for local hooks, CI, and Codex hooks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+TYPES = (
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "revert",
+    "style",
+    "test",
+)
+
+SUBJECT_RE = re.compile(
+    rf"^({'|'.join(TYPES)})(\([a-z0-9][a-z0-9._/-]*\))?!?: \S.+$"
+)
+
+
+def valid_subject(subject: str) -> bool:
+    return bool(SUBJECT_RE.match(subject))
+
+
+def error_message(subject: str, source: str) -> str:
+    allowed = ", ".join(TYPES)
+    return "\n".join(
+        [
+            f"{source} must use Conventional Commits.",
+            "",
+            "Expected: <type>[optional scope][!]: <description>",
+            f"Allowed types: {allowed}",
+            "",
+            "Examples:",
+            "  fix(commands): route direct unmerged Gdiff files",
+            "  docs: clarify Gdiff help text",
+            "",
+            f"Got: {subject or '<empty>'}",
+        ]
+    )
+
+
+def check_subject(subject: str, source: str) -> bool:
+    if valid_subject(subject):
+        return True
+
+    print(error_message(subject, source), file=sys.stderr)
+    return False
+
+
+def commit_subject_from_file(path: Path) -> str:
+    with path.open(encoding="utf-8") as commit_msg:
+        for line in commit_msg:
+            subject = line.rstrip("\r\n")
+            if subject.startswith("#") or not subject.strip():
+                continue
+            return subject
+
+    return ""
+
+
+def git(args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], text=True)
+
+
+def check_range(range_spec: str) -> bool:
+    commits = [
+        line for line in git(["rev-list", "--reverse", range_spec]).splitlines() if line
+    ]
+    ok = True
+
+    for commit in commits:
+        subject = git(["log", "-1", "--format=%s", commit]).rstrip("\n")
+        ok = check_subject(subject, f"commit {commit[:12]} subject") and ok
+
+    return ok
+
+
+def normalize_shell_tokens(command: str) -> list[str] | None:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return None
+
+
+def git_commit_args(tokens: list[str]) -> list[str] | None:
+    for idx, token in enumerate(tokens):
+        if token != "git":
+            continue
+
+        pos = idx + 1
+        while pos < len(tokens):
+            option = tokens[pos]
+            if option in {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}:
+                pos += 2
+                continue
+            if option.startswith(("--git-dir=", "--work-tree=", "--namespace=")):
+                pos += 1
+                continue
+            break
+
+        if pos < len(tokens) and tokens[pos] == "commit":
+            return tokens[pos + 1 :]
+
+    return None
+
+
+def inline_commit_subject(command: str) -> str | None:
+    tokens = normalize_shell_tokens(command)
+    if not tokens:
+        return None
+
+    while tokens[:3] == ["direnv", "exec", "."]:
+        tokens = tokens[3:]
+
+    args = git_commit_args(tokens)
+    if args is None:
+        return None
+
+    for idx, arg in enumerate(args):
+        if arg in {"-m", "--message"} and idx + 1 < len(args):
+            return args[idx + 1]
+        if arg.startswith("-") and not arg.startswith("--") and "m" in arg:
+            message = arg.split("m", 1)[1]
+            if message:
+                return message
+            if idx + 1 < len(args):
+                return args[idx + 1]
+        if arg.startswith("-m") and arg != "-m":
+            return arg[2:]
+        if arg.startswith("--message="):
+            return arg.split("=", 1)[1]
+
+    return None
+
+
+def codex_pre_tool_use() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return 0
+
+    subject = inline_commit_subject(command)
+    if subject is None or valid_subject(subject):
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": error_message(
+                        subject, "git commit subject"
+                    ),
+                }
+            }
+        )
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--message-file", type=Path)
+    parser.add_argument("--range", dest="range_spec")
+    parser.add_argument("--source", default="commit subject")
+    parser.add_argument("--subject")
+    parser.add_argument("--codex-pre-tool-use", action="store_true")
+    args = parser.parse_args()
+
+    if args.codex_pre_tool_use:
+        return codex_pre_tool_use()
+
+    if args.message_file is not None:
+        subject = commit_subject_from_file(args.message_file)
+        return 0 if check_subject(subject, "commit subject") else 1
+
+    if args.range_spec is not None:
+        return 0 if check_range(args.range_spec) else 1
+
+    if args.subject is not None:
+        return 0 if check_subject(args.subject, args.source) else 1
+
+    parser.error(
+        "one of --message-file, --range, --subject, or --codex-pre-tool-use is required"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

Commit subjects are expected to use Conventional Commits, but the repo did not enforce that locally or in CI.

## Solution

- Add a shared commit-subject validator.
- Add a tracked `commit-msg` hook and `just install-hooks` setup target.
- Add `just commitlint` and wire it into `just ci`.
- Check PR titles and pushed commit subjects in the quality workflow.