### PR TITLE
Keep Greview split projection synced

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -689,6 +689,9 @@ Generated paired-window contract: ~             *diffs.nvim-paired-windows*
         `require('diffs.commands').greview_split()` opens the currently
         selected |:Greview| file in a generated split pair. It uses the review
         buffer cursor, quickfix item, or loclist item as the file selection.
+        Once opened, that Greview-owned pair follows review-map file and hunk
+        selection until the pair is closed. The review quickfix list remains
+        the authoritative file map.
 
         `require('diffs.commands').review_file_at_line(bufnr, lnum)` returns
         the filename at a given line in a review buffer by walking backwards
@@ -720,7 +723,8 @@ MAPPINGS                                                 *diffs.nvim-mappings*
                         Open the currently selected |:Greview| file in a
                         generated split pair. The review buffer remains the
                         full-repo map; this action opens one file pair for
-                        focused inspection.
+                        focused inspection and follows later review-map
+                        selections until that pair is closed.
 
 Example configuration: >lua
     vim.keymap.set('n', '<leader>gd', '<Plug>(diffs-gdiff)')

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -16,6 +16,7 @@ local split = require('diffs.split')
 
 local dbg = log.dbg
 local notify = log.notify
+local greview_follow_group = vim.api.nvim_create_augroup('diffs_greview_follow', { clear = false })
 
 ---@class diffs.HunkKeymap
 ---@field mode string
@@ -26,6 +27,18 @@ local notify = log.notify
 local hunk_keymaps = {}
 ---@type table<integer, integer>
 local hunk_keymap_autocmds = {}
+
+---@class diffs.GreviewFollowState
+---@field left_buf integer
+---@field right_buf integer
+---@field file string
+---@field hunk_index? integer
+---@field autocmds integer[]
+---@field pending? boolean
+---@field pending_item? table
+
+---@type table<integer, diffs.GreviewFollowState>
+local greview_follow_states = {}
 
 ---@param bufnr integer
 ---@param mode string
@@ -393,6 +406,16 @@ local function set_generated_diff_buffer_options(bufnr)
   vim.api.nvim_set_option_value('filetype', 'diff', { buf = bufnr })
 end
 
+---@param win integer
+local function clear_generated_diff_window_bindings(win)
+  if not vim.api.nvim_win_is_valid(win) then
+    return
+  end
+
+  vim.api.nvim_set_option_value('scrollbind', false, { win = win })
+  vim.api.nvim_set_option_value('cursorbind', false, { win = win })
+end
+
 ---@class diffs.GeneratedDiffBufferOpts
 ---@field name string
 ---@field lines string[]
@@ -436,9 +459,12 @@ local function show_generated_diff_buffer(bufnr, vertical)
   local existing_win = M.find_diffs_window()
   if existing_win then
     vim.api.nvim_set_current_win(existing_win)
+    split.release_pair_window_options(existing_win)
+    clear_generated_diff_window_bindings(existing_win)
     vim.api.nvim_win_set_buf(existing_win, bufnr)
   else
     vim.cmd(vertical and 'vsplit' or 'split')
+    clear_generated_diff_window_bindings(vim.api.nvim_get_current_win())
     vim.api.nvim_win_set_buf(0, bufnr)
   end
 end
@@ -616,14 +642,81 @@ local function filetype_for_path(repo_root, path)
   return nil
 end
 
+---@param win integer?
+local function restore_window(win)
+  if type(win) == 'number' and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_set_current_win(win)
+  end
+end
+
+---@param review_buf integer
+local function stop_greview_follow(review_buf)
+  local state = greview_follow_states[review_buf]
+  if state then
+    for _, id in ipairs(state.autocmds or {}) do
+      pcall(vim.api.nvim_del_autocmd, id)
+    end
+  end
+  greview_follow_states[review_buf] = nil
+  if vim.api.nvim_buf_is_valid(review_buf) then
+    pcall(vim.api.nvim_buf_del_var, review_buf, 'diffs_review_split_buf')
+  end
+end
+
+---@param review_buf integer
+---@return integer?
+local function stored_greview_pair_buf(review_buf)
+  local state = greview_follow_states[review_buf]
+  if state then
+    return state.right_buf
+  end
+
+  local previous = get_buf_var(review_buf, 'diffs_review_split_buf')
+  if type(previous) == 'number' then
+    return previous
+  end
+  return nil
+end
+
+---@param review_buf integer
+local function close_owned_greview_pair(review_buf)
+  local previous = stored_greview_pair_buf(review_buf)
+  stop_greview_follow(review_buf)
+  if type(previous) == 'number' and vim.api.nvim_buf_is_valid(previous) then
+    split.close_pair(previous)
+  end
+end
+
+---@param state diffs.GreviewFollowState?
+---@return boolean
+local function greview_pair_valid(state)
+  if
+    not state
+    or not vim.api.nvim_buf_is_valid(state.left_buf)
+    or not vim.api.nvim_buf_is_valid(state.right_buf)
+  then
+    return false
+  end
+
+  return get_buf_var(state.left_buf, 'diffs_split_peer') == state.right_buf
+    and get_buf_var(state.right_buf, 'diffs_split_peer') == state.left_buf
+end
+
 ---@class diffs.GreviewSplitOpts
 ---@field bufnr? integer
 ---@field lnum? integer
 ---@field item? table
 
+---@class diffs.GreviewSplitContext
+---@field review_buf integer
+---@field selected diffs.GeneratedFileSelection
+---@field diff_spec diffs.DiffSpec
+---@field repo_root string
+---@field diff_lines string[]
+
 ---@param opts? diffs.GreviewSplitOpts
----@return { left_buf: integer, right_buf: integer, left_win: integer, right_win: integer }?
-function M.greview_split(opts)
+---@return diffs.GreviewSplitContext?, string?, integer?, integer?
+local function greview_split_context(opts)
   opts = opts or {}
 
   ---@type diffs.GeneratedFileSelectionOpts
@@ -634,88 +727,264 @@ function M.greview_split(opts)
   }
   local selected, select_err = lists.selected_generated_file(selection_opts)
   if not selected then
-    notify(select_err or 'no Greview file selected', vim.log.levels.WARN)
-    return nil
+    return nil, select_err or 'no Greview file selected', vim.log.levels.WARN, nil
   end
 
   local review_buf = selected.bufnr
   if not vim.api.nvim_buf_is_valid(review_buf) then
-    notify('selected Greview buffer is no longer valid', vim.log.levels.WARN)
-    return nil
+    return nil, 'selected Greview buffer is no longer valid', vim.log.levels.WARN, review_buf
   end
 
   local source, source_err = get_source_var(review_buf)
   if source_err then
-    notify('invalid diffs_source metadata: ' .. tostring(source_err), vim.log.levels.WARN)
-    return nil
+    return nil,
+      'invalid diffs_source metadata: ' .. tostring(source_err),
+      vim.log.levels.WARN,
+      review_buf
   end
   if not source or source.kind ~= 'review' then
-    notify('selected file is not from a Greview buffer', vim.log.levels.WARN)
-    return nil
+    return nil, 'selected file is not from a Greview buffer', vim.log.levels.WARN, nil
   end
 
   local diff_spec, normalized, spec_err =
     review.diff_spec_for_file(source.review, source.repo_root, selected.file)
   if not diff_spec then
-    notify(spec_err or 'cannot build Greview split diff spec', vim.log.levels.ERROR)
-    return nil
+    return nil, spec_err or 'cannot build Greview split diff spec', vim.log.levels.ERROR, review_buf
   end
 
   local repo_root = normalized and normalized.repo_root or source.repo_root
   local diff_lines, render_err = render.file(diff_spec, repo_root)
   if not diff_lines then
-    notify(render_err or 'cannot render Greview split file', vim.log.levels.ERROR)
-    return nil
+    return nil, render_err or 'cannot render Greview split file', vim.log.levels.ERROR, review_buf
   end
   if #diff_lines == 0 then
-    notify('no changes for ' .. diffspec.label(diff_spec), vim.log.levels.INFO)
-    return nil
+    return nil, 'no changes for ' .. diffspec.label(diff_spec), vim.log.levels.INFO, review_buf
   end
 
+  return {
+    review_buf = review_buf,
+    selected = selected,
+    diff_spec = diff_spec,
+    repo_root = repo_root,
+    diff_lines = diff_lines,
+  },
+    nil,
+    nil,
+    review_buf
+end
+
+---@type fun(review_buf: integer, item?: table)
+local schedule_greview_follow
+
+local function refresh_greview_jump_callback()
+  lists.set_generated_jump_callback(function(item)
+    if type(item) == 'table' and type(item.bufnr) == 'number' then
+      schedule_greview_follow(item.bufnr, item)
+    end
+  end)
+end
+
+---@param review_buf integer
+---@param opened { left_buf: integer, right_buf: integer, left_win: integer, right_win: integer }
+---@param selected diffs.GeneratedFileSelection
+local function start_greview_follow(review_buf, opened, selected)
+  refresh_greview_jump_callback()
+  stop_greview_follow(review_buf)
+
+  ---@type diffs.GreviewFollowState
+  local state = {
+    left_buf = opened.left_buf,
+    right_buf = opened.right_buf,
+    file = selected.file,
+    hunk_index = selected.hunk_index,
+    autocmds = {},
+  }
+  greview_follow_states[review_buf] = state
+  vim.api.nvim_buf_set_var(review_buf, 'diffs_review_split_buf', opened.right_buf)
+
+  state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd({ 'BufEnter', 'CursorMoved' }, {
+    group = greview_follow_group,
+    buffer = review_buf,
+    callback = function(args)
+      schedule_greview_follow(args.buf)
+    end,
+  })
+  state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd('BufWipeout', {
+    group = greview_follow_group,
+    buffer = review_buf,
+    once = true,
+    callback = function(args)
+      stop_greview_follow(args.buf)
+    end,
+  })
+
+  local function stop_if_owned_pair(args)
+    local current = greview_follow_states[review_buf]
+    if current and (args.buf == current.left_buf or args.buf == current.right_buf) then
+      stop_greview_follow(review_buf)
+    end
+  end
+
+  state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd('BufWipeout', {
+    group = greview_follow_group,
+    buffer = opened.left_buf,
+    once = true,
+    callback = stop_if_owned_pair,
+  })
+  state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd('BufWipeout', {
+    group = greview_follow_group,
+    buffer = opened.right_buf,
+    once = true,
+    callback = stop_if_owned_pair,
+  })
+end
+
+---@param context diffs.GreviewSplitContext
+---@param opts? { restore_focus?: boolean, restore_win?: integer }
+---@return { left_buf: integer, right_buf: integer, left_win: integer, right_win: integer }?, string?, integer?
+local function open_greview_split_pair(context, opts)
+  opts = opts or {}
+
+  local review_buf = context.review_buf
   local review_win = first_window_for_buffer(review_buf)
   if not review_win then
-    notify('cannot open Greview split without a visible review buffer', vim.log.levels.WARN)
-    return nil
+    return nil, 'cannot open Greview split without a visible review buffer', vim.log.levels.WARN
   end
+  split.release_pair_window_options(review_win)
+  clear_generated_diff_window_bindings(review_win)
 
-  local previous = get_buf_var(review_buf, 'diffs_review_split_buf')
+  local previous = stored_greview_pair_buf(review_buf)
+  stop_greview_follow(review_buf)
   if type(previous) == 'number' and vim.api.nvim_buf_is_valid(previous) then
     split.close_pair(previous)
   end
 
   review_win = first_window_for_buffer(review_buf)
   if not review_win then
-    notify('cannot open Greview split without a visible review buffer', vim.log.levels.WARN)
-    return nil
+    return nil, 'cannot open Greview split without a visible review buffer', vim.log.levels.WARN
   end
 
-  local restore_win = vim.api.nvim_get_current_win()
+  local restore_win = opts.restore_win or vim.api.nvim_get_current_win()
   vim.api.nvim_set_current_win(review_win)
   vim.cmd('belowright split')
   local launcher_win = vim.api.nvim_get_current_win()
 
   local opened, split_err = split.open({
-    spec = diff_spec,
-    repo_root = repo_root,
-    filetype = filetype_for_path(repo_root, selected.file),
-    diff_lines = diff_lines,
-    hunk_index = selected.hunk_index,
+    spec = context.diff_spec,
+    repo_root = context.repo_root,
+    filetype = filetype_for_path(context.repo_root, context.selected.file),
+    diff_lines = context.diff_lines,
+    hunk_index = context.selected.hunk_index,
     quickfix = false,
   })
   if not opened then
     if vim.api.nvim_win_is_valid(launcher_win) then
       pcall(vim.api.nvim_win_close, launcher_win, true)
     end
-    if vim.api.nvim_win_is_valid(restore_win) then
-      vim.api.nvim_set_current_win(restore_win)
-    elseif vim.api.nvim_win_is_valid(review_win) then
-      vim.api.nvim_set_current_win(review_win)
+    restore_window(restore_win)
+    return nil, split_err or 'cannot open Greview split', vim.log.levels.ERROR
+  end
+
+  start_greview_follow(review_buf, opened, context.selected)
+  if opts.restore_focus then
+    restore_window(restore_win)
+  end
+  return opened, nil, nil
+end
+
+---@param review_buf integer
+---@param item? table
+local function follow_greview_selection(review_buf, item)
+  local state = greview_follow_states[review_buf]
+  if not state then
+    return
+  end
+
+  if not vim.api.nvim_buf_is_valid(review_buf) or not greview_pair_valid(state) then
+    stop_greview_follow(review_buf)
+    return
+  end
+
+  local restore_win = vim.api.nvim_get_current_win()
+  local context = greview_split_context({ bufnr = review_buf, item = item })
+  if not context then
+    close_owned_greview_pair(review_buf)
+    restore_window(restore_win)
+    return
+  end
+
+  local selected = context.selected
+  if selected.file == state.file then
+    if selected.hunk_index then
+      if split.move_pair_to_hunk_index(state.right_buf, selected.hunk_index) then
+        state.hunk_index = selected.hunk_index
+      end
+    elseif selected.hunk_index ~= state.hunk_index then
+      state.hunk_index = nil
     end
-    notify(split_err or 'cannot open Greview split', vim.log.levels.ERROR)
+    restore_window(restore_win)
+    return
+  end
+
+  local opened = open_greview_split_pair(context, {
+    restore_focus = true,
+    restore_win = restore_win,
+  })
+  if not opened then
+    close_owned_greview_pair(review_buf)
+  end
+  restore_window(restore_win)
+end
+
+schedule_greview_follow = function(review_buf, item)
+  local state = greview_follow_states[review_buf]
+  if not state then
+    return
+  end
+  state.pending_item = item or state.pending_item
+  if state.pending then
+    return
+  end
+
+  state.pending = true
+  vim.schedule(function()
+    local current = greview_follow_states[review_buf]
+    if not current then
+      return
+    end
+    local pending_item = current.pending_item
+    current.pending = false
+    current.pending_item = nil
+    follow_greview_selection(review_buf, pending_item)
+  end)
+end
+
+refresh_greview_jump_callback()
+
+---@param opts? diffs.GreviewSplitOpts
+---@return { left_buf: integer, right_buf: integer, left_win: integer, right_win: integer }?
+function M.greview_split(opts)
+  local restore_win = vim.api.nvim_get_current_win()
+  local context, err, level, review_buf = greview_split_context(opts)
+  if not context then
+    if review_buf then
+      close_owned_greview_pair(review_buf)
+      restore_window(restore_win)
+    end
+    notify(err or 'cannot open Greview split', level or vim.log.levels.WARN)
     return nil
   end
 
-  vim.api.nvim_buf_set_var(review_buf, 'diffs_review_split_buf', opened.right_buf)
+  local opened, split_err, split_level = open_greview_split_pair(context, {
+    restore_focus = true,
+    restore_win = restore_win,
+  })
+  if not opened then
+    restore_window(restore_win)
+    notify(split_err or 'cannot open Greview split', split_level or vim.log.levels.ERROR)
+    return nil
+  end
+
   return opened
 end
 

--- a/lua/diffs/lists.lua
+++ b/lua/diffs/lists.lua
@@ -5,6 +5,9 @@ local hunk_model = require('diffs.hunks')
 local generated_list_autocmds = {}
 local generated_list_state = {}
 local quickfix_keymap_autocmd
+---@type fun(item: table?)?
+local generated_jump_callback
+local quickfix_enter_desc = 'Open quickfix item'
 
 local group = vim.api.nvim_create_augroup('diffs_generated_lists', { clear = false })
 
@@ -463,8 +466,32 @@ local function jump_current_quickfix_item()
   local item, is_loclist = current_quickfix_item()
   local row = vim.api.nvim_win_get_cursor(0)[1]
   local command = is_loclist and 'll' or 'cc'
-  vim.cmd(command .. ' ' .. row)
+  local jumped = false
+  if type(item) == 'table' and type(item.bufnr) == 'number' then
+    local item_win = windows_for_buffer(item.bufnr)[1]
+    if item_win then
+      if generated_jump_callback then
+        generated_jump_callback(item)
+      end
+      local lnum = math.max(1, math.min(item.lnum or 1, vim.api.nvim_buf_line_count(item.bufnr)))
+      local col = math.max(0, (item.col or 1) - 1)
+      vim.api.nvim_set_current_win(item_win)
+      vim.api.nvim_win_set_cursor(item_win, { lnum, col })
+      jumped = true
+    end
+  end
+  if not jumped then
+    vim.cmd(command .. ' ' .. row)
+  end
   sync_split_item(item)
+  if generated_jump_callback then
+    generated_jump_callback(item)
+  end
+end
+
+---@param callback fun(item: table?)?
+function M.set_generated_jump_callback(callback)
+  generated_jump_callback = callback
 end
 
 ---@class diffs.GeneratedFileSelectionOpts
@@ -519,14 +546,26 @@ function M.selected_generated_file(opts)
 end
 
 ---@param bufnr integer
----@return boolean
-local function has_enter_keymap(bufnr)
+---@return table?
+local function enter_keymap(bufnr)
   for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, 'n')) do
     if keymap.lhs == '<CR>' then
-      return true
+      return keymap
     end
   end
-  return false
+  return nil
+end
+
+---@param bufnr integer
+local function set_quickfix_keymap(bufnr)
+  local existing = enter_keymap(bufnr)
+  if existing and existing.desc ~= quickfix_enter_desc then
+    return
+  end
+  vim.keymap.set('n', '<CR>', jump_current_quickfix_item, {
+    buffer = bufnr,
+    desc = quickfix_enter_desc,
+  })
 end
 
 function M.ensure_quickfix_keymap()
@@ -538,15 +577,18 @@ function M.ensure_quickfix_keymap()
     group = group,
     pattern = 'qf',
     callback = function(args)
-      if has_enter_keymap(args.buf) then
-        return
-      end
-      vim.keymap.set('n', '<CR>', jump_current_quickfix_item, {
-        buffer = args.buf,
-        desc = 'Open quickfix item',
-      })
+      set_quickfix_keymap(args.buf)
     end,
   })
+
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if
+      vim.api.nvim_buf_is_valid(bufnr)
+      and vim.api.nvim_get_option_value('filetype', { buf = bufnr }) == 'qf'
+    then
+      set_quickfix_keymap(bufnr)
+    end
+  end
 end
 
 -- selene: allow(global_usage)

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -470,23 +470,53 @@ local function set_window_lnum(win, lnum)
   vim.api.nvim_win_set_cursor(win, { clamp_lnum(bufnr, lnum), 0 })
 end
 
+---@param callback function
+local function with_cursor_sync_suppressed(callback)
+  local was_syncing = syncing_cursor
+  syncing_cursor = true
+  local ok, err = pcall(callback)
+  syncing_cursor = was_syncing
+  if not ok then
+    error(err, 0)
+  end
+end
+
 ---@param wins integer[]
 ---@param callback function
-local function without_cursorbind(wins, callback)
+local function with_window_bindings_disabled(wins, callback)
   local saved = {}
+  local ordered = {}
   for _, win in ipairs(wins) do
-    if vim.api.nvim_win_is_valid(win) then
-      saved[win] = vim.api.nvim_get_option_value('cursorbind', { win = win })
+    if not saved[win] and vim.api.nvim_win_is_valid(win) then
+      ordered[#ordered + 1] = win
+      saved[win] = {
+        cursorbind = vim.api.nvim_get_option_value('cursorbind', { win = win }),
+        scrollbind = vim.api.nvim_get_option_value('scrollbind', { win = win }),
+      }
       vim.api.nvim_set_option_value('cursorbind', false, { win = win })
+      vim.api.nvim_set_option_value('scrollbind', false, { win = win })
     end
   end
 
-  callback()
+  local ok, err = pcall(callback)
 
-  for win, value in pairs(saved) do
-    if vim.api.nvim_win_is_valid(win) then
-      vim.api.nvim_set_option_value('cursorbind', value, { win = win })
+  local current_win = vim.api.nvim_get_current_win()
+  if saved[current_win] and vim.api.nvim_win_is_valid(current_win) then
+    local value = saved[current_win]
+    vim.api.nvim_set_option_value('scrollbind', value.scrollbind, { win = current_win })
+    vim.api.nvim_set_option_value('cursorbind', value.cursorbind, { win = current_win })
+  end
+
+  for _, win in ipairs(ordered) do
+    local value = saved[win]
+    if win ~= current_win and vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_set_option_value('scrollbind', value.scrollbind, { win = win })
+      vim.api.nvim_set_option_value('cursorbind', value.cursorbind, { win = win })
     end
+  end
+
+  if not ok then
+    error(err, 0)
   end
 end
 
@@ -505,16 +535,18 @@ local function move_pair_to_hunk(bufnr, hunk)
   local peer_wins = peer and windows_for_buffer(peer) or {}
   local all_wins = vim.list_extend(vim.deepcopy(own_wins), peer_wins)
 
-  without_cursorbind(all_wins, function()
-    for _, win in ipairs(own_wins) do
-      set_window_lnum(win, hunk_target_lnum(hunk, source.side))
-    end
-
-    if peer and peer_source then
-      for _, win in ipairs(peer_wins) do
-        set_window_lnum(win, hunk_target_lnum(hunk, peer_source.side))
+  with_cursor_sync_suppressed(function()
+    with_window_bindings_disabled(all_wins, function()
+      for _, win in ipairs(own_wins) do
+        set_window_lnum(win, hunk_target_lnum(hunk, source.side))
       end
-    end
+
+      if peer and peer_source then
+        for _, win in ipairs(peer_wins) do
+          set_window_lnum(win, hunk_target_lnum(hunk, peer_source.side))
+        end
+      end
+    end)
   end)
 
   if vim.api.nvim_win_is_valid(current_win) then
@@ -556,9 +588,7 @@ local function sync_cursor_to_hunk(bufnr)
     return
   end
 
-  syncing_cursor = true
   move_pair_to_hunk(bufnr, hunk)
-  syncing_cursor = false
 end
 
 clear_cursor_sync = function(bufnr)
@@ -973,6 +1003,17 @@ function M.close_pair(bufnr)
   return true
 end
 
+---@param win integer
+---@return boolean
+function M.release_pair_window_options(win)
+  if not vim.api.nvim_win_is_valid(win) or not pair_window_options[win] then
+    return false
+  end
+
+  clear_pair_window_options(win)
+  return true
+end
+
 ---@param bufnr integer
 ---@return boolean
 function M.open_source(bufnr)
@@ -1058,6 +1099,24 @@ function M.goto_prev(bufnr)
     notify('wrapped to last hunk', vim.log.levels.INFO)
   end
   move_pair_to_hunk(bufnr, hunk)
+end
+
+---@param bufnr integer
+---@param hunk_index integer?
+---@return boolean
+function M.move_pair_to_hunk_index(bufnr, hunk_index)
+  if type(hunk_index) ~= 'number' then
+    return false
+  end
+
+  local hunks = buffer_split_hunks(bufnr)
+  local hunk = hunks[hunk_index]
+  if not hunk then
+    return false
+  end
+
+  move_pair_to_hunk(bufnr, hunk)
+  return true
 end
 
 M.sync_cursor_to_hunk = sync_cursor_to_hunk

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -218,6 +218,23 @@ local function create_mode_only_review_repo()
   }
 end
 
+local function create_mixed_mode_review_repo()
+  local repo = create_mode_only_review_repo()
+
+  git_cmd(repo.repo_root, { 'checkout', '-f', 'mode-base' })
+  write_repo_file(repo.repo_root, 'lua/changed.lua', { 'old' })
+  git_cmd(repo.repo_root, { 'add', 'lua/changed.lua' })
+  git_cmd(repo.repo_root, { 'commit', '-qm', 'add changed file' })
+
+  git_cmd(repo.repo_root, { 'checkout', '-f', 'mode-topic' })
+  git_cmd(repo.repo_root, { 'rebase', 'mode-base' })
+  write_repo_file(repo.repo_root, 'lua/changed.lua', { 'new' })
+  git_cmd(repo.repo_root, { 'add', 'lua/changed.lua' })
+  git_cmd(repo.repo_root, { 'commit', '-qm', 'change file' })
+
+  return repo
+end
+
 local function edit_file(path)
   vim.cmd('edit ' .. vim.fn.fnameescape(path))
   local bufnr = vim.api.nvim_get_current_buf()
@@ -269,6 +286,38 @@ local function find_quickfix_window()
     end
   end
   return nil
+end
+
+---@param loclist boolean
+---@return integer?
+local function find_list_window(loclist)
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    local info = vim.fn.getwininfo(win)[1]
+    if type(info) == 'table' and info.quickfix == 1 then
+      if loclist and info.loclist == 1 then
+        return win
+      end
+      if not loclist and info.loclist == 0 then
+        return win
+      end
+    end
+  end
+  return nil
+end
+
+---@param win integer
+---@return integer?
+local function find_loclist_window_for_window(win)
+  local winnr = vim.fn.win_id2win(win)
+  if winnr == 0 then
+    return nil
+  end
+
+  local loclist = vim.fn.getloclist(winnr, { winid = 0 })
+  if type(loclist) ~= 'table' or type(loclist.winid) ~= 'number' or loclist.winid == 0 then
+    return nil
+  end
+  return loclist.winid
 end
 
 local function find_buffer_line(bufnr, text)
@@ -2453,6 +2502,302 @@ describe('commands', function()
       assert.are.same(
         diffspec.rev_to_rev(repo.base, repo.target, 'lua/one.lua'),
         vim.api.nvim_buf_get_var(second_opened.right_buf, 'diffs_spec')
+      )
+    end)
+
+    it('follows review file transitions after the split pair is opened once', function()
+      local repo = create_review_repo()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = repo.base,
+        target = repo.target,
+        mode = 'direct',
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+      local review_win = vim.api.nvim_get_current_win()
+
+      local two_line = find_buffer_line(bufnr, '+line 2 changed')
+      assert.is_not_nil(two_line)
+      vim.api.nvim_win_set_cursor(review_win, { two_line, 0 })
+      local opened = commands.greview_split({ bufnr = bufnr })
+      assert.is_not_nil(opened)
+      table.insert(test_buffers, opened.left_buf)
+      table.insert(test_buffers, opened.right_buf)
+
+      vim.api.nvim_set_current_win(review_win)
+      local one_line = find_buffer_line(bufnr, '+new one')
+      assert.is_not_nil(one_line)
+      vim.api.nvim_win_set_cursor(review_win, { one_line, 0 })
+      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
+
+      local followed_right
+      vim.wait(100, function()
+        local ok, right = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_review_split_buf')
+        if not ok or right == opened.right_buf or not vim.api.nvim_buf_is_valid(right) then
+          return false
+        end
+        local spec = vim.api.nvim_buf_get_var(right, 'diffs_spec')
+        if spec.scope and spec.scope.path == 'lua/one.lua' then
+          followed_right = right
+          return true
+        end
+        return false
+      end)
+
+      assert.is_not_nil(followed_right)
+      table.insert(test_buffers, followed_right)
+      table.insert(test_buffers, vim.api.nvim_buf_get_var(followed_right, 'diffs_split_peer'))
+      assert.is_false(vim.api.nvim_buf_is_valid(opened.left_buf))
+      assert.is_false(vim.api.nvim_buf_is_valid(opened.right_buf))
+      assert.are.equal(review_win, vim.api.nvim_get_current_win())
+
+      local qf = quickfix_items()
+      assert.are.equal(2, #qf)
+      assert.are.equal(bufnr, qf[1].bufnr)
+      assert.are.equal(bufnr, qf[2].bufnr)
+    end)
+
+    it('moves same-file review hunk transitions through the existing split pair', function()
+      local repo = create_review_repo()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = repo.base,
+        target = repo.target,
+        mode = 'direct',
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+      local review_win = vim.api.nvim_get_current_win()
+
+      local first_hunk_line = find_buffer_line(bufnr, '+line 2 changed')
+      assert.is_not_nil(first_hunk_line)
+      vim.api.nvim_win_set_cursor(review_win, { first_hunk_line, 0 })
+      local opened = commands.greview_split({ bufnr = bufnr })
+      assert.is_not_nil(opened)
+      table.insert(test_buffers, opened.left_buf)
+      table.insert(test_buffers, opened.right_buf)
+      local split_hunks = vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_split_hunks')
+
+      vim.api.nvim_set_current_win(review_win)
+      local second_hunk_line = find_buffer_line(bufnr, '+line 11 changed')
+      assert.is_not_nil(second_hunk_line)
+      vim.api.nvim_win_set_cursor(review_win, { second_hunk_line, 0 })
+      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
+
+      vim.wait(100, function()
+        return vim.api.nvim_win_get_cursor(opened.right_win)[1] == split_hunks[2].new_range.start
+      end)
+
+      assert.are.equal(opened.right_buf, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_split_buf'))
+      assert.are.same(
+        { split_hunks[2].old_range.start, 0 },
+        vim.api.nvim_win_get_cursor(opened.left_win)
+      )
+      assert.are.same(
+        { split_hunks[2].new_range.start, 0 },
+        vim.api.nvim_win_get_cursor(opened.right_win)
+      )
+      assert.are.equal(review_win, vim.api.nvim_get_current_win())
+    end)
+
+    it('updates the owned split pair after review quickfix and loclist jumps', function()
+      local repo = create_review_repo()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = repo.base,
+        target = repo.target,
+        mode = 'direct',
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+
+      local one_line = find_buffer_line(bufnr, '+new one')
+      assert.is_not_nil(one_line)
+      vim.api.nvim_win_set_cursor(0, { one_line, 0 })
+      local opened = commands.greview_split({ bufnr = bufnr })
+      assert.is_not_nil(opened)
+      table.insert(test_buffers, opened.left_buf)
+      table.insert(test_buffers, opened.right_buf)
+
+      vim.cmd('copen')
+      local qf_win = find_list_window(false)
+      assert.is_not_nil(qf_win)
+      vim.api.nvim_set_current_win(qf_win)
+      vim.api.nvim_win_set_cursor(qf_win, { 2, 0 })
+      vim.cmd('normal \r')
+
+      local followed_right
+      vim.wait(100, function()
+        local ok, right = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_review_split_buf')
+        if not ok or right == opened.right_buf or not vim.api.nvim_buf_is_valid(right) then
+          return false
+        end
+        local spec = vim.api.nvim_buf_get_var(right, 'diffs_spec')
+        if spec.scope and spec.scope.path == 'lua/two.lua' then
+          followed_right = right
+          return true
+        end
+        return false
+      end)
+
+      assert.is_not_nil(followed_right)
+      table.insert(test_buffers, followed_right)
+      local followed_left = vim.api.nvim_buf_get_var(followed_right, 'diffs_split_peer')
+      table.insert(test_buffers, followed_left)
+
+      local review_win = find_window_for_buffer(bufnr)
+      assert.is_not_nil(review_win)
+      vim.api.nvim_set_current_win(review_win)
+      vim.cmd('lopen')
+      local loc_win = find_loclist_window_for_window(review_win)
+      assert.is_not_nil(loc_win)
+      vim.api.nvim_set_current_win(loc_win)
+      vim.api.nvim_win_set_cursor(loc_win, { 2, 0 })
+      vim.cmd('normal \r')
+
+      local right_win = find_window_for_buffer(followed_right)
+      local left_win = find_window_for_buffer(followed_left)
+      local split_hunks = vim.api.nvim_buf_get_var(followed_right, 'diffs_split_hunks')
+      vim.wait(100, function()
+        return right_win
+          and vim.api.nvim_win_is_valid(right_win)
+          and vim.api.nvim_win_get_cursor(right_win)[1] == split_hunks[2].new_range.start
+      end)
+
+      assert.are.equal(followed_right, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_split_buf'))
+      assert.are.same({ split_hunks[2].old_range.start, 0 }, vim.api.nvim_win_get_cursor(left_win))
+      assert.are.same({ split_hunks[2].new_range.start, 0 }, vim.api.nvim_win_get_cursor(right_win))
+    end)
+
+    it('stops following after the owned split pair is closed', function()
+      local repo = create_review_repo()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = repo.base,
+        target = repo.target,
+        mode = 'direct',
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+      local review_win = vim.api.nvim_get_current_win()
+
+      local two_line = find_buffer_line(bufnr, '+line 2 changed')
+      assert.is_not_nil(two_line)
+      vim.api.nvim_win_set_cursor(review_win, { two_line, 0 })
+      local opened = commands.greview_split({ bufnr = bufnr })
+      assert.is_not_nil(opened)
+
+      split.close_pair(opened.right_buf)
+      assert.is_false(vim.api.nvim_buf_is_valid(opened.left_buf))
+      assert.is_false(vim.api.nvim_buf_is_valid(opened.right_buf))
+      assert.is_false(has_buf_var(bufnr, 'diffs_review_split_buf'))
+
+      vim.api.nvim_set_current_win(review_win)
+      local one_line = find_buffer_line(bufnr, '+new one')
+      assert.is_not_nil(one_line)
+      vim.api.nvim_win_set_cursor(review_win, { one_line, 0 })
+      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
+
+      assert.is_false(has_buf_var(bufnr, 'diffs_review_split_buf'))
+    end)
+
+    it('closes stale review split pairs for unsupported auto-follow selections', function()
+      local repo = create_mixed_mode_review_repo()
+      local notifications = capture_notifications()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = repo.base,
+        target = repo.target,
+        mode = 'direct',
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+      local review_win = vim.api.nvim_get_current_win()
+
+      local changed_line = find_buffer_line(bufnr, '+new')
+      assert.is_not_nil(changed_line)
+      vim.api.nvim_win_set_cursor(review_win, { changed_line, 0 })
+      local opened = commands.greview_split({ bufnr = bufnr })
+      assert.is_not_nil(opened)
+
+      local mode_line = find_buffer_line(bufnr, 'diff --git a/scripts/tool.sh b/scripts/tool.sh')
+      assert.is_not_nil(mode_line)
+      vim.api.nvim_set_current_win(review_win)
+      vim.api.nvim_win_set_cursor(review_win, { mode_line, 0 })
+      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
+
+      vim.wait(100, function()
+        return not vim.api.nvim_buf_is_valid(opened.right_buf)
+          and not has_buf_var(bufnr, 'diffs_review_split_buf')
+      end)
+
+      assert.is_false(vim.api.nvim_buf_is_valid(opened.left_buf))
+      assert.is_false(vim.api.nvim_buf_is_valid(opened.right_buf))
+      assert.is_false(has_buf_var(bufnr, 'diffs_review_split_buf'))
+      assert.are.equal(0, #notifications)
+    end)
+
+    it('keeps Greview follow compatible with split-pair cursor sync', function()
+      local repo = create_review_repo()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = repo.base,
+        target = repo.target,
+        mode = 'direct',
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+      local review_win = vim.api.nvim_get_current_win()
+
+      local first_hunk_line = find_buffer_line(bufnr, '+line 2 changed')
+      assert.is_not_nil(first_hunk_line)
+      vim.api.nvim_win_set_cursor(review_win, { first_hunk_line, 0 })
+      local opened = commands.greview_split({ bufnr = bufnr })
+      assert.is_not_nil(opened)
+      table.insert(test_buffers, opened.left_buf)
+      table.insert(test_buffers, opened.right_buf)
+      local split_hunks = vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_split_hunks')
+
+      vim.api.nvim_set_current_win(opened.right_win)
+      split.goto_next(opened.right_buf)
+      assert.are.same(
+        { split_hunks[2].old_range.start, 0 },
+        vim.api.nvim_win_get_cursor(opened.left_win)
+      )
+      assert.are.same(
+        { split_hunks[2].new_range.start, 0 },
+        vim.api.nvim_win_get_cursor(opened.right_win)
+      )
+
+      vim.api.nvim_set_current_win(review_win)
+      vim.api.nvim_win_set_cursor(review_win, { first_hunk_line, 0 })
+      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
+
+      vim.wait(100, function()
+        return vim.api.nvim_win_get_cursor(opened.right_win)[1] == split_hunks[1].new_range.start
+      end)
+
+      assert.are.equal(opened.right_buf, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_split_buf'))
+      assert.are.same(
+        { split_hunks[1].old_range.start, 0 },
+        vim.api.nvim_win_get_cursor(opened.left_win)
+      )
+      assert.are.same(
+        { split_hunks[1].new_range.start, 0 },
+        vim.api.nvim_win_get_cursor(opened.right_win)
       )
     end)
 


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #306.

## Solution

The solution keeps an opened Greview split pair following review-map file and hunk selection; routes generated quickfix/loclist jumps through the active review projection without clobbering the pair; and handles file transitions, hunk transitions, qf/loclist jumps, stale-pair close, and split cursor-sync compatibility.
