### PR TITLE
feat: add generated diff line rails

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -438,6 +438,10 @@ replace their layout unless the user invoked a generated diffs.nvim view.
     code language, plus diff header highlighting for `diff --git`, `---`,
     `+++`, and `@@` lines.
 
+    Generated `diffs://` unified buffers include old and new line-number rails
+    before the unified diff text. A blank rail cell means that line does not
+    exist on that side of the diff.
+
     In the default unified layout, if a `diffs://` window already exists in the
     current tabpage, the new diff replaces its buffer instead of creating
     another split.

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -7,6 +7,7 @@ local gdiff_parser = require('diffs.gdiff')
 local git = require('diffs.git')
 local hunk_model = require('diffs.hunks')
 local log = require('diffs.log')
+local rails = require('diffs.rails')
 local render = require('diffs.render')
 local review = require('diffs.review')
 local runtime = require('diffs.runtime')
@@ -253,6 +254,16 @@ local function set_diff_hunks_var(bufnr, diff_lines, diff_spec)
 end
 
 ---@param bufnr integer
+---@param info diffs.RailInfo?
+local function set_diff_rails_var(bufnr, info)
+  if info then
+    vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_width', info.prefix_width)
+  else
+    pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_width')
+  end
+end
+
+---@param bufnr integer
 local function clear_diff_hunks_var(bufnr)
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_hunks')
 end
@@ -382,9 +393,11 @@ end
 ---@return integer
 local function create_generated_diff_buffer(opts)
   local bufnr = vim.api.nvim_create_buf(false, true)
-  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, opts.lines)
+  local display_lines, rail_info = rails.annotate(opts.lines)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, display_lines)
   set_generated_diff_buffer_options(bufnr)
   vim.api.nvim_buf_set_name(bufnr, opts.name)
+  set_diff_rails_var(bufnr, rail_info)
 
   if opts.diff_spec then
     set_diff_spec_var(bufnr, opts.diff_spec)
@@ -422,9 +435,11 @@ end
 ---@param diff_lines string[]
 ---@param diff_spec? diffs.DiffSpec
 local function replace_generated_diff_buffer_lines(bufnr, diff_lines, diff_spec)
+  local display_lines, rail_info = rails.annotate(diff_lines)
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
-  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, diff_lines)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, display_lines)
   set_generated_diff_buffer_options(bufnr)
+  set_diff_rails_var(bufnr, rail_info)
 
   if diff_spec then
     set_diff_hunks_var(bufnr, diff_lines, diff_spec)

--- a/lua/diffs/merge.lua
+++ b/lua/diffs/merge.lua
@@ -3,6 +3,7 @@ local M = {}
 local conflict = require('diffs.conflict')
 local keymaps = require('diffs.keymaps')
 local notify = require('diffs.log').notify
+local rails = require('diffs.rails')
 
 local ns = vim.api.nvim_create_namespace('diffs-merge')
 
@@ -23,10 +24,12 @@ local buffer_keymaps = {}
 ---@return diffs.MergeHunkInfo[]
 function M.parse_hunks(bufnr)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local rail_width = rails.width_for_buffer(bufnr)
   local hunks = {}
   local current = nil
 
   for i, line in ipairs(lines) do
+    line = rails.strip(line, rail_width)
     local idx = i - 1
     if line:match('^@@') then
       if current then

--- a/lua/diffs/parser.lua
+++ b/lua/diffs/parser.lua
@@ -14,6 +14,7 @@
 ---@field file_new_count integer?
 ---@field prefix_width integer
 ---@field quote_width integer
+---@field rail_width integer?
 ---@field repo_root string?
 ---@field context_before string[]?
 ---@field context_after string[]?
@@ -23,6 +24,7 @@
 local M = {}
 
 local dbg = require('diffs.log').dbg
+local rails = require('diffs.rails')
 
 ---@type table<string, {ft: string?, lang: string?}>
 local ft_lang_cache = {}
@@ -151,11 +153,13 @@ end
 function M.parse_buffer(bufnr)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   local repo_root = get_repo_root(bufnr)
+  local rail_width = rails.width_for_buffer(bufnr)
 
   local quote_prefix = nil
   local quote_width = 0
   for _, l in ipairs(lines) do
-    local qp = l:match('^(>+ )diff %-%-') or l:match('^(>+ )@@ %-')
+    local logical = rails.strip(l, rail_width)
+    local qp = logical:match('^(>+ )diff %-%-') or logical:match('^(>+ )@@ %-')
     if qp then
       quote_prefix = qp
       quote_width = #qp
@@ -219,6 +223,7 @@ function M.parse_buffer(bufnr)
         file_new_start = file_new_start,
         file_new_count = file_new_count,
         repo_root = repo_root,
+        rail_width = rail_width > 0 and rail_width or nil,
       }
       if hunk_count == 1 and header_start and #header_lines > 0 then
         hunk.header_start_line = header_start
@@ -239,11 +244,12 @@ function M.parse_buffer(bufnr)
   end
 
   for i, line in ipairs(lines) do
-    local logical = line
+    local without_rails = rails.strip(line, rail_width)
+    local logical = without_rails
     if quote_prefix then
-      if line:sub(1, quote_width) == quote_prefix then
-        logical = line:sub(quote_width + 1)
-      elseif line:match('^>+$') then
+      if without_rails:sub(1, quote_width) == quote_prefix then
+        logical = without_rails:sub(quote_width + 1)
+      elseif without_rails:match('^>+$') then
         logical = ''
       end
     end
@@ -268,7 +274,7 @@ function M.parse_buffer(bufnr)
     if filename then
       flush_hunk()
       current_filename = filename
-      current_quote_width = (logical ~= line) and quote_width or 0
+      current_quote_width = rail_width + ((logical ~= without_rails) and quote_width or 0)
       local cache_key = (repo_root or '') .. '\0' .. filename
       local cached = ft_lang_cache[cache_key]
       if cached then

--- a/lua/diffs/rails.lua
+++ b/lua/diffs/rails.lua
@@ -1,0 +1,119 @@
+local M = {}
+
+local hunk_model = require('diffs.hunks')
+
+---@class diffs.RailInfo
+---@field width integer
+---@field prefix_width integer
+
+---@param value integer?
+---@param width integer
+---@return string
+local function format_lnum(value, width)
+  if not value then
+    return string.rep(' ', width)
+  end
+  return string.format('%' .. width .. 'd', value)
+end
+
+---@param line diffs.GdiffHunkLine?
+---@return integer?
+local function old_lnum(line)
+  if line and (line.kind == 'context' or line.kind == 'delete') then
+    return line.old_lnum
+  end
+  return nil
+end
+
+---@param line diffs.GdiffHunkLine?
+---@return integer?
+local function new_lnum(line)
+  if line and (line.kind == 'context' or line.kind == 'add') then
+    return line.new_lnum
+  end
+  return nil
+end
+
+---@param lines string[]
+---@return table<integer, diffs.GdiffHunkLine>, integer
+local function collect_lines(lines)
+  local by_lnum = {}
+  local max_lnum = 0
+
+  for _, hunk in ipairs(hunk_model.parse(lines)) do
+    for _, line in ipairs(hunk.lines) do
+      by_lnum[line.lnum] = line
+      max_lnum = math.max(max_lnum, line.old_lnum or 0, line.new_lnum or 0)
+    end
+  end
+
+  return by_lnum, max_lnum
+end
+
+---@param lines string[]
+---@return string[], diffs.RailInfo?
+function M.annotate(lines)
+  local by_lnum, max_lnum = collect_lines(lines)
+  if vim.tbl_isempty(by_lnum) then
+    return lines, nil
+  end
+
+  local width = math.max(1, #tostring(max_lnum))
+  local prefix_width = width + 1 + width + 3
+  local annotated = {}
+
+  for lnum, text in ipairs(lines) do
+    local line = by_lnum[lnum]
+    annotated[lnum] = format_lnum(old_lnum(line), width)
+      .. ' '
+      .. format_lnum(new_lnum(line), width)
+      .. ' | '
+      .. text
+  end
+
+  return annotated, {
+    width = width,
+    prefix_width = prefix_width,
+  }
+end
+
+---@param line string
+---@param prefix_width integer?
+---@return string
+function M.strip(line, prefix_width)
+  if type(prefix_width) ~= 'number' or prefix_width <= 0 then
+    return line
+  end
+  return line:sub(prefix_width + 1)
+end
+
+---@param lines string[]
+---@param prefix_width integer?
+---@return string[]
+function M.strip_lines(lines, prefix_width)
+  if type(prefix_width) ~= 'number' or prefix_width <= 0 then
+    return lines
+  end
+
+  local stripped = {}
+  for i, line in ipairs(lines) do
+    stripped[i] = M.strip(line, prefix_width)
+  end
+  return stripped
+end
+
+---@param bufnr integer
+---@return integer
+function M.width_for_buffer(bufnr)
+  local ok, width = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_rail_width')
+  if ok and type(width) == 'number' and width > 0 then
+    return width
+  end
+  return 0
+end
+
+M._test = {
+  format_lnum = format_lnum,
+}
+
+return M

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -3,6 +3,7 @@ local helpers = require('spec.helpers')
 local commands = require('diffs.commands')
 local diffspec = require('diffs.spec')
 local git = require('diffs.git')
+local rails = require('diffs.rails')
 local runtime = require('diffs.runtime')
 
 local saved_git = {}
@@ -118,8 +119,17 @@ local function write_binary_file(path, text)
   assert.are.equal(0, vim.v.shell_error)
 end
 
+local function buffer_lines(bufnr)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local ok, rail_width = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_rail_width')
+  if ok then
+    return rails.strip_lines(lines, rail_width)
+  end
+  return lines
+end
+
 local function buffer_text(bufnr)
-  return table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), '\n')
+  return table.concat(buffer_lines(bufnr), '\n')
 end
 
 local function has_buf_var(bufnr, name)
@@ -370,7 +380,7 @@ describe('commands', function()
 
       local diff_buf = vim.api.nvim_get_current_buf()
       table.insert(test_buffers, diff_buf)
-      local lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
+      local lines = buffer_lines(diff_buf)
 
       assert.is_true(called_index)
       assert.is_false(called_head)
@@ -394,6 +404,11 @@ describe('commands', function()
       assert.is_true(helpers.has_keymap(diff_buf, 'dp'))
       assert.are.equal('diff --git a/lua/foo.lua b/lua/foo.lua', lines[1])
       assert.is_true(table.concat(lines, '\n'):find('+local x = 1', 1, true) ~= nil)
+
+      local display_lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
+      assert.are.equal(6, vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_width'))
+      assert.are.equal('    | diff --git a/lua/foo.lua b/lua/foo.lua', display_lines[1])
+      assert.is_true(table.concat(display_lines, '\n'):find('  2 | +local x = 1', 1, true) ~= nil)
     end)
 
     it('opens default :Gdiff for untracked files as index to worktree additions', function()
@@ -424,7 +439,7 @@ describe('commands', function()
 
       local diff_buf = vim.api.nvim_get_current_buf()
       table.insert(test_buffers, diff_buf)
-      local lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
+      local lines = buffer_lines(diff_buf)
 
       assert.are.equal('diffs://unstaged:lua/new.lua', vim.api.nvim_buf_get_name(diff_buf))
       assert.are.same(
@@ -563,7 +578,7 @@ describe('commands', function()
 
       local diff_buf = vim.api.nvim_get_current_buf()
       table.insert(test_buffers, diff_buf)
-      local lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
+      local lines = buffer_lines(diff_buf)
 
       assert.are.equal('HEAD~3', captured_revision)
       assert.are.equal('diffs://HEAD~3:lua/foo.lua', vim.api.nvim_buf_get_name(diff_buf))
@@ -672,7 +687,7 @@ describe('commands', function()
 
       local diff_buf = vim.api.nvim_get_current_buf()
       table.insert(test_buffers, diff_buf)
-      local text = table.concat(vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false), '\n')
+      local text = buffer_text(diff_buf)
       assert.is_true(text:find('-line 2', 1, true) ~= nil)
       assert.is_true(text:find('+line 2', 1, true) ~= nil)
       assert.is_true(text:find('\\ No newline at end of file', 1, true) ~= nil)
@@ -873,7 +888,7 @@ describe('commands', function()
       table.insert(test_buffers, diff_buf)
 
       local function assert_unmerged_view(bufnr)
-        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        local lines = buffer_lines(bufnr)
         local text = table.concat(lines, '\n')
 
         assert.are.equal('diffs://unmerged:file.txt', vim.api.nvim_buf_get_name(bufnr))
@@ -1056,7 +1071,7 @@ describe('commands', function()
         diffspec.index_to_worktree('lua/new.lua'),
         vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
       )
-      local text = table.concat(vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false), '\n')
+      local text = buffer_text(diff_buf)
       assert.is_true(text:find('new file mode 100644', 1, true) ~= nil)
       assert.is_true(text:find('--- /dev/null', 1, true) ~= nil)
       local diff_hunks = vim.api.nvim_buf_get_var(diff_buf, 'diffs_hunks')
@@ -1101,7 +1116,7 @@ describe('commands', function()
         diffspec.head_to_index('lua/new.lua'),
         vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
       )
-      local text = table.concat(vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false), '\n')
+      local text = buffer_text(diff_buf)
       assert.is_true(text:find('new file mode 100644', 1, true) ~= nil)
       assert.is_true(text:find('--- /dev/null', 1, true) ~= nil)
       local diff_hunks = vim.api.nvim_buf_get_var(diff_buf, 'diffs_hunks')
@@ -1146,7 +1161,7 @@ describe('commands', function()
         diffspec.head_to_index('lua/deleted.lua'),
         vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
       )
-      local text = table.concat(vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false), '\n')
+      local text = buffer_text(diff_buf)
       assert.is_true(text:find('deleted file mode 100644', 1, true) ~= nil)
       assert.is_true(text:find('+++ /dev/null', 1, true) ~= nil)
       local diff_hunks = vim.api.nvim_buf_get_var(diff_buf, 'diffs_hunks')
@@ -1326,7 +1341,7 @@ describe('commands', function()
         assert_no_hunk_maps(bufnr)
       end
 
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      local lines = buffer_lines(bufnr)
       assert.are.equal(case.first_line, lines[1])
       assert.is_false(vim.tbl_contains(lines, 'stale lifecycle content'))
     end

--- a/spec/merge_spec.lua
+++ b/spec/merge_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('spec.helpers')
 local merge = require('diffs.merge')
+local rails = require('diffs.rails')
 
 local function default_config(overrides)
   local cfg = {
@@ -47,6 +48,31 @@ describe('merge', function()
       })
 
       local hunks = merge.parse_hunks(bufnr)
+      assert.are.equal(1, #hunks)
+      assert.are.equal(3, hunks[1].start_line)
+      assert.are.equal(7, hunks[1].end_line)
+      assert.are.same({ 'local x = 1' }, hunks[1].del_lines)
+      assert.are.same({ 'local x = 2' }, hunks[1].add_lines)
+
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('parses generated hunks with line-number rails', function()
+      local annotated, info = rails.annotate({
+        'diff --git a/file.lua b/file.lua',
+        '--- a/file.lua',
+        '+++ b/file.lua',
+        '@@ -1,3 +1,3 @@',
+        ' local M = {}',
+        '-local x = 1',
+        '+local x = 2',
+        ' return M',
+      })
+      local bufnr = helpers.create_buffer(annotated)
+      vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_width', info.prefix_width)
+
+      local hunks = merge.parse_hunks(bufnr)
+
       assert.are.equal(1, #hunks)
       assert.are.equal(3, hunks[1].start_line)
       assert.are.equal(7, hunks[1].end_line)

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -1,5 +1,6 @@
 require('spec.helpers')
 local parser = require('diffs.parser')
+local rails = require('diffs.rails')
 
 describe('parser', function()
   describe('parse_buffer', function()
@@ -52,6 +53,34 @@ describe('parser', function()
       assert.are.equal('lua', hunks[1].lang)
       assert.are.equal(3, hunks[1].start_line)
       assert.are.equal(3, #hunks[1].lines)
+      delete_buffer(bufnr)
+    end)
+
+    it('strips generated line-number rails before parsing hunks', function()
+      local annotated, info = rails.annotate({
+        'diff --git a/lua/test.lua b/lua/test.lua',
+        '--- a/lua/test.lua',
+        '+++ b/lua/test.lua',
+        '@@ -1,2 +1,3 @@',
+        ' local M = {}',
+        '+local new = true',
+        ' return M',
+      })
+      local bufnr = create_buffer(annotated)
+      vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_width', info.prefix_width)
+
+      local hunks = parser.parse_buffer(bufnr)
+
+      assert.are.equal(1, #hunks)
+      assert.are.equal('lua/test.lua', hunks[1].filename)
+      assert.are.equal(info.prefix_width, hunks[1].quote_width)
+      assert.are.equal(info.prefix_width, hunks[1].rail_width)
+      assert.are.equal(4, hunks[1].start_line)
+      assert.are.same({
+        ' local M = {}',
+        '+local new = true',
+        ' return M',
+      }, hunks[1].lines)
       delete_buffer(bufnr)
     end)
 

--- a/spec/rails_spec.lua
+++ b/spec/rails_spec.lua
@@ -1,0 +1,41 @@
+require('spec.helpers')
+
+local rails = require('diffs.rails')
+
+describe('diffs.rails', function()
+  it('adds old and new line-number rails to unified diff lines', function()
+    local annotated, info = rails.annotate({
+      'diff --git a/file.txt b/file.txt',
+      '--- a/file.txt',
+      '+++ b/file.txt',
+      '@@ -9,3 +10,4 @@',
+      ' alpha',
+      '-beta',
+      '+beta changed',
+      ' gamma',
+      '+delta',
+      '\\ No newline at end of file',
+    })
+
+    assert.are.same({
+      width = 2,
+      prefix_width = 8,
+    }, info)
+    assert.are.equal('      | diff --git a/file.txt b/file.txt', annotated[1])
+    assert.are.equal('      | @@ -9,3 +10,4 @@', annotated[4])
+    assert.are.equal(' 9 10 |  alpha', annotated[5])
+    assert.are.equal('10    | -beta', annotated[6])
+    assert.are.equal('   11 | +beta changed', annotated[7])
+    assert.are.equal('11 12 |  gamma', annotated[8])
+    assert.are.equal('   13 | +delta', annotated[9])
+    assert.are.equal('      | \\ No newline at end of file', annotated[10])
+  end)
+
+  it('leaves non-diff content unchanged', function()
+    local lines = { 'not a diff' }
+    local annotated, info = rails.annotate(lines)
+
+    assert.are.equal(lines, annotated)
+    assert.is_nil(info)
+  end)
+end)

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -3,6 +3,7 @@ local helpers = require('spec.helpers')
 local commands = require('diffs.commands')
 local diffspec = require('diffs.spec')
 local git = require('diffs.git')
+local rails = require('diffs.rails')
 local runtime = require('diffs.runtime')
 
 local saved_git = {}
@@ -84,6 +85,11 @@ local function cleanup_buffers()
     end
   end
   test_buffers = {}
+end
+
+local function buffer_lines(bufnr)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  return rails.strip_lines(lines, rails.width_for_buffer(bufnr))
 end
 
 describe('read_buffer', function()
@@ -575,7 +581,7 @@ describe('read_buffer', function()
       assert.are.equal('/home/test/repo', captured_cmd[3])
       assert.are.equal('diff', captured_cmd[4])
 
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      local lines = buffer_lines(bufnr)
       assert.are.equal('diff --git a/file.lua b/file.lua', lines[1])
     end)
 
@@ -619,7 +625,7 @@ describe('read_buffer', function()
       assert.are.equal('diff', captured_cmd[4])
       assert.are.equal('origin/main', captured_cmd[#captured_cmd])
 
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      local lines = buffer_lines(bufnr)
       assert.are.equal('diff --git a/file.lua b/file.lua', lines[1])
     end)
 
@@ -706,7 +712,7 @@ describe('read_buffer', function()
       })
       commands.read_buffer(bufnr)
 
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      local lines = buffer_lines(bufnr)
       assert.are.equal('diff --git a/lua/diffs/init.lua b/lua/diffs/init.lua', lines[1])
       assert.are.equal('--- a/lua/diffs/init.lua', lines[2])
       assert.are.equal('+++ b/lua/diffs/init.lua', lines[3])
@@ -729,7 +735,7 @@ describe('read_buffer', function()
       })
       commands.read_buffer(bufnr)
 
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      local lines = buffer_lines(bufnr)
       assert.are.equal('diff --git a/old_name.lua b/new_name.lua', lines[1])
       assert.are.equal('--- a/old_name.lua', lines[2])
       assert.are.equal('+++ b/new_name.lua', lines[3])
@@ -771,7 +777,7 @@ describe('read_buffer', function()
 
       commands.read_buffer(bufnr)
 
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      local lines = buffer_lines(bufnr)
       assert.are.equal('diff --git a/replace_test.lua b/replace_test.lua', lines[1])
       for _, line in ipairs(lines) do
         assert.is_not_equal('stale', line)


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #251.

## Solution

The solution adds old/new line-number rails to generated unified `diffs://` buffers; keeps raw hunk metadata and mutation behavior backed by unannotated diff lines; and strips generated rails in runtime parsing and merge-resolution parsing so highlighting and conflict helpers keep working.
