### PR TITLE
feat: add split Gdiff layout

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -438,13 +438,16 @@ replace their layout unless the user invoked a generated diffs.nvim view.
     code language, plus diff header highlighting for `diff --git`, `---`,
     `+++`, and `@@` lines.
 
-    If a `diffs://` window already exists in the current tabpage, the new
-    diff replaces its buffer instead of creating another split.
+    In the default unified layout, if a `diffs://` window already exists in the
+    current tabpage, the new diff replaces its buffer instead of creating
+    another split.
 
-    This is a generated unified diff workspace, not Fugitive `:Gdiffsplit`
-    parity. diffs.nvim owns the `diffs://` buffer, hunk metadata, and plugin
-    actions. It does not enter native Vim `&diff` mode, open writable Fugitive
-    object buffers, or emulate `:Gdiffsplit` window lifecycle.
+    This is a generated diff workspace, not Fugitive `:Gdiffsplit` parity.
+    diffs.nvim owns the `diffs://` buffers, hunk metadata, and plugin actions.
+    The default unified layout does not enter native Vim `&diff` mode, open
+    writable Fugitive object buffers, or emulate `:Gdiffsplit` window lifecycle.
+    The experimental `++layout=split` variant uses native `&diff` alignment for
+    generated old/new endpoint windows, but disables diff folds as layout.
 
     Plain direct |:Gdiff| from a worktree file compares the index to the
     worktree and shows only unstaged changes. Staged-only changes report no
@@ -459,6 +462,8 @@ replace their layout unless the user invoked a generated diffs.nvim view.
     Parameters: ~
         ++novertical (optional) Force a horizontal split. Useful with |:Gvdiff|
                     or command wrappers.
+        ++layout=split (optional) Open the current single-file comparison as
+                    experimental paired old/new generated endpoint windows.
         {object}    (string, optional) Fugitive-style object to diff against.
                     Defaults to the current file in the index.
 

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -10,6 +10,7 @@ local log = require('diffs.log')
 local render = require('diffs.render')
 local review = require('diffs.review')
 local runtime = require('diffs.runtime')
+local split = require('diffs.split')
 
 local dbg = log.dbg
 local notify = log.notify
@@ -274,7 +275,7 @@ end
 
 ---@class diffs.GeneratedBufferSource
 ---@field version integer
----@field kind "file"|"file_pair"|"section"|"review"|"unmerged"
+---@field kind "file"|"file_pair"|"section"|"review"|"unmerged"|"split_endpoint"
 ---@field repo_root string
 ---@field spec? diffs.DiffSpec
 ---@field edge? "staged"|"unstaged"
@@ -283,6 +284,8 @@ end
 ---@field section? "staged"|"unstaged"
 ---@field review? diffs.GreviewSpec
 ---@field working_path? string
+---@field side? "left"|"right"
+---@field filetype? string
 
 ---@param source table
 ---@return diffs.GeneratedBufferSource?
@@ -302,6 +305,17 @@ local function normalize_source(source)
       error('expected file spec')
     end
     source.spec = diffspec.new(source.spec)
+  elseif source.kind == 'split_endpoint' then
+    if source.spec == nil then
+      error('expected split endpoint spec')
+    end
+    source.spec = diffspec.new(source.spec)
+    if source.side ~= 'left' and source.side ~= 'right' then
+      error('expected split endpoint side')
+    end
+    if type(source.path) ~= 'string' or source.path == '' then
+      error('expected split endpoint path')
+    end
   elseif source.kind == 'file_pair' then
     if source.edge ~= 'staged' and source.edge ~= 'unstaged' then
       error('expected file_pair edge')
@@ -597,6 +611,10 @@ function M.gdiff(args, vertical)
     and diff_path == rel_path
     and git.is_unmerged(filepath)
   then
+    if parsed.layout == 'split' then
+      notify('split Gdiff does not support unmerged files yet', vim.log.levels.ERROR)
+      return
+    end
     M.gdiff_file(filepath, {
       vertical = vertical,
       unmerged = true,
@@ -604,8 +622,9 @@ function M.gdiff(args, vertical)
     return
   end
 
+  local worktree_lines = content.from_buffer(bufnr)
   local diff_lines, render_err = render.file(diff_spec, repo_root, {
-    worktree_lines = content.from_buffer(bufnr),
+    worktree_lines = worktree_lines,
   })
   if not diff_lines then
     notify(render_err or 'unknown error', vim.log.levels.ERROR)
@@ -614,6 +633,19 @@ function M.gdiff(args, vertical)
 
   if #diff_lines == 0 then
     notify('no changes for ' .. diffspec.label(diff_spec), vim.log.levels.INFO)
+    return
+  end
+
+  if parsed.layout == 'split' then
+    local opened, split_err = split.open({
+      spec = diff_spec,
+      repo_root = repo_root,
+      filetype = vim.api.nvim_get_option_value('filetype', { buf = bufnr }),
+      worktree_lines = worktree_lines,
+    })
+    if not opened then
+      notify(split_err or 'cannot open split Gdiff', vim.log.levels.ERROR)
+    end
     return
   end
 
@@ -846,6 +878,14 @@ function M.read_buffer(bufnr)
   local repo_root = source and source.repo_root or get_buf_var(bufnr, 'diffs_repo_root')
   if not repo_root then
     notify('cannot reload diffs:// buffer without diffs_repo_root', vim.log.levels.WARN)
+    return
+  end
+
+  if source and source.kind == 'split_endpoint' then
+    local ok, err = split.read_buffer(bufnr, source)
+    if not ok then
+      notify(err or 'cannot reload split diffs:// buffer', vim.log.levels.WARN)
+    end
     return
   end
 

--- a/lua/diffs/gdiff.lua
+++ b/lua/diffs/gdiff.lua
@@ -9,6 +9,7 @@ local diffspec = require('diffs.spec')
 ---@class diffs.GdiffParseResult
 ---@field spec diffs.DiffSpec
 ---@field novertical boolean
+---@field layout "unified"|"split"
 
 local function normalize_rev(rev)
   if rev == '@' then
@@ -91,10 +92,18 @@ function M.parse(args, context)
   local current = context.current and diffspec.endpoint(context.current) or diffspec.worktree()
   local tokens = split_args(args)
   local novertical = false
+  local layout = 'unified'
 
   while tokens[1] and tokens[1]:match('^%+%+') do
     if tokens[1] == '++novertical' then
       novertical = true
+      table.remove(tokens, 1)
+    elseif tokens[1]:match('^%+%+layout=') then
+      local value = tokens[1]:match('^%+%+layout=(.+)$')
+      if value ~= 'unified' and value ~= 'split' then
+        return nil, 'unsupported layout ' .. tostring(value)
+      end
+      layout = value
       table.remove(tokens, 1)
     else
       return nil, 'unknown option ' .. tokens[1]
@@ -113,7 +122,9 @@ function M.parse(args, context)
     return {
       spec = default_spec(current, path),
       novertical = novertical,
-    }, nil
+      layout = layout,
+    },
+      nil
   end
 
   local endpoint, err = parse_object_endpoint(tokens[1])
@@ -124,7 +135,9 @@ function M.parse(args, context)
   return {
     spec = diffspec.file(endpoint, current, path),
     novertical = novertical,
-  }, nil
+    layout = layout,
+  },
+    nil
 end
 
 M._test = {

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -1,0 +1,364 @@
+local M = {}
+
+local diffspec = require('diffs.spec')
+local log = require('diffs.log')
+local render = require('diffs.render')
+
+local notify = log.notify
+
+---@class diffs.SplitOpenOpts
+---@field spec diffs.DiffSpec
+---@field repo_root string
+---@field filetype? string
+---@field worktree_lines? diffs.ContentLines|string[]
+
+---@class diffs.SplitEndpointSource
+---@field version integer
+---@field kind "split_endpoint"
+---@field repo_root string
+---@field spec diffs.DiffSpec
+---@field side "left"|"right"
+---@field path string
+---@field filetype? string
+
+---@param repo_root string
+---@param path string
+---@return string
+local function abs_path(repo_root, path)
+  return repo_root .. '/' .. path
+end
+
+---@param endpoint diffs.Endpoint
+---@return string
+local function endpoint_name(endpoint)
+  endpoint = diffspec.endpoint(endpoint)
+  if endpoint.kind == diffspec.endpoint_kind.tree then
+    return endpoint.rev
+  end
+  return endpoint.kind
+end
+
+---@param diff_spec diffs.DiffSpec
+---@param side "left"|"right"
+---@return diffs.Endpoint
+local function side_endpoint(diff_spec, side)
+  diff_spec = diffspec.new(diff_spec)
+  return side == 'left' and diff_spec.left or diff_spec.right
+end
+
+---@param lines string[]
+---@return string[]
+local function plain_lines(lines)
+  local result = {}
+  for i, line in ipairs(lines) do
+    result[i] = line
+  end
+  return result
+end
+
+---@param source diffs.SplitEndpointSource
+---@param opts? { worktree_lines?: diffs.ContentLines|string[] }
+---@return string[]?, string?
+local function endpoint_lines(source, opts)
+  opts = opts or {}
+  local spec = diffspec.new(source.spec)
+  local lines, err = render.read_endpoint(
+    side_endpoint(spec, source.side),
+    abs_path(source.repo_root, source.path),
+    {
+      worktree_lines = opts.worktree_lines,
+      empty_on_missing = true,
+    }
+  )
+  if not lines then
+    return nil, err or ('could not read ' .. source.side .. ' endpoint')
+  end
+  return plain_lines(lines), nil
+end
+
+---@param bufnr integer
+---@param source diffs.SplitEndpointSource
+local function set_source_vars(bufnr, source)
+  vim.api.nvim_buf_set_var(bufnr, 'diffs_repo_root', source.repo_root)
+  vim.api.nvim_buf_set_var(bufnr, 'diffs_spec', diffspec.new(source.spec))
+  vim.api.nvim_buf_set_var(bufnr, 'diffs_source', source)
+  vim.api.nvim_buf_set_var(bufnr, 'diffs_split_side', source.side)
+end
+
+---@param bufnr integer
+---@param filetype? string
+local function set_buffer_options(bufnr, filetype)
+  vim.api.nvim_set_option_value('buftype', 'nowrite', { buf = bufnr })
+  vim.api.nvim_set_option_value('bufhidden', 'delete', { buf = bufnr })
+  vim.api.nvim_set_option_value('swapfile', false, { buf = bufnr })
+  vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
+  if filetype and filetype ~= '' then
+    vim.api.nvim_set_option_value('filetype', filetype, { buf = bufnr })
+  end
+end
+
+---@param bufnr integer
+---@param mode string
+---@param lhs string
+---@return table?
+local function get_buffer_keymap(bufnr, mode, lhs)
+  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, mode)) do
+    if keymap.lhs == lhs then
+      return keymap
+    end
+  end
+  return nil
+end
+
+---@param bufnr integer
+local function set_keymaps(bufnr)
+  if not get_buffer_keymap(bufnr, 'n', 'q') then
+    vim.keymap.set('n', 'q', function()
+      M.close_pair(vim.api.nvim_get_current_buf())
+    end, { buffer = bufnr, desc = 'Close split diff' })
+  end
+  if not get_buffer_keymap(bufnr, 'n', '<CR>') then
+    vim.keymap.set('n', '<CR>', function()
+      M.open_source(vim.api.nvim_get_current_buf())
+    end, { buffer = bufnr, desc = 'Open source file' })
+  end
+end
+
+---@param source diffs.SplitEndpointSource
+---@return string
+local function buffer_name(source)
+  local spec = diffspec.new(source.spec)
+  local endpoint = side_endpoint(spec, source.side)
+  return 'diffs://split:' .. source.side .. ':' .. endpoint_name(endpoint) .. ':' .. source.path
+end
+
+---@param source diffs.SplitEndpointSource
+---@param lines string[]
+---@return integer
+local function create_buffer(source, lines)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  vim.api.nvim_buf_set_name(bufnr, buffer_name(source))
+  set_source_vars(bufnr, source)
+  set_buffer_options(bufnr, source.filetype)
+  set_keymaps(bufnr)
+  return bufnr
+end
+
+---@param win integer
+local function disable_diff_folds(win)
+  vim.api.nvim_set_option_value('foldmethod', 'manual', { win = win })
+  vim.api.nvim_set_option_value('foldenable', false, { win = win })
+  vim.api.nvim_set_option_value('foldcolumn', '0', { win = win })
+end
+
+---@param win integer
+local function enable_diff(win)
+  vim.api.nvim_set_current_win(win)
+  vim.cmd.diffthis()
+  disable_diff_folds(win)
+end
+
+---@param bufnr integer
+---@return integer?
+local function split_peer(bufnr)
+  local ok, peer = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_split_peer')
+  if ok and type(peer) == 'number' and vim.api.nvim_buf_is_valid(peer) then
+    return peer
+  end
+  return nil
+end
+
+---@param buffers table<integer, boolean>
+---@param bufnr integer?
+local function add_valid_buffer(buffers, bufnr)
+  if type(bufnr) == 'number' and vim.api.nvim_buf_is_valid(bufnr) then
+    buffers[bufnr] = true
+  end
+end
+
+---@param win integer
+---@param buffers table<integer, boolean>
+---@return boolean
+local function window_has_buffer(win, buffers)
+  return buffers[vim.api.nvim_win_get_buf(win)] == true
+end
+
+---@param opts diffs.SplitOpenOpts
+---@return { left_buf: integer, right_buf: integer, left_win: integer, right_win: integer }?, string?
+function M.open(opts)
+  local spec = diffspec.new(opts.spec)
+  local filetype = opts.filetype
+  local path = spec.scope.path
+  local base_source = {
+    version = 1,
+    kind = 'split_endpoint',
+    repo_root = opts.repo_root,
+    spec = spec,
+    path = path,
+    filetype = filetype,
+  }
+
+  local left_source = vim.tbl_extend('force', base_source, { side = 'left' })
+  local right_source = vim.tbl_extend('force', base_source, { side = 'right' })
+  local left_lines, left_err = endpoint_lines(left_source, { worktree_lines = opts.worktree_lines })
+  if not left_lines then
+    return nil, left_err
+  end
+  local right_lines, right_err =
+    endpoint_lines(right_source, { worktree_lines = opts.worktree_lines })
+  if not right_lines then
+    return nil, right_err
+  end
+
+  local left_buf = create_buffer(left_source, left_lines)
+  local right_buf = create_buffer(right_source, right_lines)
+  local left_win = vim.api.nvim_get_current_win()
+  vim.cmd('rightbelow vsplit')
+  local right_win = vim.api.nvim_get_current_win()
+
+  vim.api.nvim_win_set_buf(left_win, left_buf)
+  vim.api.nvim_win_set_buf(right_win, right_buf)
+  vim.api.nvim_buf_set_var(left_buf, 'diffs_split_peer', right_buf)
+  vim.api.nvim_buf_set_var(right_buf, 'diffs_split_peer', left_buf)
+
+  enable_diff(left_win)
+  enable_diff(right_win)
+  vim.api.nvim_set_current_win(right_win)
+  vim.cmd.diffupdate()
+  disable_diff_folds(left_win)
+  disable_diff_folds(right_win)
+
+  log.dbg('opened split diff buffers %d/%d for %s', left_buf, right_buf, diffspec.label(spec))
+  return {
+    left_buf = left_buf,
+    right_buf = right_buf,
+    left_win = left_win,
+    right_win = right_win,
+  },
+    nil
+end
+
+---@param source table
+---@return diffs.SplitEndpointSource
+local function normalize_source(source)
+  return {
+    version = 1,
+    kind = 'split_endpoint',
+    repo_root = source.repo_root,
+    spec = diffspec.new(source.spec),
+    side = source.side,
+    path = source.path,
+    filetype = source.filetype,
+  }
+end
+
+---@param bufnr integer
+---@param source table
+---@return boolean, string?
+function M.read_buffer(bufnr, source)
+  source = normalize_source(source)
+  local lines, err = endpoint_lines(source)
+  if not lines then
+    return false, err
+  end
+
+  vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  set_source_vars(bufnr, source)
+  set_buffer_options(bufnr, source.filetype)
+  set_keymaps(bufnr)
+  return true, nil
+end
+
+---@param bufnr? integer
+---@return boolean
+function M.close_pair(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+  local buffers = {}
+  add_valid_buffer(buffers, bufnr)
+  add_valid_buffer(buffers, split_peer(bufnr))
+  if vim.tbl_isempty(buffers) then
+    return false
+  end
+
+  local pair_wins = {}
+  local non_pair_wins = {}
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    if vim.api.nvim_win_is_valid(win) then
+      if window_has_buffer(win, buffers) then
+        pair_wins[#pair_wins + 1] = win
+      else
+        non_pair_wins[#non_pair_wins + 1] = win
+      end
+    end
+  end
+
+  local keep_win
+  if #non_pair_wins == 0 then
+    local current_win = vim.api.nvim_get_current_win()
+    for _, win in ipairs(pair_wins) do
+      if win == current_win then
+        keep_win = win
+        break
+      end
+    end
+    keep_win = keep_win or pair_wins[1]
+    if keep_win and vim.api.nvim_win_is_valid(keep_win) then
+      vim.api.nvim_set_current_win(keep_win)
+      vim.cmd.diffoff()
+      vim.cmd.enew()
+    end
+  end
+
+  for _, win in ipairs(pair_wins) do
+    if win ~= keep_win and vim.api.nvim_win_is_valid(win) then
+      pcall(vim.api.nvim_win_close, win, true)
+    end
+  end
+
+  for buf in pairs(buffers) do
+    if vim.api.nvim_buf_is_valid(buf) then
+      pcall(vim.api.nvim_buf_delete, buf, { force = true })
+    end
+  end
+
+  local focus_win = non_pair_wins[1] or keep_win
+  if focus_win and vim.api.nvim_win_is_valid(focus_win) then
+    vim.api.nvim_set_current_win(focus_win)
+  end
+
+  return true
+end
+
+---@param bufnr integer
+---@return boolean
+function M.open_source(bufnr)
+  local ok, source = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_source')
+  if not ok or type(source) ~= 'table' or source.kind ~= 'split_endpoint' then
+    notify('missing split diff source metadata', vim.log.levels.WARN)
+    return false
+  end
+
+  source = normalize_source(source)
+  local endpoint = side_endpoint(source.spec, source.side)
+  if endpoint.kind ~= diffspec.endpoint_kind.worktree then
+    notify('cannot open non-worktree split endpoint as a source file', vim.log.levels.WARN)
+    return false
+  end
+
+  local filepath = abs_path(source.repo_root, source.path)
+  local target_lnum = vim.api.nvim_win_get_cursor(0)[1]
+  vim.cmd.edit(vim.fn.fnameescape(filepath))
+  local lnum = math.max(1, math.min(target_lnum, vim.api.nvim_buf_line_count(0)))
+  vim.api.nvim_win_set_cursor(0, { lnum, 0 })
+  return true
+end
+
+M._test = {
+  buffer_name = buffer_name,
+  endpoint_lines = endpoint_lines,
+}
+
+return M

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -287,6 +287,53 @@ describe('commands', function()
   end)
 
   describe('Gdiff DiffSpec rendering', function()
+    local function create_split_source()
+      local source_buf = vim.api.nvim_create_buf(false, true)
+      table.insert(test_buffers, source_buf)
+      vim.api.nvim_buf_set_name(source_buf, '/tmp/repo/lua/foo.lua')
+      vim.api.nvim_buf_set_lines(source_buf, 0, -1, false, {
+        'local M = {}',
+        'local x = 1',
+        'return M',
+      })
+      vim.api.nvim_set_option_value('filetype', 'lua', { buf = source_buf })
+      vim.api.nvim_set_current_buf(source_buf)
+
+      mock_git_method('get_relative_path', function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return 'lua/foo.lua'
+      end)
+      mock_git_method('get_index_content', function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return { 'local M = {}', 'return M' }
+      end)
+      mock_repo_root(function(filepath)
+        assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+        return '/tmp/repo'
+      end)
+
+      return source_buf
+    end
+
+    local function find_split_windows(left_buf, right_buf)
+      local left_win
+      local right_win
+      local left_index
+      local right_index
+      for i, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local win_buf = vim.api.nvim_win_get_buf(win)
+        if win_buf == left_buf then
+          left_win = win
+          left_index = i
+        elseif win_buf == right_buf then
+          right_win = win
+          right_index = i
+        end
+      end
+
+      return left_win, right_win, left_index, right_index
+    end
+
     it('opens default :Gdiff as an unstaged index to worktree diff', function()
       local source_buf = vim.api.nvim_create_buf(false, true)
       table.insert(test_buffers, source_buf)
@@ -388,6 +435,101 @@ describe('commands', function()
       assert.is_true(text:find('new file mode 100644', 1, true) ~= nil)
       assert.is_true(text:find('--- /dev/null', 1, true) ~= nil)
       assert.is_true(text:find('+local M = {}', 1, true) ~= nil)
+    end)
+
+    it('opens opt-in split :Gdiff as paired endpoint windows', function()
+      local saved_splitright = vim.o.splitright
+      vim.o.splitright = false
+      local ok, err = pcall(function()
+        create_split_source()
+        commands.gdiff('++layout=split', false)
+      end)
+      vim.o.splitright = saved_splitright
+      assert.is_true(ok, err)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+      local left_win, right_win, left_index, right_index = find_split_windows(left_buf, right_buf)
+
+      assert.is_not_nil(left_win)
+      assert.is_not_nil(right_win)
+      assert.is_true(left_index < right_index)
+      assert.are.equal('diffs://split:left:index:lua/foo.lua', vim.api.nvim_buf_get_name(left_buf))
+      assert.are.equal(
+        'diffs://split:right:worktree:lua/foo.lua',
+        vim.api.nvim_buf_get_name(right_buf)
+      )
+      assert.are.same(
+        { 'local M = {}', 'return M' },
+        vim.api.nvim_buf_get_lines(left_buf, 0, -1, false)
+      )
+      assert.are.same(
+        { 'local M = {}', 'local x = 1', 'return M' },
+        vim.api.nvim_buf_get_lines(right_buf, 0, -1, false)
+      )
+      assert.are.same(
+        diffspec.index_to_worktree('lua/foo.lua'),
+        vim.api.nvim_buf_get_var(left_buf, 'diffs_spec')
+      )
+      assert.are.equal('left', vim.api.nvim_buf_get_var(left_buf, 'diffs_split_side'))
+      assert.are.equal('right', vim.api.nvim_buf_get_var(right_buf, 'diffs_split_side'))
+      assert.are.equal('lua', vim.api.nvim_get_option_value('filetype', { buf = left_buf }))
+      assert.are.equal('lua', vim.api.nvim_get_option_value('filetype', { buf = right_buf }))
+      assert.is_false(vim.api.nvim_get_option_value('modifiable', { buf = left_buf }))
+      assert.is_false(vim.api.nvim_get_option_value('modifiable', { buf = right_buf }))
+      assert.is_true(vim.api.nvim_get_option_value('diff', { win = left_win }))
+      assert.is_true(vim.api.nvim_get_option_value('diff', { win = right_win }))
+      assert.are.equal('manual', vim.api.nvim_get_option_value('foldmethod', { win = left_win }))
+      assert.are.equal('manual', vim.api.nvim_get_option_value('foldmethod', { win = right_win }))
+      assert.is_false(vim.api.nvim_get_option_value('foldenable', { win = left_win }))
+      assert.is_false(vim.api.nvim_get_option_value('foldenable', { win = right_win }))
+      assert.are.equal('0', vim.api.nvim_get_option_value('foldcolumn', { win = left_win }))
+      assert.are.equal('0', vim.api.nvim_get_option_value('foldcolumn', { win = right_win }))
+      assert.is_true(helpers.has_keymap(left_buf, 'q'))
+      assert.is_true(helpers.has_keymap(right_buf, 'q'))
+      assert.is_true(helpers.has_keymap(left_buf, '<CR>'))
+      assert.is_true(helpers.has_keymap(right_buf, '<CR>'))
+      assert.is_false(helpers.has_keymap(right_buf, 'dp'))
+      assert.is_false(helpers.has_keymap(right_buf, 'do'))
+    end)
+
+    it('closes paired split endpoint buffers with q and can reopen the same split', function()
+      local source_buf = create_split_source()
+
+      commands.gdiff('++layout=split', false)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+      local _, right_win = find_split_windows(left_buf, right_buf)
+
+      vim.api.nvim_set_current_win(right_win)
+      vim.cmd('normal q')
+
+      assert.is_false(vim.api.nvim_buf_is_valid(left_buf))
+      assert.is_false(vim.api.nvim_buf_is_valid(right_buf))
+
+      vim.api.nvim_set_current_buf(source_buf)
+      assert.has_no.errors(function()
+        commands.gdiff('++layout=split', false)
+      end)
+
+      local reopened_right_buf = vim.api.nvim_get_current_buf()
+      local reopened_left_buf = vim.api.nvim_buf_get_var(reopened_right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, reopened_left_buf)
+      table.insert(test_buffers, reopened_right_buf)
+
+      assert.are.equal(
+        'diffs://split:left:index:lua/foo.lua',
+        vim.api.nvim_buf_get_name(reopened_left_buf)
+      )
+      assert.are.equal(
+        'diffs://split:right:worktree:lua/foo.lua',
+        vim.api.nvim_buf_get_name(reopened_right_buf)
+      )
     end)
 
     it('preserves the explicit revision generated buffer surface', function()

--- a/spec/gdiff_spec.lua
+++ b/spec/gdiff_spec.lua
@@ -20,6 +20,7 @@ describe('diffs.gdiff', function()
 
     assert.are.same(diffspec.index_to_worktree(path), result.spec)
     assert.is_false(result.novertical)
+    assert.are.equal('unified', result.layout)
   end)
 
   it('maps explicit revisions to revision -> worktree', function()
@@ -65,6 +66,29 @@ describe('diffs.gdiff', function()
 
     assert.are.same(diffspec.rev_to_worktree('HEAD', path), result.spec)
     assert.is_true(result.novertical)
+    assert.are.equal('unified', result.layout)
+  end)
+
+  it('parses opt-in split layout separately from endpoint parsing', function()
+    local result = parse('++layout=split HEAD')
+
+    assert.are.same(diffspec.rev_to_worktree('HEAD', path), result.spec)
+    assert.is_false(result.novertical)
+    assert.are.equal('split', result.layout)
+  end)
+
+  it('allows explicit unified layout', function()
+    local result = parse('++layout=unified HEAD')
+
+    assert.are.same(diffspec.rev_to_worktree('HEAD', path), result.spec)
+    assert.are.equal('unified', result.layout)
+  end)
+
+  it('rejects unsupported layouts', function()
+    local result, err = gdiff.parse('++layout=tiled HEAD', { path = path })
+
+    assert.is_nil(result)
+    assert.are.equal('unsupported layout tiled', err)
   end)
 
   it('rejects unknown ++ options', function()

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -327,6 +327,42 @@ describe('read_buffer', function()
       assert.is_true(diff_hunks[1].actionable)
     end)
 
+    it('reloads split endpoint buffers from source metadata', function()
+      local called_index = false
+      mock_git({
+        get_index_content = function(filepath)
+          called_index = true
+          assert.are.equal('/tmp/repo/lua/foo.lua', filepath)
+          return { 'local M = {}', 'return M' }
+        end,
+      })
+
+      local bufnr = create_diffs_buffer('diffs://split:left:index:lua/foo.lua', {
+        diffs_source = {
+          version = 1,
+          kind = 'split_endpoint',
+          repo_root = '/tmp/repo',
+          spec = diffspec.index_to_worktree('lua/foo.lua'),
+          side = 'left',
+          path = 'lua/foo.lua',
+          filetype = 'lua',
+        },
+      })
+
+      commands.read_buffer(bufnr)
+
+      assert.is_true(called_index)
+      assert.are.same(
+        { 'local M = {}', 'return M' },
+        vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      )
+      assert.are.equal('lua', vim.api.nvim_get_option_value('filetype', { buf = bufnr }))
+      assert.is_false(vim.api.nvim_get_option_value('modifiable', { buf = bufnr }))
+      assert.are.equal('left', vim.api.nvim_buf_get_var(bufnr, 'diffs_split_side'))
+      assert.is_true(helpers.has_keymap(bufnr, 'q'))
+      assert.is_true(helpers.has_keymap(bufnr, '<CR>'))
+    end)
+
     it('reloads untracked DiffSpec buffers with empty index content and hunk metadata', function()
       mock_git({
         get_index_content = function(filepath)


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #252.

## Solution

The solution adds opt-in `:Gdiff ++layout=split` for single-file generated diffs; renders old/new endpoints in real paired windows with native diff alignment and no diff-fold layout; and stores split endpoint metadata so `diffs://` reloads, close/reopen, and source-open behavior stay owned by diffs.nvim.
