### PR TITLE
docs: define paired-window contract

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -421,9 +421,10 @@ Generated workspace boundaries: ~
 
 diffs.nvim only replaces layout for buffers it creates and can model as
 explicit endpoints. Today that means generated |:Gdiff| buffers, |:Greview|
-buffers, and plugin-owned launches from integrations such as Fugitive status
-maps. Future generated commit or split views must follow the same rule: first
-model the source endpoints, then own the layout.
+buffers, experimental split views, and plugin-owned launches from integrations
+such as Fugitive status maps. Generated commit views and any other future layout
+replacements must follow the same rule: first model the source endpoints, then
+own the layout.
 
 Ordinary `git`, `gitcommit`, `diff`, `extra_filetypes`, picker previews, and
 third-party integration buffers remain highlight-only. diffs.nvim may attach
@@ -521,10 +522,86 @@ replace their layout unless the user invoked a generated diffs.nvim view.
     appears only for supported tree -> index hunks/ranges. Read-only and
     unsupported generated buffers do not expose mutation maps.
 
-    Native paired-window expectations such as `:Gdiffsplit`, `:Gdiffsplit!`,
-    3-way `&diff` windows, writable Fugitive object buffers, and `dq` are
-    outside the generated-buffer contract. Track that product direction in
-    upstream issues #252 and #253.
+    Native expectations outside this generated-buffer contract, such as
+    `:Gdiffsplit!`, 3-way `&diff` windows, writable Fugitive object buffers,
+    and `dq`, are not emulated.
+
+Generated paired-window contract: ~             *diffs.nvim-paired-windows*
+
+    The `++layout=split` view is the generated split rendering of a single
+    |:Gdiff| file comparison. It is not a parser for arbitrary diff text and it
+    must only apply when diffs.nvim owns explicit endpoint metadata.
+
+    The contract below describes the target behavior for generated paired
+    windows. It is an implementation target for the experimental split view, not
+    a claim that every current release implements each item.
+
+    Model: ~
+        - The left window displays the old endpoint and the right window
+          displays the new endpoint.
+        - Both buffers are generated `diffs://` endpoint buffers with stored
+          repo root, DiffSpec, endpoint side, and source path metadata.
+        - Both endpoint buffers are read-only views. Edits happen in real source
+          buffers opened from the generated view.
+        - Native `&diff` alignment may provide filler rows, but diff folds are
+          not the layout mechanism and should be disabled for generated split
+          windows.
+        - Window-local user settings such as statusline, statuscolumn, number,
+          and cursorline should be preserved unless the generated view
+          explicitly owns and documents a local display choice.
+
+    Lifecycle: ~
+        - Opening a split view creates or reuses a coherent pair. It must not
+          leave stale endpoint buffers with duplicate `diffs://` names.
+        - `q` closes the pair, not just the current endpoint. Both generated
+          endpoint buffers should be deleted.
+        - Manually closing, wiping, or deleting either endpoint should not leave
+          an actionable half-pair. The remaining side should be closed or
+          detached from pair-only mappings and metadata.
+        - If the pair contains the last usable window, closing it may replace
+          one window with an empty buffer rather than closing Neovim.
+
+    Refresh: ~
+        - `:edit`, `BufReadCmd`, and pair-owned refresh paths should reload the
+          same comparison from stored metadata.
+        - Refreshing either endpoint should refresh both endpoints when the peer
+          is still valid.
+        - A failed reload should report the failing endpoint/spec and avoid a
+          silent partial update where one side is fresh and the other is stale.
+
+    Navigation: ~
+        - `]c` and `[c` should work from either endpoint and move through the
+          same underlying hunk sequence.
+        - Moving to a hunk should keep the paired windows aligned. If an
+          endpoint has no real line for that side of the hunk, land on the
+          nearest aligned row rather than inventing buffer text.
+        - Wrapping behavior should match unified generated |:Gdiff| hunk
+          navigation.
+
+    Source opening: ~
+        - `<CR>` opens a real worktree source file only when the current
+          endpoint and row can be mapped to worktree content.
+        - Tree-backed and index-backed rows should explain that they cannot be
+          opened as writable worktree files.
+        - Source opening should prefer an existing source window when one is
+          already visible.
+
+    Cursor and scroll sync: ~
+        - The paired windows should act as one comparison while still allowing
+          the cursor to live on either side.
+        - Cursor and scroll sync may be best-effort around native diff filler
+          rows, but it must not mutate generated buffers from decoration or
+          redraw callbacks.
+        - Sync should not require global options or leave unrelated windows
+          scroll-bound after the pair closes.
+
+    Deferred decisions: ~
+        - Quickfix and location-list targets for split rows are not settled.
+          Until that is decided, split |:Gdiff| should not add new qf/loclist
+          behavior beyond existing |:Greview| lists.
+        - Direct editing of the right-side generated worktree endpoint is not
+          part of the contract. Generated endpoint buffers remain read-only
+          unless a later API explicitly changes that ownership model.
 
 
 :Gvdiff [object]                                                     *:Gvdiff*
@@ -702,13 +779,14 @@ Diff buffer mappings: ~
                                                                 *diffs.nvim-q*
     q               Close the diff window. Available in all `diffs://`
                     buffers created by |:Gdiff|, |:Gvdiff|, |:Ghdiff|,
-                    or the fugitive status keymaps.
-    ]c              Jump to the next hunk boundary in generated |:Gdiff|
+                    or the fugitive status keymaps. In generated paired split
+                    views, close the pair; see |diffs.nvim-paired-windows|.
+    ]c              Jump to the next hunk boundary in unified generated |:Gdiff|
                     buffers.
-    [c              Jump to the previous hunk boundary in generated |:Gdiff|
-                    buffers.
+    [c              Jump to the previous hunk boundary in unified generated
+                    |:Gdiff| buffers.
     <CR>            Open the real worktree file at the current |:Gdiff| hunk
-                    location when the right side is worktree-backed.
+                    location when the current endpoint row is worktree-backed.
     dp              In Normal mode, stage the current whole hunk when the
                     buffer compares the index to the worktree. In Visual mode,
                     stage selected changed lines inside one hunk.


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #253.

## Solution

The solution documents the target contract for generated paired split `:Gdiff` windows; separates current mapping behavior from future paired-window lifecycle expectations; and keeps qf/loclist targeting and editability explicitly deferred.
