### PR TITLE
feat: add generated diff qf loclist navigation

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -6,6 +6,7 @@ local diffspec = require('diffs.spec')
 local gdiff_parser = require('diffs.gdiff')
 local git = require('diffs.git')
 local hunk_model = require('diffs.hunks')
+local lists = require('diffs.lists')
 local log = require('diffs.log')
 local rails = require('diffs.rails')
 local render = require('diffs.render')
@@ -682,6 +683,9 @@ function M.gdiff(args, vertical)
     },
   })
   show_generated_diff_buffer(diff_buf, vertical)
+  lists.set_for_unified_buffer(diff_buf, diff_lines, {
+    title = 'diff: ' .. diffspec.label(diff_spec),
+  })
   attach_generated_diff_buffer(diff_buf)
   dbg('opened diff buffer %d for %s (%s)', diff_buf, diff_path, diffspec.label(diff_spec))
 end
@@ -825,6 +829,11 @@ function M.gdiff_file(filepath, opts)
     end
   end
 
+  lists.set_for_unified_buffer(diff_buf, diff_lines, {
+    title = 'diff: ' .. diff_label .. ':' .. rel_path,
+    diff_spec = diff_spec,
+  })
+
   attach_generated_diff_buffer(diff_buf)
 
   if diff_label == 'unmerged' then
@@ -877,6 +886,9 @@ function M.gdiff_section(repo_root, opts)
     },
   })
   show_generated_diff_buffer(diff_buf, opts.vertical)
+  lists.set_for_unified_buffer(diff_buf, result, {
+    title = 'diff: ' .. diff_label .. ':all',
+  })
   attach_generated_diff_buffer(diff_buf)
   dbg('opened section diff buffer %d (%s)', diff_buf, diff_label)
 end
@@ -992,6 +1004,10 @@ function M.read_buffer(bufnr)
 
   replace_generated_diff_buffer_lines(bufnr, diff_lines, stored_spec)
   M.setup_diff_buf(bufnr)
+  lists.set_for_unified_buffer(bufnr, diff_lines, {
+    title = 'diff: ' .. (debug_label or name:gsub('^diffs://', '')),
+    diff_spec = stored_spec,
+  })
 
   dbg('reloaded diff buffer %d (%s)', bufnr, debug_label)
 

--- a/lua/diffs/lists.lua
+++ b/lua/diffs/lists.lua
@@ -1,0 +1,548 @@
+local M = {}
+
+local hunk_model = require('diffs.hunks')
+
+local generated_list_autocmds = {}
+local generated_list_state = {}
+local quickfix_keymap_autocmd
+
+local group = vim.api.nvim_create_augroup('diffs_generated_lists', { clear = false })
+
+---@param bufnr integer
+---@param name string
+---@return any
+local function get_buf_var(bufnr, name)
+  local ok, value = pcall(vim.api.nvim_buf_get_var, bufnr, name)
+  if ok then
+    return value
+  end
+  return nil
+end
+
+---@param bufnr integer
+---@return diffs.DiffSpec?
+local function buffer_diff_spec(bufnr)
+  return get_buf_var(bufnr, 'diffs_spec')
+end
+
+---@param bufnr integer
+---@return integer[]
+local function windows_for_buffer(bufnr)
+  local wins = {}
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    if vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_buf(win) == bufnr then
+      wins[#wins + 1] = win
+    end
+  end
+  return wins
+end
+
+---@param win integer
+---@return integer?
+local function win_number(win)
+  local nr = vim.fn.win_id2win(win)
+  if nr > 0 then
+    return nr
+  end
+  return nil
+end
+
+---@param hunk diffs.GdiffHunk
+---@return string
+local function hunk_file(hunk)
+  return hunk.file or hunk.path or '(unknown)'
+end
+
+---@param hunk diffs.GdiffHunk
+---@return integer
+local function file_lnum(hunk)
+  return hunk.file_header_range and hunk.file_header_range.start or hunk.buffer_range.start
+end
+
+---@param line string
+---@return string?
+local function diff_file(line)
+  local old_path, new_path = line:match('^diff %-%-git a/(.-) b/(.+)$')
+  return new_path or old_path
+end
+
+---@param hunk diffs.GdiffHunk
+---@return integer, integer
+local function hunk_stats(hunk)
+  local adds = 0
+  local dels = 0
+  for _, line in ipairs(hunk.lines or {}) do
+    if line.kind == 'add' then
+      adds = adds + 1
+    elseif line.kind == 'delete' then
+      dels = dels + 1
+    end
+  end
+  return adds, dels
+end
+
+---@param entries table[]
+---@param by_file table<string, table>
+---@param file string
+---@param lnum integer
+---@return table
+local function ensure_file_entry(entries, by_file, file, lnum)
+  local entry = by_file[file]
+  if entry then
+    entry.lnum = math.min(entry.lnum, lnum)
+    return entry
+  end
+
+  entry = {
+    file = file,
+    lnum = lnum,
+    adds = 0,
+    dels = 0,
+    hunks = {},
+  }
+  by_file[file] = entry
+  entries[#entries + 1] = entry
+  return entry
+end
+
+---@param hunks diffs.GdiffHunk[]
+---@param diff_lines? string[]
+---@return table[]
+local function file_entries(hunks, diff_lines)
+  local by_file = {}
+  local entries = {}
+  for lnum, line in ipairs(diff_lines or {}) do
+    local file = diff_file(line)
+    if file then
+      ensure_file_entry(entries, by_file, file, lnum)
+    end
+  end
+
+  for _, hunk in ipairs(hunks) do
+    local file = hunk_file(hunk)
+    local entry = ensure_file_entry(entries, by_file, file, file_lnum(hunk))
+    local adds, dels = hunk_stats(hunk)
+    entry.adds = entry.adds + adds
+    entry.dels = entry.dels + dels
+    entry.hunks[#entry.hunks + 1] = hunk
+  end
+  return entries
+end
+
+---@param entries table[]
+local function format_file_text(entries)
+  local max_fname = 0
+  local max_add, max_del = 0, 0
+  for _, entry in ipairs(entries) do
+    max_fname = math.max(max_fname, #entry.file)
+    if entry.adds > 0 then
+      max_add = math.max(max_add, #tostring(entry.adds) + 1)
+    end
+    if entry.dels > 0 then
+      max_del = math.max(max_del, #tostring(entry.dels) + 1)
+    end
+  end
+
+  for _, entry in ipairs(entries) do
+    local padded = entry.file .. string.rep(' ', max_fname - #entry.file)
+    local parts = { padded }
+    if max_add > 0 then
+      parts[#parts + 1] = entry.adds > 0 and string.format('%' .. max_add .. 's', '+' .. entry.adds)
+        or string.rep(' ', max_add)
+    end
+    if max_del > 0 then
+      parts[#parts + 1] = entry.dels > 0 and string.format('%' .. max_del .. 's', '-' .. entry.dels)
+        or string.rep(' ', max_del)
+    end
+    entry.text = table.concat(parts, ' '):gsub('%s+$', '')
+  end
+end
+
+---@param bufnr integer
+---@param entries table[]
+---@return table[]
+local function quickfix_items(bufnr, entries)
+  format_file_text(entries)
+  local items = {}
+  for _, entry in ipairs(entries) do
+    items[#items + 1] = {
+      bufnr = bufnr,
+      lnum = entry.lnum,
+      col = 1,
+      text = entry.text,
+      user_data = {
+        diffs = {
+          kind = 'file',
+          file = entry.file,
+        },
+      },
+    }
+  end
+  return items
+end
+
+---@param hunks diffs.GdiffHunk[]
+---@param entries table[]
+---@param lnum integer
+---@return string?
+local function file_at_lnum(hunks, entries, lnum)
+  entries = entries or file_entries(hunks)
+  if #entries == 0 then
+    return nil
+  end
+
+  local selected = entries[1].file
+  for _, entry in ipairs(entries) do
+    if lnum >= entry.lnum then
+      selected = entry.file
+    else
+      break
+    end
+  end
+  return selected
+end
+
+---@param bufnr integer
+---@param hunks diffs.GdiffHunk[]
+---@param file string?
+---@return table[]
+local function loclist_items(bufnr, hunks, file)
+  local file_hunk_count = {}
+  local items = {}
+  for _, hunk in ipairs(hunks) do
+    local hfile = hunk_file(hunk)
+    if not file or hfile == file then
+      file_hunk_count[hfile] = (file_hunk_count[hfile] or 0) + 1
+      items[#items + 1] = {
+        bufnr = bufnr,
+        lnum = hunk.buffer_range.start,
+        col = 1,
+        text = ('%s (hunk %d) %s'):format(hfile, file_hunk_count[hfile], hunk.header),
+        user_data = {
+          diffs = {
+            kind = 'hunk',
+            file = hfile,
+            hunk = hunk.index,
+          },
+        },
+      }
+    end
+  end
+  return items
+end
+
+---@param title string
+---@param items table[]
+local function set_quickfix(title, items)
+  M.ensure_quickfix_keymap()
+  vim.fn.setqflist({}, ' ', {
+    title = title,
+    items = items,
+    quickfixtextfunc = 'v:lua._diffs_qftf',
+  })
+end
+
+---@param win integer
+---@param title string
+---@param items table[]
+local function set_loclist(win, title, items)
+  local nr = win_number(win)
+  if not nr then
+    return
+  end
+  M.ensure_quickfix_keymap()
+  vim.fn.setloclist(nr, {}, ' ', {
+    title = title,
+    items = items,
+    quickfixtextfunc = 'v:lua._diffs_qftf',
+  })
+end
+
+---@param bufnr integer
+---@param win integer
+---@param force? boolean
+local function refresh_loclist_for_window(bufnr, win, force)
+  local state = generated_list_state[bufnr]
+  if not state or not vim.api.nvim_win_is_valid(win) then
+    return
+  end
+  if vim.api.nvim_win_get_buf(win) ~= bufnr then
+    return
+  end
+
+  local cursor = vim.api.nvim_win_get_cursor(win)[1]
+  local file = file_at_lnum(state.hunks, state.entries, cursor)
+  local cache = state.win_files or {}
+  state.win_files = cache
+  if not force and cache[win] == file then
+    return
+  end
+  cache[win] = file
+
+  set_loclist(win, state.loclist_title, loclist_items(bufnr, state.hunks, file))
+end
+
+---@param bufnr integer
+local function refresh_current_loclist(bufnr)
+  local win = vim.api.nvim_get_current_win()
+  refresh_loclist_for_window(bufnr, win, false)
+end
+
+---@param bufnr integer
+local function ensure_generated_autocmds(bufnr)
+  if generated_list_autocmds[bufnr] then
+    return
+  end
+
+  local ids = {}
+  ids[#ids + 1] = vim.api.nvim_create_autocmd({ 'BufEnter', 'CursorMoved' }, {
+    group = group,
+    buffer = bufnr,
+    callback = function(args)
+      refresh_current_loclist(args.buf)
+    end,
+  })
+  ids[#ids + 1] = vim.api.nvim_create_autocmd('BufWipeout', {
+    group = group,
+    buffer = bufnr,
+    once = true,
+    callback = function(args)
+      generated_list_state[args.buf] = nil
+      generated_list_autocmds[args.buf] = nil
+    end,
+  })
+  generated_list_autocmds[bufnr] = ids
+end
+
+---@param item table?
+local function sync_split_item(item)
+  if type(item) ~= 'table' or type(item.bufnr) ~= 'number' then
+    return
+  end
+
+  local source = get_buf_var(item.bufnr, 'diffs_source')
+  if type(source) ~= 'table' or source.kind ~= 'split_endpoint' then
+    return
+  end
+
+  require('diffs.split').sync_cursor_to_hunk(item.bufnr)
+end
+
+---@param info table
+---@return table[]
+local function quickfix_text_items(info)
+  if info.quickfix == 1 then
+    return vim.fn.getqflist({ id = info.id, items = 0 }).items
+  end
+  return vim.fn.getloclist(info.winid or 0, { id = info.id, items = 0 }).items
+end
+
+---@return table?, boolean
+local function current_quickfix_item()
+  local info = vim.fn.getwininfo(vim.api.nvim_get_current_win())[1]
+  if type(info) ~= 'table' or info.quickfix ~= 1 then
+    return nil, false
+  end
+
+  local is_loclist = info.loclist == 1
+  local row = vim.api.nvim_win_get_cursor(0)[1]
+  local items = is_loclist and vim.fn.getloclist(0, { items = 0 }).items
+    or vim.fn.getqflist({ items = 0 }).items
+  return items[row], is_loclist
+end
+
+local function jump_current_quickfix_item()
+  local item, is_loclist = current_quickfix_item()
+  local row = vim.api.nvim_win_get_cursor(0)[1]
+  local command = is_loclist and 'll' or 'cc'
+  vim.cmd(command .. ' ' .. row)
+  sync_split_item(item)
+end
+
+---@param bufnr integer
+---@return boolean
+local function has_enter_keymap(bufnr)
+  for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, 'n')) do
+    if keymap.lhs == '<CR>' then
+      return true
+    end
+  end
+  return false
+end
+
+function M.ensure_quickfix_keymap()
+  if quickfix_keymap_autocmd then
+    return
+  end
+
+  quickfix_keymap_autocmd = vim.api.nvim_create_autocmd('FileType', {
+    group = group,
+    pattern = 'qf',
+    callback = function(args)
+      if has_enter_keymap(args.buf) then
+        return
+      end
+      vim.keymap.set('n', '<CR>', jump_current_quickfix_item, {
+        buffer = args.buf,
+        desc = 'Open quickfix item',
+      })
+    end,
+  })
+end
+
+-- selene: allow(global_usage)
+function _G._diffs_qftf(info)
+  local items = quickfix_text_items(info)
+  local max_lnum = 0
+  for i = info.start_idx, info.end_idx do
+    local e = items[i]
+    if e and e.lnum > 0 then
+      max_lnum = math.max(max_lnum, #tostring(e.lnum))
+    end
+  end
+  local lnum_fmt = '%' .. math.max(max_lnum, 1) .. 'd'
+  local lines = {}
+  for i = info.start_idx, info.end_idx do
+    local e = items[i] or {}
+    local text = e.text or ''
+    if max_lnum > 0 and e.lnum and e.lnum > 0 then
+      lines[#lines + 1] = ('%s  %s'):format(lnum_fmt:format(e.lnum), text)
+    else
+      lines[#lines + 1] = text
+    end
+  end
+  return lines
+end
+
+---@param bufnr integer
+---@param diff_lines string[]
+---@param opts? { title?: string, loclist_title?: string, diff_spec?: diffs.DiffSpec }
+function M.set_for_unified_buffer(bufnr, diff_lines, opts)
+  opts = opts or {}
+  local diff_spec = opts.diff_spec or buffer_diff_spec(bufnr)
+  local hunks = hunk_model.parse(diff_lines, diff_spec)
+  local entries = file_entries(hunks, diff_lines)
+  local title = opts.title or 'diffs'
+  local loclist_title = opts.loclist_title or (title .. ' hunks')
+
+  generated_list_state[bufnr] = {
+    hunks = hunks,
+    entries = entries,
+    loclist_title = loclist_title,
+    win_files = {},
+  }
+  ensure_generated_autocmds(bufnr)
+
+  set_quickfix(title, quickfix_items(bufnr, entries))
+  for _, win in ipairs(windows_for_buffer(bufnr)) do
+    refresh_loclist_for_window(bufnr, win, true)
+  end
+end
+
+---@param hunk diffs.GdiffHunk
+---@param side "left"|"right"
+---@return integer
+local function split_hunk_lnum(hunk, side)
+  local range = side == 'left' and hunk.old_range or hunk.new_range
+  return math.max(1, range.start)
+end
+
+---@param hunk diffs.GdiffHunk
+---@param side "left"|"right"
+---@return "left"|"right", integer
+local function split_target(hunk, side)
+  local range = side == 'left' and hunk.old_range or hunk.new_range
+  if range.count > 0 then
+    return side, split_hunk_lnum(hunk, side)
+  end
+
+  local fallback_side = side == 'left' and 'right' or 'left'
+  return fallback_side, split_hunk_lnum(hunk, fallback_side)
+end
+
+---@param left_buf integer
+---@param right_buf integer
+---@param hunks diffs.GdiffHunk[]
+---@param side "left"|"right"
+---@return table[]
+local function split_loclist_items(left_buf, right_buf, hunks, side)
+  local items = {}
+  for i, hunk in ipairs(hunks) do
+    local target_side, target_lnum = split_target(hunk, side)
+    items[#items + 1] = {
+      bufnr = target_side == 'left' and left_buf or right_buf,
+      lnum = target_lnum,
+      col = 1,
+      text = ('%s (hunk %d) %s'):format(hunk_file(hunk), i, hunk.header),
+      user_data = {
+        diffs = {
+          kind = 'split_hunk',
+          file = hunk_file(hunk),
+          hunk = i,
+          side = side,
+        },
+      },
+    }
+  end
+  return items
+end
+
+---@param opts { left_buf: integer, right_buf: integer, hunks: diffs.GdiffHunk[] }
+---@return table[]
+local function split_quickfix_items(opts)
+  local entries = file_entries(opts.hunks)
+  format_file_text(entries)
+  local items = {}
+  for _, entry in ipairs(entries) do
+    local first_hunk = entry.hunks[1]
+    local target_side = 'right'
+    local target_lnum = entry.lnum
+    if first_hunk then
+      target_side, target_lnum = split_target(first_hunk, 'right')
+    end
+    items[#items + 1] = {
+      bufnr = target_side == 'left' and opts.left_buf or opts.right_buf,
+      lnum = target_lnum,
+      col = 1,
+      text = entry.text,
+      user_data = {
+        diffs = {
+          kind = 'file',
+          file = entry.file,
+        },
+      },
+    }
+  end
+  return items
+end
+
+---@param opts { title: string, loclist_title?: string, left_buf: integer, right_buf: integer, left_win?: integer, right_win?: integer, hunks: diffs.GdiffHunk[] }
+function M.set_for_split_pair(opts)
+  local title = opts.title
+  local loclist_title = opts.loclist_title or (title .. ' hunks')
+
+  set_quickfix(title, split_quickfix_items(opts))
+  for _, win in ipairs(opts.left_win and { opts.left_win } or windows_for_buffer(opts.left_buf)) do
+    set_loclist(
+      win,
+      loclist_title,
+      split_loclist_items(opts.left_buf, opts.right_buf, opts.hunks, 'left')
+    )
+  end
+  for _, win in ipairs(opts.right_win and { opts.right_win } or windows_for_buffer(opts.right_buf)) do
+    set_loclist(
+      win,
+      loclist_title,
+      split_loclist_items(opts.left_buf, opts.right_buf, opts.hunks, 'right')
+    )
+  end
+end
+
+M._test = {
+  file_at_lnum = file_at_lnum,
+  file_entries = file_entries,
+  loclist_items = loclist_items,
+  quickfix_items = quickfix_items,
+}
+
+return M

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local git = require('diffs.git')
+local lists = require('diffs.lists')
 local log = require('diffs.log')
 
 local dbg = log.dbg
@@ -315,121 +316,6 @@ function M.run(review, deps)
   return deps.replace_combined_diffs(result, review.repo_root), nil
 end
 
--- selene: allow(global_usage)
-function _G._diffs_qftf(info)
-  local items = info.quickfix == 1 and vim.fn.getqflist({ id = info.id, items = 0 }).items
-    or vim.fn.getloclist(0, { id = info.id, items = 0 }).items
-  local max_lnum = 0
-  for i = info.start_idx, info.end_idx do
-    local e = items[i]
-    if e.lnum > 0 then
-      max_lnum = math.max(max_lnum, #tostring(e.lnum))
-    end
-  end
-  local lnum_fmt = '%' .. math.max(max_lnum, 1) .. 'd'
-  local lines = {}
-  for i = info.start_idx, info.end_idx do
-    local e = items[i]
-    local text = e.text or ''
-    if max_lnum > 0 and e.lnum > 0 then
-      table.insert(lines, ('%s  %s'):format(lnum_fmt:format(e.lnum), text))
-    else
-      table.insert(lines, text)
-    end
-  end
-  return lines
-end
-
----@param diff_buf integer
----@param result string[]
----@return table[], table[]
-function M.list_items(diff_buf, result)
-  local qf_items = {}
-  local loc_items = {}
-  local current_file = nil
-  local file_adds, file_dels = {}, {}
-  local file_hunk_count = {}
-
-  for i, line in ipairs(result) do
-    local file = line:match('^diff %-%-git a/.+ b/(.+)$')
-    if file then
-      current_file = file
-      file_adds[file] = 0
-      file_dels[file] = 0
-      file_hunk_count[file] = 0
-      table.insert(qf_items, {
-        bufnr = diff_buf,
-        lnum = i,
-        text = file,
-      })
-    elseif current_file and line:match('^@@') then
-      file_hunk_count[current_file] = file_hunk_count[current_file] + 1
-      table.insert(loc_items, {
-        bufnr = diff_buf,
-        lnum = i,
-        text = current_file,
-        _hunk = file_hunk_count[current_file],
-        _header = line:match('^(@@.-@@)') or '',
-      })
-    elseif current_file then
-      local ch = line:sub(1, 1)
-      if ch == '+' and not line:match('^%+%+%+') then
-        file_adds[current_file] = file_adds[current_file] + 1
-      elseif ch == '-' and not line:match('^%-%-%-') then
-        file_dels[current_file] = file_dels[current_file] + 1
-      end
-    end
-  end
-
-  local max_fname = 0
-  local max_add, max_del = 0, 0
-  for _, item in ipairs(qf_items) do
-    max_fname = math.max(max_fname, #item.text)
-    local a = file_adds[item.text] or 0
-    local d = file_dels[item.text] or 0
-    if a > 0 then
-      max_add = math.max(max_add, #tostring(a) + 1)
-    end
-    if d > 0 then
-      max_del = math.max(max_del, #tostring(d) + 1)
-    end
-  end
-
-  for _, item in ipairs(qf_items) do
-    local file = item.text
-    local a = file_adds[file] or 0
-    local d = file_dels[file] or 0
-    local padded = file .. string.rep(' ', max_fname - #file)
-    local parts = { padded }
-    if max_add > 0 then
-      parts[#parts + 1] = a > 0 and string.format('%' .. max_add .. 's', '+' .. a)
-        or string.rep(' ', max_add)
-    end
-    if max_del > 0 then
-      parts[#parts + 1] = d > 0 and string.format('%' .. max_del .. 's', '-' .. d)
-        or string.rep(' ', max_del)
-    end
-    item.text = table.concat(parts, '  '):gsub('%s+$', '')
-  end
-
-  local max_loc_fname = 0
-  for _, item in ipairs(loc_items) do
-    max_loc_fname = math.max(max_loc_fname, #item.text)
-  end
-  for _, item in ipairs(loc_items) do
-    item.text = item.text
-      .. string.rep(' ', max_loc_fname - #item.text)
-      .. '  (hunk '
-      .. item._hunk
-      .. ') '
-      .. item._header
-    item._hunk = nil
-    item._header = nil
-  end
-
-  return qf_items, loc_items
-end
-
 ---@param spec? diffs.GreviewSpec
 ---@param deps diffs.ReviewDeps
 ---@return integer?
@@ -477,19 +363,10 @@ function M.greview(spec, deps)
     },
   })
 
-  local qf_items, loc_items = M.list_items(diff_buf, result)
-  vim.fn.setqflist({}, ' ', {
-    title = 'review: ' .. review.display,
-    items = qf_items,
-    quickfixtextfunc = 'v:lua._diffs_qftf',
-  })
-
   deps.show_generated_diff_buffer(diff_buf, review.vertical)
-
-  vim.fn.setloclist(0, {}, ' ', {
-    title = 'review hunks: ' .. review.display,
-    items = loc_items,
-    quickfixtextfunc = 'v:lua._diffs_qftf',
+  lists.set_for_unified_buffer(diff_buf, result, {
+    title = 'review: ' .. review.display,
+    loclist_title = 'review hunks: ' .. review.display,
   })
 
   deps.attach_generated_diff_buffer(diff_buf)

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -2,19 +2,29 @@ local M = {}
 
 local diffspec = require('diffs.spec')
 local hunk_model = require('diffs.hunks')
+local lists = require('diffs.lists')
 local log = require('diffs.log')
 local render = require('diffs.render')
 
 local notify = log.notify
+local schedule = vim.schedule
 
 ---@type table<integer, boolean>
 local closing_buffers = {}
 ---@type table<integer, integer>
 local cleanup_autocmds = {}
 ---@type table<integer, integer>
+local cursor_sync_autocmds = {}
+---@type table<integer, integer>
 local peer_buffers = {}
 ---@type table<integer, table<string, any>>
 local pair_window_options = {}
+local syncing_cursor = false
+
+---@type fun(bufnr: integer)
+local clear_cursor_sync
+---@type fun(bufnr: integer)
+local ensure_cursor_sync
 
 ---@class diffs.SplitOpenOpts
 ---@field spec diffs.DiffSpec
@@ -352,6 +362,9 @@ local function clear_split_state(bufnr)
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_peer')
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_hunks')
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_side')
+  if clear_cursor_sync then
+    clear_cursor_sync(bufnr)
+  end
   clear_owned_split_keymaps(bufnr)
 end
 
@@ -504,6 +517,85 @@ local function move_pair_to_hunk(bufnr, hunk)
   if vim.api.nvim_win_is_valid(current_win) then
     vim.api.nvim_set_current_win(current_win)
   end
+end
+
+---@param hunks diffs.GdiffHunk[]
+---@param side "left"|"right"
+---@param lnum integer
+---@return diffs.GdiffHunk?
+local function hunk_at_target_lnum(hunks, side, lnum)
+  for _, hunk in ipairs(hunks) do
+    if hunk_target_lnum(hunk, side) == lnum then
+      return hunk
+    end
+  end
+  return nil
+end
+
+---@param bufnr integer
+local function sync_cursor_to_hunk(bufnr)
+  if syncing_cursor then
+    return
+  end
+
+  local source = buffer_source(bufnr)
+  local hunks = buffer_split_hunks(bufnr)
+  if not source or #hunks == 0 then
+    return
+  end
+
+  local win = current_or_first_window_for_buffer(bufnr)
+  if not win then
+    return
+  end
+  local hunk = hunk_at_target_lnum(hunks, source.side, vim.api.nvim_win_get_cursor(win)[1])
+  if not hunk then
+    return
+  end
+
+  syncing_cursor = true
+  move_pair_to_hunk(bufnr, hunk)
+  syncing_cursor = false
+end
+
+clear_cursor_sync = function(bufnr)
+  if cursor_sync_autocmds[bufnr] then
+    pcall(vim.api.nvim_del_autocmd, cursor_sync_autocmds[bufnr])
+    cursor_sync_autocmds[bufnr] = nil
+  end
+end
+
+ensure_cursor_sync = function(bufnr)
+  if cursor_sync_autocmds[bufnr] then
+    return
+  end
+
+  local target_buf = bufnr
+  cursor_sync_autocmds[bufnr] = vim.api.nvim_create_autocmd(
+    { 'BufEnter', 'CursorMoved', 'WinEnter' },
+    {
+      callback = function(args)
+        if not vim.api.nvim_buf_is_valid(target_buf) then
+          clear_cursor_sync(target_buf)
+          return
+        end
+        if vim.api.nvim_get_current_buf() ~= target_buf then
+          return
+        end
+        if args.event == 'BufEnter' then
+          vim.defer_fn(function()
+            schedule(function()
+              if vim.api.nvim_buf_is_valid(target_buf) then
+                sync_cursor_to_hunk(target_buf)
+              end
+            end)
+          end, 0)
+          return
+        end
+        sync_cursor_to_hunk(target_buf)
+      end,
+    }
+  )
 end
 
 ---@param bufnr integer
@@ -714,6 +806,8 @@ function M.open(opts)
   vim.api.nvim_win_set_buf(left_win, left_buf)
   vim.api.nvim_win_set_buf(right_win, right_buf)
   set_peers(left_buf, right_buf)
+  ensure_cursor_sync(left_buf)
+  ensure_cursor_sync(right_buf)
 
   enable_diff(left_win)
   enable_diff(right_win)
@@ -721,6 +815,14 @@ function M.open(opts)
   vim.cmd.diffupdate()
   set_pair_window_options(left_win)
   set_pair_window_options(right_win)
+  lists.set_for_split_pair({
+    title = 'diff: ' .. diffspec.label(spec),
+    left_buf = left_buf,
+    right_buf = right_buf,
+    left_win = left_win,
+    right_win = right_win,
+    hunks = split_hunks,
+  })
 
   log.dbg('opened split diff buffers %d/%d for %s', left_buf, right_buf, diffspec.label(spec))
   return {
@@ -795,7 +897,15 @@ function M.read_buffer(bufnr, source)
     else
       set_peers(peer, bufnr)
     end
+    ensure_cursor_sync(bufnr)
+    ensure_cursor_sync(peer)
     refresh_visible_pair_options(bufnr)
+    lists.set_for_split_pair({
+      title = 'diff: ' .. diffspec.label(source.spec),
+      left_buf = source.side == 'left' and bufnr or peer,
+      right_buf = source.side == 'right' and bufnr or peer,
+      hunks = split_hunks,
+    })
   end
   return true, nil
 end
@@ -938,6 +1048,8 @@ function M.goto_prev(bufnr)
   end
   move_pair_to_hunk(bufnr, hunk)
 end
+
+M.sync_cursor_to_hunk = sync_cursor_to_hunk
 
 M._test = {
   buffer_name = buffer_name,

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -137,6 +137,15 @@ local function buffer_text(bufnr)
   return table.concat(buffer_lines(bufnr), '\n')
 end
 
+local function quickfix_items()
+  return vim.fn.getqflist({ items = 0 }).items
+end
+
+local function loclist_items(win)
+  local nr = win and vim.fn.win_id2win(win) or 0
+  return vim.fn.getloclist(nr, { items = 0 }).items
+end
+
 local function has_buf_var(bufnr, name)
   local ok = pcall(vim.api.nvim_buf_get_var, bufnr, name)
   return ok
@@ -421,6 +430,18 @@ describe('commands', function()
       assert.are.equal(6, vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_width'))
       assert.are.equal('    | diff --git a/lua/foo.lua b/lua/foo.lua', display_lines[1])
       assert.is_true(table.concat(display_lines, '\n'):find('  2 | +local x = 1', 1, true) ~= nil)
+
+      local qf = quickfix_items()
+      assert.are.equal(1, #qf)
+      assert.are.equal(diff_buf, qf[1].bufnr)
+      assert.are.equal(1, qf[1].lnum)
+      assert.is_true(qf[1].text:find('lua/foo.lua', 1, true) ~= nil)
+
+      local loc = loclist_items()
+      assert.are.equal(1, #loc)
+      assert.are.equal(diff_buf, loc[1].bufnr)
+      assert.are.equal(diff_hunks[1].buffer_range.start, loc[1].lnum)
+      assert.is_true(loc[1].text:find('lua/foo.lua', 1, true) ~= nil)
     end)
 
     it('opens default :Gdiff for untracked files as index to worktree additions', function()
@@ -529,6 +550,19 @@ describe('commands', function()
       assert.is_true(helpers.has_keymap(right_buf, '[c'))
       assert.is_false(helpers.has_keymap(right_buf, 'dp'))
       assert.is_false(helpers.has_keymap(right_buf, 'do'))
+
+      local qf = quickfix_items()
+      assert.are.equal(1, #qf)
+      assert.are.equal(right_buf, qf[1].bufnr)
+      assert.are.equal(1, qf[1].lnum)
+      assert.is_true(qf[1].text:find('lua/foo.lua', 1, true) ~= nil)
+
+      local left_loc = loclist_items(left_win)
+      local right_loc = loclist_items(right_win)
+      assert.are.equal(1, #left_loc)
+      assert.are.equal(1, #right_loc)
+      assert.are.equal(left_buf, left_loc[1].bufnr)
+      assert.are.equal(right_buf, right_loc[1].bufnr)
     end)
 
     it('moves split hunk navigation through both endpoint windows', function()
@@ -572,6 +606,11 @@ describe('commands', function()
       local hunks = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_hunks')
 
       assert.are.equal(2, #hunks)
+      local right_loc = loclist_items(right_win)
+      assert.are.equal(2, #right_loc)
+      assert.are.equal(right_buf, right_loc[2].bufnr)
+      assert.are.equal(hunks[2].new_range.start, right_loc[2].lnum)
+
       vim.api.nvim_set_current_win(right_win)
       vim.api.nvim_win_set_cursor(right_win, { hunks[1].new_range.start, 0 })
 
@@ -584,6 +623,78 @@ describe('commands', function()
 
       assert.are.same({ hunks[1].old_range.start, 0 }, vim.api.nvim_win_get_cursor(left_win))
       assert.are.same({ hunks[1].new_range.start, 0 }, vim.api.nvim_win_get_cursor(right_win))
+
+      vim.api.nvim_set_current_win(right_win)
+      vim.cmd('lopen')
+      local found_qf = false
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local buf = vim.api.nvim_win_get_buf(win)
+        if vim.api.nvim_get_option_value('buftype', { buf = buf }) == 'quickfix' then
+          vim.api.nvim_set_current_win(win)
+          found_qf = true
+          break
+        end
+      end
+      assert.is_true(found_qf)
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+      vim.cmd('normal \r')
+      vim.wait(100, function()
+        return vim.api.nvim_win_get_cursor(left_win)[1] == hunks[2].old_range.start
+      end)
+
+      assert.are.same({ hunks[2].old_range.start, 0 }, vim.api.nvim_win_get_cursor(left_win))
+      assert.are.same({ hunks[2].new_range.start, 0 }, vim.api.nvim_win_get_cursor(right_win))
+    end)
+
+    it('targets the old endpoint for split deleted hunks in qf and loclist', function()
+      create_split_source({
+        index_lines = {
+          'line 1',
+          'line 2',
+          'line 3',
+        },
+        worktree_lines = {},
+      })
+      commands.gdiff('++layout=split', false)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+      local left_win, right_win = find_split_windows(left_buf, right_buf)
+      local hunks = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_hunks')
+
+      assert.are.equal(1, #hunks)
+      assert.are.equal(0, hunks[1].new_range.count)
+
+      local qf = quickfix_items()
+      assert.are.equal(1, #qf)
+      assert.are.equal(left_buf, qf[1].bufnr)
+      assert.are.equal(hunks[1].old_range.start, qf[1].lnum)
+
+      local right_loc = loclist_items(right_win)
+      assert.are.equal(1, #right_loc)
+      assert.are.equal(left_buf, right_loc[1].bufnr)
+      assert.are.equal(hunks[1].old_range.start, right_loc[1].lnum)
+
+      vim.api.nvim_set_current_win(right_win)
+      vim.cmd('lopen')
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local buf = vim.api.nvim_win_get_buf(win)
+        if vim.api.nvim_get_option_value('buftype', { buf = buf }) == 'quickfix' then
+          vim.api.nvim_set_current_win(win)
+          break
+        end
+      end
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      vim.cmd('normal \r')
+      vim.wait(100, function()
+        return vim.api.nvim_get_current_buf() == left_buf
+          and vim.api.nvim_win_get_cursor(left_win)[1] == hunks[1].old_range.start
+      end)
+
+      assert.are.equal(left_buf, vim.api.nvim_get_current_buf())
+      assert.are.same({ hunks[1].old_range.start, 0 }, vim.api.nvim_win_get_cursor(left_win))
     end)
 
     it('opens the worktree split endpoint in an existing source window', function()
@@ -1029,6 +1140,18 @@ describe('commands', function()
         path = 'renamed.txt',
         old_path = 'file.txt',
       }, vim.api.nvim_buf_get_var(diff_buf, 'diffs_source'))
+
+      local qf = quickfix_items()
+      assert.are.equal(1, #qf)
+      assert.are.equal(diff_buf, qf[1].bufnr)
+      assert.are.equal(1, qf[1].lnum)
+      assert.is_true(qf[1].text:find('renamed.txt', 1, true) ~= nil)
+
+      local loc = loclist_items()
+      assert.are.equal(1, #loc)
+      assert.are.equal(diff_buf, loc[1].bufnr)
+      assert.is_true(loc[1].lnum > 1)
+      assert.is_true(loc[1].text:find('renamed.txt', 1, true) ~= nil)
     end)
 
     it('opens staged and unstaged section headers as explicit section buffers', function()
@@ -1545,6 +1668,16 @@ describe('commands', function()
       local lines = buffer_lines(bufnr)
       assert.are.equal(case.first_line, lines[1])
       assert.is_false(vim.tbl_contains(lines, 'stale lifecycle content'))
+
+      local qf = quickfix_items()
+      assert.is_true(#qf >= 1, case.label)
+      assert.are.equal(bufnr, qf[1].bufnr, case.label)
+      assert.are.equal(1, qf[1].lnum, case.label)
+
+      local loc = loclist_items()
+      assert.is_true(#loc >= 1, case.label)
+      assert.are.equal(bufnr, loc[1].bufnr, case.label)
+      assert.is_true(loc[1].lnum > 1, case.label)
     end
 
     it('preserves generated buffer metadata and action keymaps across reloads', function()
@@ -1941,6 +2074,134 @@ describe('commands', function()
       assert.are.equal('origin/main', vim.api.nvim_buf_get_var(bufnr, 'diffs_review_base'))
       assert.are.equal('refs/forge/pr/42', vim.api.nvim_buf_get_var(bufnr, 'diffs_review_target'))
       assert.are.equal('merge-base', vim.api.nvim_buf_get_var(bufnr, 'diffs_review_mode'))
+    end)
+
+    it(
+      'uses quickfix as the review file index and loclist as the active file hunk index',
+      function()
+        mock_repo_root(function(path)
+          assert.are.equal('/tmp/repo/.', path)
+          return '/tmp/repo'
+        end)
+        mock_systemlist(function(cmd)
+          if cmd[4] == 'rev-parse' then
+            return { 'commit' }
+          end
+          if cmd[4] == 'merge-base' then
+            return { 'merge-base-commit' }
+          end
+          if cmd[4] ~= 'diff' then
+            return {}
+          end
+          return {
+            'diff --git a/lua/one.lua b/lua/one.lua',
+            '--- a/lua/one.lua',
+            '+++ b/lua/one.lua',
+            '@@ -1 +1 @@',
+            '-old one',
+            '+new one',
+            'diff --git a/lua/two.lua b/lua/two.lua',
+            '--- a/lua/two.lua',
+            '+++ b/lua/two.lua',
+            '@@ -1 +1 @@',
+            '-old two',
+            '+new two',
+            '@@ -5 +5 @@',
+            '-older two',
+            '+newer two',
+          }
+        end)
+        mock_runtime_attach(function() end)
+
+        local bufnr = commands.greview({
+          base = 'origin/main',
+          target = 'refs/forge/pr/42',
+          mode = 'merge-base',
+          repo = '/tmp/repo',
+        })
+        table.insert(test_buffers, bufnr)
+
+        local qf = quickfix_items()
+        assert.are.equal(2, #qf)
+        assert.are.equal(bufnr, qf[1].bufnr)
+        assert.are.equal(1, qf[1].lnum)
+        assert.is_true(qf[1].text:find('lua/one.lua', 1, true) ~= nil)
+        assert.are.equal(bufnr, qf[2].bufnr)
+        assert.are.equal(7, qf[2].lnum)
+        assert.is_true(qf[2].text:find('lua/two.lua', 1, true) ~= nil)
+
+        local loc = loclist_items()
+        assert.are.equal(1, #loc)
+        assert.are.equal(4, loc[1].lnum)
+        assert.is_true(loc[1].text:find('lua/one.lua', 1, true) ~= nil)
+
+        vim.api.nvim_win_set_cursor(0, { 7, 0 })
+        vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
+
+        loc = loclist_items()
+        assert.are.equal(2, #loc)
+        assert.are.equal(10, loc[1].lnum)
+        assert.are.equal(13, loc[2].lnum)
+        assert.is_true(loc[1].text:find('lua/two.lua', 1, true) ~= nil)
+        assert.is_true(loc[2].text:find('lua/two.lua', 1, true) ~= nil)
+      end
+    )
+
+    it('keeps no-hunk review file records in quickfix with an empty active loclist', function()
+      mock_repo_root(function(path)
+        assert.are.equal('/tmp/repo/.', path)
+        return '/tmp/repo'
+      end)
+      mock_systemlist(function(cmd)
+        if cmd[4] == 'rev-parse' then
+          return { 'commit' }
+        end
+        if cmd[4] == 'merge-base' then
+          return { 'merge-base-commit' }
+        end
+        if cmd[4] ~= 'diff' then
+          return {}
+        end
+        return {
+          'diff --git a/lua/mode.lua b/lua/mode.lua',
+          'old mode 100644',
+          'new mode 100755',
+          'diff --git a/lua/changed.lua b/lua/changed.lua',
+          '--- a/lua/changed.lua',
+          '+++ b/lua/changed.lua',
+          '@@ -1 +1 @@',
+          '-old',
+          '+new',
+        }
+      end)
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = 'origin/main',
+        target = 'refs/forge/pr/42',
+        mode = 'merge-base',
+        repo = '/tmp/repo',
+      })
+      table.insert(test_buffers, bufnr)
+
+      local qf = quickfix_items()
+      assert.are.equal(2, #qf)
+      assert.are.equal(bufnr, qf[1].bufnr)
+      assert.are.equal(1, qf[1].lnum)
+      assert.is_true(qf[1].text:find('lua/mode.lua', 1, true) ~= nil)
+      assert.are.equal(bufnr, qf[2].bufnr)
+      assert.are.equal(4, qf[2].lnum)
+      assert.is_true(qf[2].text:find('lua/changed.lua', 1, true) ~= nil)
+
+      assert.are.equal(0, #loclist_items())
+
+      vim.api.nvim_win_set_cursor(0, { 4, 0 })
+      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
+
+      local loc = loclist_items()
+      assert.are.equal(1, #loc)
+      assert.are.equal(7, loc[1].lnum)
+      assert.is_true(loc[1].text:find('lua/changed.lua', 1, true) ~= nil)
     end)
   end)
 


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #303.

## Solution

The solution adds a shared generated-list layer for quickfix file indexes and active-file loclist hunk indexes; wire generated `:Gdiff`, section, review, reload, and split-pair paths into the qf/loclist contract; and keeps no-hunk file records in quickfix and make split zero-count hunks target the existing endpoint.
