### PR TITLE
fix: clarify Greview missing refs

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -548,7 +548,11 @@ local function render_source(source)
   end
 
   if source.kind == 'review' then
-    return review.reload_source(source, review_deps()), nil, 'review'
+    local review_lines, review_err = review.reload_source(source, review_deps())
+    if not review_lines then
+      return nil, nil, review_err
+    end
+    return review_lines, nil, 'review'
   end
 
   local abs_path = source.repo_root .. '/' .. source.path
@@ -945,7 +949,12 @@ function M.read_buffer(bufnr)
     if not stored_spec and path == 'all' then
       diff_lines = render_section_source(repo_root, label)
     elseif not stored_spec and label == 'review' then
-      diff_lines = review.reload(bufnr, repo_root, path, review_deps())
+      local review_err
+      diff_lines, review_err = review.reload(bufnr, repo_root, path, review_deps())
+      if not diff_lines then
+        notify(review_err or 'cannot reload review buffer', vim.log.levels.WARN)
+        return
+      end
     elseif not stored_spec then
       local abs_path = repo_root .. '/' .. path
 

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -68,6 +68,53 @@ local function default_branch(repo_root)
   return ref[1]:gsub('^refs/remotes/', '')
 end
 
+---@param repo_root string
+---@param args string[]
+---@return boolean
+local function git_exits_zero(repo_root, args)
+  local cmd = { 'git', '-C', repo_root }
+  vim.list_extend(cmd, args)
+  vim.fn.systemlist(cmd)
+  return vim.v.shell_error == 0
+end
+
+---@param repo_root string
+---@param ref string
+---@return boolean
+local function ref_exists(repo_root, ref)
+  return git_exits_zero(repo_root, { 'rev-parse', '--verify', '--quiet', ref .. '^{commit}' })
+end
+
+---@param repo_root string
+---@param base string
+---@param target string
+---@return boolean
+local function merge_base_exists(repo_root, base, target)
+  return git_exits_zero(repo_root, { 'merge-base', base, target })
+end
+
+---@param repo_root string
+---@param base string
+---@param target string?
+---@param mode string?
+---@param display string
+---@return string?
+local function validate_refs(repo_root, base, target, mode, display)
+  if not ref_exists(repo_root, base) then
+    return ('Greview base ref not found: %s (spec: %s)'):format(base, display)
+  end
+
+  if target and not ref_exists(repo_root, target) then
+    return ('Greview target ref not found: %s (spec: %s)'):format(target, display)
+  end
+
+  if target and mode == 'merge-base' and not merge_base_exists(repo_root, base, target) then
+    return 'Greview merge base not found for spec: ' .. display
+  end
+
+  return nil
+end
+
 ---@param arg? string
 ---@return diffs.GreviewSpec?, string?
 function M.parse_arg(arg)
@@ -157,6 +204,11 @@ function M.normalize(spec, repo_root_override)
       display = base .. '..' .. target
       exec_args = { base, target }
     end
+  end
+
+  local ref_err = validate_refs(repo_root, base, target, mode, display)
+  if ref_err then
+    return nil, ref_err
   end
 
   return {
@@ -258,7 +310,7 @@ end
 function M.run(review, deps)
   local result = vim.fn.systemlist(M.build_cmd(review))
   if vim.v.shell_error ~= 0 then
-    return nil, 'git diff failed'
+    return nil, 'git diff failed for Greview spec: ' .. review.display
   end
   return deps.replace_combined_diffs(result, review.repo_root), nil
 end
@@ -460,24 +512,31 @@ function M.file_at_line(buf, lnum)
   return nil
 end
 
----@param source diffs.GeneratedBufferSource
+---@param review_spec diffs.GreviewSpec?
+---@param repo_root string
 ---@param deps diffs.ReviewDeps
----@return string[]
-function M.reload_source(source, deps)
-  local normalized = select(1, M.normalize(source.review, source.repo_root))
-  if normalized then
-    local result = select(1, M.run(normalized, deps))
-    return result or {}
+---@return string[]?, string?
+local function reload_spec(review_spec, repo_root, deps)
+  local normalized, normalize_err = M.normalize(review_spec, repo_root)
+  if not normalized then
+    return nil, normalize_err
   end
 
-  return {}
+  return M.run(normalized, deps)
+end
+
+---@param source diffs.GeneratedBufferSource
+---@param deps diffs.ReviewDeps
+---@return string[]?, string?
+function M.reload_source(source, deps)
+  return reload_spec(source.review, source.repo_root, deps)
 end
 
 ---@param bufnr integer
 ---@param repo_root string
 ---@param path string
 ---@param deps diffs.ReviewDeps
----@return string[]
+---@return string[]?, string?
 function M.reload(bufnr, repo_root, path, deps)
   local stored_base = get_buf_var(bufnr, 'diffs_review_base')
   local stored_target = get_buf_var(bufnr, 'diffs_review_target')
@@ -491,18 +550,14 @@ function M.reload(bufnr, repo_root, path, deps)
       mode = stored_mode,
     }
   else
-    review_spec = select(1, M.parse_arg(path))
-  end
-
-  if review_spec then
-    local normalized = select(1, M.normalize(review_spec, repo_root))
-    if normalized then
-      local result = select(1, M.run(normalized, deps))
-      return result or {}
+    local parse_err
+    review_spec, parse_err = M.parse_arg(path)
+    if not review_spec then
+      return nil, parse_err
     end
   end
 
-  return {}
+  return reload_spec(review_spec, repo_root, deps)
 end
 
 return M

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -29,8 +29,12 @@ end
 local function mock_systemlist(fn)
   saved_systemlist = vim.fn.systemlist
   vim.fn.systemlist = function(cmd)
-    local result = fn(cmd)
-    saved_systemlist({ 'true' })
+    local result, shell_error = fn(cmd)
+    if shell_error and shell_error ~= 0 then
+      saved_systemlist({ 'false' })
+    else
+      saved_systemlist({ 'true' })
+    end
     return result
   end
 end
@@ -1448,6 +1452,12 @@ describe('commands', function()
         return entry and entry.worktree and '100644' or nil
       end)
       mock_systemlist(function(cmd)
+        if cmd[4] == 'rev-parse' then
+          return { 'commit' }
+        end
+        if cmd[4] == 'merge-base' then
+          return { 'merge-base-commit' }
+        end
         if
           contains_cmd_arg(cmd, '--name-status')
           or contains_cmd_arg(cmd, '--numstat')
@@ -1697,14 +1707,20 @@ describe('commands', function()
     end)
 
     it('normalizes default base inside the resolved repo', function()
-      local captured_cmd
+      local captured_cmds = {}
       mock_repo_root(function(path)
         assert.are.equal('/tmp/repo/.', path)
         return '/tmp/repo'
       end)
       mock_systemlist(function(cmd)
-        captured_cmd = cmd
-        return { 'refs/remotes/origin/main' }
+        captured_cmds[#captured_cmds + 1] = cmd
+        if cmd[4] == 'symbolic-ref' then
+          return { 'refs/remotes/origin/main' }
+        end
+        if cmd[4] == 'rev-parse' then
+          return { 'commit' }
+        end
+        return {}
       end)
 
       local review = commands._test.normalize_greview({ repo = '/tmp/repo' })
@@ -1714,7 +1730,11 @@ describe('commands', function()
       assert.are.equal('origin/main', review.display)
       assert.are.same(
         { 'git', '-C', '/tmp/repo', 'symbolic-ref', 'refs/remotes/origin/HEAD' },
-        captured_cmd
+        captured_cmds[1]
+      )
+      assert.are.same(
+        { 'git', '-C', '/tmp/repo', 'rev-parse', '--verify', '--quiet', 'origin/main^{commit}' },
+        captured_cmds[2]
       )
     end)
 
@@ -1759,6 +1779,114 @@ describe('commands', function()
   end)
 
   describe('greview', function()
+    it('reports a missing base ref before rendering', function()
+      local called_diff = false
+      local notifications = capture_notifications()
+      mock_repo_root(function(path)
+        assert.are.equal('/tmp/repo/.', path)
+        return '/tmp/repo'
+      end)
+      mock_systemlist(function(cmd)
+        if cmd[4] == 'diff' then
+          called_diff = true
+        end
+        if cmd[4] == 'rev-parse' then
+          return {}, 1
+        end
+        return {}
+      end)
+
+      local bufnr = commands.greview({
+        base = 'missing/ref',
+        repo = '/tmp/repo',
+      })
+
+      assert.is_nil(bufnr)
+      assert.is_false(called_diff)
+      assert.are.equal(vim.log.levels.ERROR, notifications[#notifications].level)
+      assert.is_true(
+        notifications[#notifications].message:find(
+          'Greview base ref not found: missing/ref (spec: missing/ref)',
+          1,
+          true
+        ) ~= nil
+      )
+    end)
+
+    it('reports a missing target ref before rendering', function()
+      local called_diff = false
+      local called_merge_base = false
+      local notifications = capture_notifications()
+      mock_repo_root(function(path)
+        assert.are.equal('/tmp/repo/.', path)
+        return '/tmp/repo'
+      end)
+      mock_systemlist(function(cmd)
+        if cmd[4] == 'diff' then
+          called_diff = true
+        elseif cmd[4] == 'merge-base' then
+          called_merge_base = true
+        elseif cmd[4] == 'rev-parse' and cmd[7] == 'missing/target^{commit}' then
+          return {}, 1
+        end
+        return {}
+      end)
+
+      local bufnr = commands.greview({
+        base = 'HEAD',
+        target = 'missing/target',
+        mode = 'merge-base',
+        repo = '/tmp/repo',
+      })
+
+      assert.is_nil(bufnr)
+      assert.is_false(called_diff)
+      assert.is_false(called_merge_base)
+      assert.are.equal(vim.log.levels.ERROR, notifications[#notifications].level)
+      assert.is_true(
+        notifications[#notifications].message:find(
+          'Greview target ref not found: missing/target (spec: HEAD...missing/target)',
+          1,
+          true
+        ) ~= nil
+      )
+    end)
+
+    it('reports a missing merge base before rendering merge-base reviews', function()
+      local called_diff = false
+      local notifications = capture_notifications()
+      mock_repo_root(function(path)
+        assert.are.equal('/tmp/repo/.', path)
+        return '/tmp/repo'
+      end)
+      mock_systemlist(function(cmd)
+        if cmd[4] == 'diff' then
+          called_diff = true
+        elseif cmd[4] == 'merge-base' then
+          return {}, 1
+        end
+        return {}
+      end)
+
+      local bufnr = commands.greview({
+        base = 'HEAD',
+        target = 'other',
+        mode = 'merge-base',
+        repo = '/tmp/repo',
+      })
+
+      assert.is_nil(bufnr)
+      assert.is_false(called_diff)
+      assert.are.equal(vim.log.levels.ERROR, notifications[#notifications].level)
+      assert.is_true(
+        notifications[#notifications].message:find(
+          'Greview merge base not found for spec: HEAD...other',
+          1,
+          true
+        ) ~= nil
+      )
+    end)
+
     it('opens a review buffer for an explicit merge-base target', function()
       local captured_cmd
       mock_repo_root(function(path)
@@ -1766,6 +1894,15 @@ describe('commands', function()
         return '/tmp/repo'
       end)
       mock_systemlist(function(cmd)
+        if cmd[4] == 'rev-parse' then
+          return { 'commit' }
+        end
+        if cmd[4] == 'merge-base' then
+          return { 'merge-base-commit' }
+        end
+        if cmd[4] ~= 'diff' then
+          return {}
+        end
         captured_cmd = cmd
         return {
           'diff --git a/file.lua b/file.lua',

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -34,8 +34,12 @@ end
 local function mock_systemlist(fn)
   saved_systemlist = vim.fn.systemlist
   vim.fn.systemlist = function(cmd)
-    local result = fn(cmd)
-    saved_systemlist({ 'true' })
+    local result, shell_error = fn(cmd)
+    if shell_error and shell_error ~= 0 then
+      saved_systemlist({ 'false' })
+    else
+      saved_systemlist({ 'true' })
+    end
     return result
   end
 end
@@ -90,6 +94,17 @@ end
 local function buffer_lines(bufnr)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   return rails.strip_lines(lines, rails.width_for_buffer(bufnr))
+end
+
+local function review_diff_lines()
+  return {
+    'diff --git a/file.lua b/file.lua',
+    '--- a/file.lua',
+    '+++ b/file.lua',
+    '@@ -1 +1 @@',
+    '-old',
+    '+new',
+  }
 end
 
 local function has_buf_var(bufnr, name)
@@ -687,15 +702,14 @@ describe('read_buffer', function()
     it('runs git diff with base ref for review label', function()
       local captured_cmd
       mock_systemlist(function(cmd)
+        if cmd[4] == 'rev-parse' then
+          return { 'commit' }
+        end
+        if cmd[4] ~= 'diff' then
+          return {}
+        end
         captured_cmd = cmd
-        return {
-          'diff --git a/file.lua b/file.lua',
-          '--- a/file.lua',
-          '+++ b/file.lua',
-          '@@ -1 +1 @@',
-          '-old',
-          '+new',
-        }
+        return review_diff_lines()
       end)
 
       local bufnr = create_diffs_buffer('diffs://review:origin/main', {
@@ -716,15 +730,17 @@ describe('read_buffer', function()
     it('runs merge-base review reload from stored review vars', function()
       local captured_cmd
       mock_systemlist(function(cmd)
+        if cmd[4] == 'rev-parse' then
+          return { 'commit' }
+        end
+        if cmd[4] == 'merge-base' then
+          return { 'merge-base-commit' }
+        end
+        if cmd[4] ~= 'diff' then
+          return {}
+        end
         captured_cmd = cmd
-        return {
-          'diff --git a/file.lua b/file.lua',
-          '--- a/file.lua',
-          '+++ b/file.lua',
-          '@@ -1 +1 @@',
-          '-old',
-          '+new',
-        }
+        return review_diff_lines()
       end)
 
       local bufnr = create_diffs_buffer('diffs://review:origin/main...refs/forge/pr/42', {
@@ -751,15 +767,14 @@ describe('read_buffer', function()
     it('parses direct review specs from the buffer name when vars are absent', function()
       local captured_cmd
       mock_systemlist(function(cmd)
+        if cmd[4] == 'rev-parse' then
+          return { 'commit' }
+        end
+        if cmd[4] ~= 'diff' then
+          return {}
+        end
         captured_cmd = cmd
-        return {
-          'diff --git a/file.lua b/file.lua',
-          '--- a/file.lua',
-          '+++ b/file.lua',
-          '@@ -1 +1 @@',
-          '-old',
-          '+new',
-        }
+        return review_diff_lines()
       end)
 
       local bufnr = create_diffs_buffer('diffs://review:origin/main..feature/topic', {
@@ -777,6 +792,87 @@ describe('read_buffer', function()
         'origin/main',
         'feature/topic',
       }, captured_cmd)
+    end)
+
+    it('reports missing review refs on reload without replacing buffer lines', function()
+      local called_diff = false
+      local notification
+      mock_notify(function(message, level)
+        notification = { message = message, level = level }
+      end)
+      mock_systemlist(function(cmd)
+        if cmd[4] == 'diff' then
+          called_diff = true
+        elseif cmd[4] == 'rev-parse' then
+          return {}, 1
+        end
+        return {}
+      end)
+
+      local bufnr = create_diffs_buffer('diffs://review:missing/ref', {
+        diffs_repo_root = '/home/test/repo',
+      })
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'stale review' })
+
+      commands.read_buffer(bufnr)
+
+      assert.is_false(called_diff)
+      assert.are.same({ 'stale review' }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
+      assert.is_not_nil(notification)
+      assert.are.equal(vim.log.levels.WARN, notification.level)
+      assert.is_true(
+        notification.message:find(
+          'Greview base ref not found: missing/ref (spec: missing/ref)',
+          1,
+          true
+        ) ~= nil
+      )
+    end)
+
+    it('reports missing review refs from source metadata without replacing buffer lines', function()
+      local called_diff = false
+      local notification
+      local validation_repo
+      mock_notify(function(message, level)
+        notification = { message = message, level = level }
+      end)
+      mock_systemlist(function(cmd)
+        if cmd[4] == 'diff' then
+          called_diff = true
+        elseif cmd[4] == 'rev-parse' then
+          validation_repo = cmd[3]
+          return {}, 1
+        end
+        return {}
+      end)
+
+      local bufnr = create_diffs_buffer('diffs://review:missing/ref', {
+        diffs_repo_root = '/wrong/repo',
+        diffs_source = {
+          version = 1,
+          kind = 'review',
+          repo_root = '/home/test/repo',
+          review = {
+            base = 'missing/ref',
+          },
+        },
+      })
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'stale review' })
+
+      commands.read_buffer(bufnr)
+
+      assert.is_false(called_diff)
+      assert.are.equal('/home/test/repo', validation_repo)
+      assert.are.same({ 'stale review' }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
+      assert.is_not_nil(notification)
+      assert.are.equal(vim.log.levels.WARN, notification.level)
+      assert.is_true(
+        notification.message:find(
+          'Greview base ref not found: missing/ref (spec: missing/ref)',
+          1,
+          true
+        ) ~= nil
+      )
     end)
   end)
 


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #297.

## Solution

The solution validate Greview base and target refs during normalization before rendering; and propagate review reload failures instead of silently replacing review buffers with empty content.
