### PR TITLE
Scope Greview follow registration

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -806,6 +806,9 @@ local function start_greview_follow(review_buf, opened, selected)
     group = greview_follow_group,
     buffer = review_buf,
     callback = function(args)
+      if get_buf_var(args.buf, 'diffs_generated_jump_in_progress') then
+        return
+      end
       schedule_greview_follow(args.buf)
     end,
   })
@@ -958,8 +961,6 @@ schedule_greview_follow = function(review_buf, item)
     follow_greview_selection(review_buf, pending_item)
   end)
 end
-
-refresh_greview_jump_callback()
 
 ---@param opts? diffs.GreviewSplitOpts
 ---@return { left_buf: integer, right_buf: integer, left_win: integer, right_win: integer }?

--- a/lua/diffs/lists.lua
+++ b/lua/diffs/lists.lua
@@ -470,13 +470,17 @@ local function jump_current_quickfix_item()
   if type(item) == 'table' and type(item.bufnr) == 'number' then
     local item_win = windows_for_buffer(item.bufnr)[1]
     if item_win then
-      if generated_jump_callback then
-        generated_jump_callback(item)
-      end
       local lnum = math.max(1, math.min(item.lnum or 1, vim.api.nvim_buf_line_count(item.bufnr)))
       local col = math.max(0, (item.col or 1) - 1)
-      vim.api.nvim_set_current_win(item_win)
-      vim.api.nvim_win_set_cursor(item_win, { lnum, col })
+      vim.api.nvim_buf_set_var(item.bufnr, 'diffs_generated_jump_in_progress', true)
+      local ok, err = pcall(function()
+        vim.api.nvim_win_set_cursor(item_win, { lnum, col })
+        vim.api.nvim_set_current_win(item_win)
+      end)
+      pcall(vim.api.nvim_buf_del_var, item.bufnr, 'diffs_generated_jump_in_progress')
+      if not ok then
+        error(err, 0)
+      end
       jumped = true
     end
   end


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

## Solution

The solution register Greview generated-list follow only when a follow pair is active; suppress review follow autocmds during direct generated-list cursor placement; and keeps generated quickfix Enter refreshable without double-dispatching follow callbacks.
