### PR TITLE
Stack current-state Greview sections

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -32,6 +32,7 @@ local hunk_keymap_autocmds = {}
 ---@field left_buf integer
 ---@field right_buf integer
 ---@field file string
+---@field key string
 ---@field hunk_index? integer
 ---@field autocmds integer[]
 ---@field pending? boolean
@@ -550,16 +551,16 @@ local function render_section_source(repo_root, section)
 end
 
 ---@param source diffs.GeneratedBufferSource
----@return string[]?, diffs.DiffSpec?, string?
+---@return string[]?, diffs.DiffSpec?, string?, table?
 local function render_source(source)
   if source.kind == 'file' then
     local diff_lines, read_err = render.file(source.spec, source.repo_root, {
       empty_on_missing = true,
     })
     if not diff_lines then
-      return nil, nil, read_err
+      return nil, nil, read_err, nil
     end
-    return diff_lines, source.spec, diffspec.label(source.spec)
+    return diff_lines, source.spec, diffspec.label(source.spec), nil
   end
 
   if source.kind == 'file_pair' then
@@ -578,19 +579,23 @@ local function render_source(source)
     end
     return render.unified_lines(old_lines, new_lines, source.old_path, source.path),
       nil,
-      source.edge .. ':' .. source.path
+      source.edge .. ':' .. source.path,
+      nil
   end
 
   if source.kind == 'section' then
-    return render_section_source(source.repo_root, source.section), nil, source.section .. ':all'
+    return render_section_source(source.repo_root, source.section),
+      nil,
+      source.section .. ':all',
+      nil
   end
 
   if source.kind == 'review' then
-    local review_lines, review_err = review.reload_source(source, review_deps())
+    local review_lines, review_err, list_opts = review.reload_source(source, review_deps())
     if not review_lines then
-      return nil, nil, review_err
+      return nil, nil, review_err, nil
     end
-    return review_lines, nil, 'review'
+    return review_lines, nil, 'review', list_opts
   end
 
   local abs_path = source.repo_root .. '/' .. source.path
@@ -598,7 +603,8 @@ local function render_source(source)
   local new_lines = git.get_file_content(':3', abs_path) or {}
   return render.unified_lines(old_lines, new_lines, source.path, source.path),
     nil,
-    'unmerged:' .. source.path
+    'unmerged:' .. source.path,
+    nil
 end
 
 ---@param diff_label string
@@ -747,7 +753,7 @@ local function greview_split_context(opts)
   end
 
   local diff_spec, normalized, spec_err =
-    review.diff_spec_for_file(source.review, source.repo_root, selected.file)
+    review.diff_spec_for_file(source.review, source.repo_root, selected.file, selected)
   if not diff_spec then
     return nil, spec_err or 'cannot build Greview split diff spec', vim.log.levels.ERROR, review_buf
   end
@@ -796,6 +802,7 @@ local function start_greview_follow(review_buf, opened, selected)
     left_buf = opened.left_buf,
     right_buf = opened.right_buf,
     file = selected.file,
+    key = selected.key or selected.file,
     hunk_index = selected.hunk_index,
     autocmds = {},
   }
@@ -917,7 +924,7 @@ local function follow_greview_selection(review_buf, item)
   end
 
   local selected = context.selected
-  if selected.file == state.file then
+  if (selected.key or selected.file) == (state.key or state.file) then
     if selected.hunk_index then
       if split.move_pair_to_hunk_index(state.right_buf, selected.hunk_index) then
         state.hunk_index = selected.hunk_index
@@ -1328,11 +1335,12 @@ function M.read_buffer(bufnr)
   local diff_lines
   local stored_spec
   local debug_label
+  local list_opts
   local label, path
 
   if source then
     local render_err
-    diff_lines, stored_spec, render_err = render_source(source)
+    diff_lines, stored_spec, render_err, list_opts = render_source(source)
     if not diff_lines then
       notify(render_err or 'cannot reload diffs:// buffer', vim.log.levels.WARN)
       return
@@ -1366,7 +1374,7 @@ function M.read_buffer(bufnr)
       diff_lines = render_section_source(repo_root, label)
     elseif not stored_spec and label == 'review' then
       local review_err
-      diff_lines, review_err = review.reload(bufnr, repo_root, path, review_deps())
+      diff_lines, review_err, list_opts = review.reload(bufnr, repo_root, path, review_deps())
       if not diff_lines then
         notify(review_err or 'cannot reload review buffer', vim.log.levels.WARN)
         return
@@ -1407,11 +1415,14 @@ function M.read_buffer(bufnr)
   end
 
   replace_generated_diff_buffer_lines(bufnr, diff_lines, stored_spec)
-  M.setup_diff_buf(bufnr)
   lists.set_for_unified_buffer(bufnr, diff_lines, {
     title = 'diff: ' .. (debug_label or name:gsub('^diffs://', '')),
     diff_spec = stored_spec,
+    metadata_for_line = list_opts and list_opts.metadata_for_line,
+    sections = list_opts and list_opts.sections,
+    store_hunks = list_opts and list_opts.store_hunks,
   })
+  M.setup_diff_buf(bufnr)
 
   dbg('reloaded diff buffer %d (%s)', bufnr, debug_label)
 

--- a/lua/diffs/hunks.lua
+++ b/lua/diffs/hunks.lua
@@ -28,6 +28,9 @@ local notify = require('diffs.log').notify
 ---@field file_header_range diffs.GdiffHunkRange?
 ---@field file_header_lines string[]
 ---@field header string
+---@field generated_key string?
+---@field section string?
+---@field section_label string?
 ---@field diff_spec diffs.DiffSpec?
 ---@field edge { left: diffs.Endpoint, right: diffs.Endpoint, mutation_target: "index"|"worktree"|nil }?
 ---@field can_put boolean
@@ -107,6 +110,15 @@ local function parse_new_path(line)
   return normalize_path(line:match('^%+%+%+ (.+)$'), true)
 end
 
+---@param line string
+---@return boolean
+local function is_review_section_header(line)
+  return line:match('^# Branch:') ~= nil
+    or line:match('^# Staged:') ~= nil
+    or line:match('^# Unstaged:') ~= nil
+    or line:match('^# Untracked:') ~= nil
+end
+
 ---@param diff_spec diffs.DiffSpec?
 ---@return diffs.DiffSpec?, "index"|"worktree"|nil, boolean, boolean
 local function normalize_spec(diff_spec)
@@ -178,7 +190,18 @@ function M.parse(diff_lines, diff_spec)
   end
 
   for lnum, line in ipairs(diff_lines) do
-    if line:match('^diff %-%-git ') then
+    if is_review_section_header(line) then
+      finish_hunk(lnum - 1)
+      current_old_path = spec and spec.scope.kind == diffspec.scope_kind.file and spec.scope.path
+        or nil
+      current_new_path = current_old_path
+      current_file = current_new_path or current_old_path
+      current_hunk = nil
+      current_file_header_start = nil
+      current_file_header_lines = {}
+      old_lnum = 0
+      new_lnum = 0
+    elseif line:match('^diff %-%-git ') then
       finish_hunk(lnum - 1)
       current_old_path, current_new_path = parse_diff_git_paths(line)
       current_file = current_new_path or current_old_path

--- a/lua/diffs/lists.lua
+++ b/lua/diffs/lists.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local diffspec = require('diffs.spec')
 local hunk_model = require('diffs.hunks')
 
 local generated_list_autocmds = {}
@@ -10,6 +11,14 @@ local generated_jump_callback
 local quickfix_enter_desc = 'Open quickfix item'
 
 local group = vim.api.nvim_create_augroup('diffs_generated_lists', { clear = false })
+
+---@class diffs.GeneratedListOptions
+---@field title? string
+---@field loclist_title? string
+---@field diff_spec? diffs.DiffSpec
+---@field metadata_for_line? fun(lnum: integer, file: string): table?
+---@field sections? table[]
+---@field store_hunks? boolean
 
 ---@param bufnr integer
 ---@param name string
@@ -88,46 +97,101 @@ end
 ---@param by_file table<string, table>
 ---@param file string
 ---@param lnum integer
+---@param meta? table
 ---@return table
-local function ensure_file_entry(entries, by_file, file, lnum)
-  local entry = by_file[file]
+local function ensure_file_entry(entries, by_file, file, lnum, meta)
+  meta = meta or {}
+  local key = meta.key or file
+  local entry = by_file[key]
   if entry then
     entry.lnum = math.min(entry.lnum, lnum)
     return entry
   end
 
   entry = {
+    key = key,
     file = file,
     lnum = lnum,
     adds = 0,
     dels = 0,
     hunks = {},
+    section = meta.section,
+    section_label = meta.section_label,
+    diff_spec = meta.diff_spec,
   }
-  by_file[file] = entry
+  by_file[key] = entry
   entries[#entries + 1] = entry
   return entry
 end
 
+---@param opts? table
+---@param lnum integer
+---@param file string
+---@return table
+local function metadata_for_line(opts, lnum, file)
+  local fn = opts and opts.metadata_for_line
+  if type(fn) ~= 'function' then
+    return {}
+  end
+
+  local meta = fn(lnum, file)
+  if type(meta) == 'table' then
+    return meta
+  end
+  return {}
+end
+
+---@param entry table
+---@return string
+local function entry_display_file(entry)
+  if type(entry.section_label) == 'string' and entry.section_label ~= '' then
+    return ('[%s] %s'):format(entry.section_label, entry.file)
+  end
+  return entry.file
+end
+
+---@param hunk diffs.GdiffHunk?
+---@return string?
+local function hunk_key(hunk)
+  if type(hunk) ~= 'table' then
+    return nil
+  end
+  return hunk.generated_key
+end
+
 ---@param hunks diffs.GdiffHunk[]
 ---@param diff_lines? string[]
+---@param opts? table
 ---@return table[]
-local function file_entries(hunks, diff_lines)
+local function file_entries(hunks, diff_lines, opts)
   local by_file = {}
   local entries = {}
   for lnum, line in ipairs(diff_lines or {}) do
     local file = diff_file(line)
     if file then
-      ensure_file_entry(entries, by_file, file, lnum)
+      ensure_file_entry(entries, by_file, file, lnum, metadata_for_line(opts, lnum, file))
     end
   end
 
   for _, hunk in ipairs(hunks) do
     local file = hunk_file(hunk)
-    local entry = ensure_file_entry(entries, by_file, file, file_lnum(hunk))
+    local meta = metadata_for_line(opts, hunk.buffer_range.start, file)
+    local entry = ensure_file_entry(entries, by_file, file, file_lnum(hunk), meta)
     local adds, dels = hunk_stats(hunk)
     entry.adds = entry.adds + adds
     entry.dels = entry.dels + dels
     entry.hunks[#entry.hunks + 1] = hunk
+    hunk.generated_key = entry.key
+    hunk.section = entry.section
+    hunk.section_label = entry.section_label
+    if not hunk.diff_spec and entry.diff_spec then
+      hunk.diff_spec = entry.diff_spec
+      local actions = diffspec.patch_actions(entry.diff_spec)
+      hunk.can_put = actions.can_put
+      hunk.can_obtain = actions.can_obtain
+      hunk.actionable = actions.can_put or actions.can_obtain
+      hunk.mutation_target = diffspec.mutation_target(entry.diff_spec)
+    end
   end
   return entries
 end
@@ -137,7 +201,8 @@ local function format_file_text(entries)
   local max_fname = 0
   local max_add, max_del = 0, 0
   for _, entry in ipairs(entries) do
-    max_fname = math.max(max_fname, #entry.file)
+    entry.display_file = entry_display_file(entry)
+    max_fname = math.max(max_fname, #entry.display_file)
     if entry.adds > 0 then
       max_add = math.max(max_add, #tostring(entry.adds) + 1)
     end
@@ -147,7 +212,7 @@ local function format_file_text(entries)
   end
 
   for _, entry in ipairs(entries) do
-    local padded = entry.file .. string.rep(' ', max_fname - #entry.file)
+    local padded = entry.display_file .. string.rep(' ', max_fname - #entry.display_file)
     local parts = { padded }
     if max_add > 0 then
       parts[#parts + 1] = entry.adds > 0 and string.format('%' .. max_add .. 's', '+' .. entry.adds)
@@ -177,6 +242,10 @@ local function quickfix_items(bufnr, entries)
         diffs = {
           kind = 'file',
           file = entry.file,
+          key = entry.key,
+          section = entry.section,
+          section_label = entry.section_label,
+          diff_spec = entry.diff_spec,
         },
       },
     }
@@ -184,47 +253,87 @@ local function quickfix_items(bufnr, entries)
   return items
 end
 
+---@param entries table[]
+---@param lnum integer
+---@param sections? table[]
+---@return table?
+local function entry_at_lnum(entries, lnum, sections)
+  if #entries == 0 then
+    return nil
+  end
+
+  local section = nil
+  for _, candidate in ipairs(sections or {}) do
+    if lnum >= candidate.start and lnum <= candidate.finish then
+      section = candidate
+      break
+    end
+  end
+
+  local selected = nil
+  for _, entry in ipairs(entries) do
+    if section and entry.section ~= section.id then
+      goto continue
+    end
+    if lnum >= entry.lnum then
+      selected = entry
+    else
+      break
+    end
+    ::continue::
+  end
+  if selected then
+    return selected
+  end
+
+  if section then
+    for _, entry in ipairs(entries) do
+      if entry.section == section.id then
+        return entry
+      end
+    end
+  end
+  return entries[1]
+end
+
 ---@param hunks diffs.GdiffHunk[]
 ---@param entries table[]
 ---@param lnum integer
 ---@return string?
 local function file_at_lnum(hunks, entries, lnum)
-  entries = entries or file_entries(hunks)
-  if #entries == 0 then
-    return nil
-  end
-
-  local selected = entries[1].file
-  for _, entry in ipairs(entries) do
-    if lnum >= entry.lnum then
-      selected = entry.file
-    else
-      break
-    end
-  end
-  return selected
+  local entry = entry_at_lnum(entries or file_entries(hunks), lnum)
+  return entry and entry.file or nil
 end
 
 ---@param bufnr integer
 ---@param hunks diffs.GdiffHunk[]
----@param file string?
+---@param entry table?
 ---@return table[]
-local function loclist_items(bufnr, hunks, file)
+local function loclist_items(bufnr, hunks, entry)
   local file_hunk_count = {}
+  local key = entry and entry.key or nil
+  local file = entry and entry.file or nil
   local items = {}
   for _, hunk in ipairs(hunks) do
     local hfile = hunk_file(hunk)
-    if not file or hfile == file then
-      file_hunk_count[hfile] = (file_hunk_count[hfile] or 0) + 1
+    local hkey = hunk_key(hunk)
+    if (key and hkey == key) or (not key and (not file or hfile == file)) then
+      local count_key = hkey or hfile
+      file_hunk_count[count_key] = (file_hunk_count[count_key] or 0) + 1
+      local display = hunk.section_label and ('[' .. hunk.section_label .. '] ' .. hfile) or hfile
       items[#items + 1] = {
         bufnr = bufnr,
         lnum = hunk.buffer_range.start,
         col = 1,
-        text = ('%s (hunk %d) %s'):format(hfile, file_hunk_count[hfile], hunk.header),
+        text = ('%s (hunk %d) %s'):format(display, file_hunk_count[count_key], hunk.header),
         user_data = {
           diffs = {
             kind = 'hunk',
             file = hfile,
+            key = hkey,
+            section = hunk.section,
+            section_label = hunk.section_label,
+            diff_spec = hunk.diff_spec,
             hunk = hunk.index,
           },
         },
@@ -271,8 +380,9 @@ local function file_hunk_index(hunks, target)
 
   local count = 0
   local file = hunk_file(target)
+  local key = hunk_key(target)
   for _, hunk in ipairs(hunks) do
-    if hunk_file(hunk) == file then
+    if (key and hunk_key(hunk) == key) or (not key and hunk_file(hunk) == file) then
       count = count + 1
     end
     if hunk == target then
@@ -312,9 +422,14 @@ local function selection_from_item(item)
 
   local state = generated_list_state[item.bufnr]
   local hunk = state and hunk_by_index(state.hunks, data.hunk) or nil
+  local key = data.key or hunk_key(hunk) or data.file
   return {
     bufnr = item.bufnr,
     file = data.file,
+    key = key,
+    section = data.section,
+    section_label = data.section_label,
+    diff_spec = data.diff_spec,
     lnum = item.lnum,
     hunk = hunk,
     hunk_index = state and file_hunk_index(state.hunks, hunk) or nil,
@@ -362,15 +477,16 @@ local function refresh_loclist_for_window(bufnr, win, force)
   end
 
   local cursor = vim.api.nvim_win_get_cursor(win)[1]
-  local file = file_at_lnum(state.hunks, state.entries, cursor)
+  local entry = entry_at_lnum(state.entries, cursor, state.sections)
+  local key = entry and entry.key or nil
   local cache = state.win_files or {}
   state.win_files = cache
-  if not force and cache[win] == file then
+  if not force and cache[win] == key then
     return
   end
-  cache[win] = file
+  cache[win] = key
 
-  set_loclist(win, state.loclist_title, loclist_items(bufnr, state.hunks, file))
+  set_loclist(win, state.loclist_title, loclist_items(bufnr, state.hunks, entry))
 end
 
 ---@param bufnr integer
@@ -506,6 +622,10 @@ end
 ---@class diffs.GeneratedFileSelection
 ---@field bufnr integer
 ---@field file string
+---@field key? string
+---@field section? string
+---@field section_label? string
+---@field diff_spec? diffs.DiffSpec
 ---@field lnum integer?
 ---@field hunk? diffs.GdiffHunk
 ---@field hunk_index? integer
@@ -533,15 +653,19 @@ function M.selected_generated_file(opts)
   end
 
   local lnum = selection_lnum(bufnr, opts.lnum)
-  local file = file_at_lnum(state.hunks, state.entries, lnum)
-  if not file then
+  local entry = entry_at_lnum(state.entries, lnum, state.sections)
+  if not entry then
     return nil, 'no generated diff file selected'
   end
 
   local hunk = hunk_at_lnum(state.hunks, lnum)
   return {
     bufnr = bufnr,
-    file = file,
+    file = entry.file,
+    key = (hunk and hunk_key(hunk)) or entry.key,
+    section = (hunk and hunk.section) or entry.section,
+    section_label = (hunk and hunk.section_label) or entry.section_label,
+    diff_spec = (hunk and hunk.diff_spec) or entry.diff_spec,
     lnum = lnum,
     hunk = hunk,
     hunk_index = file_hunk_index(state.hunks, hunk),
@@ -621,18 +745,23 @@ end
 
 ---@param bufnr integer
 ---@param diff_lines string[]
----@param opts? { title?: string, loclist_title?: string, diff_spec?: diffs.DiffSpec }
+---@param opts? diffs.GeneratedListOptions
 function M.set_for_unified_buffer(bufnr, diff_lines, opts)
   opts = opts or {}
   local diff_spec = opts.diff_spec or buffer_diff_spec(bufnr)
   local hunks = hunk_model.parse(diff_lines, diff_spec)
-  local entries = file_entries(hunks, diff_lines)
+  local entries = file_entries(hunks, diff_lines, opts)
   local title = opts.title or 'diffs'
   local loclist_title = opts.loclist_title or (title .. ' hunks')
+
+  if opts.store_hunks then
+    vim.api.nvim_buf_set_var(bufnr, 'diffs_hunks', hunks)
+  end
 
   generated_list_state[bufnr] = {
     hunks = hunks,
     entries = entries,
+    sections = opts.sections,
     loclist_title = loclist_title,
     win_files = {},
   }

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -4,6 +4,7 @@ local diffspec = require('diffs.spec')
 local git = require('diffs.git')
 local lists = require('diffs.lists')
 local log = require('diffs.log')
+local render = require('diffs.render')
 
 local dbg = log.dbg
 local notify = log.notify
@@ -245,11 +246,320 @@ function M.build_cmd(review)
   return cmd
 end
 
+---@param repo_root string
+---@param args string[]
+---@return string[]?, string?
+local function git_lines(repo_root, args)
+  local cmd = { 'git', '-C', repo_root }
+  vim.list_extend(cmd, args)
+  local result = vim.fn.systemlist(cmd)
+  if vim.v.shell_error ~= 0 then
+    return nil, table.concat(result or {}, '\n')
+  end
+  return result, nil
+end
+
+---@param line string
+---@return string?
+local function diff_line_file(line)
+  local old_path, new_path = line:match('^diff %-%-git a/(.-) b/(.+)$')
+  return new_path or old_path
+end
+
+---@param diff_lines string[]
+---@return table<string, boolean>
+local function combined_diff_files(diff_lines)
+  local files = {}
+  for _, line in ipairs(diff_lines) do
+    local file = line:match('^diff %-%-cc (.+)$') or line:match('^diff %-%-combined (.+)$')
+    if file then
+      files[file] = true
+    end
+  end
+  return files
+end
+
+---@param diff_lines string[]
+---@return table[]
+local function file_records(diff_lines)
+  local records = {}
+  local current = nil
+  for lnum, line in ipairs(diff_lines) do
+    local file = diff_line_file(line)
+    if file then
+      if current then
+        current.finish = lnum - 1
+      end
+      current = {
+        file = file,
+        start = lnum,
+        finish = #diff_lines,
+      }
+      records[#records + 1] = current
+    end
+  end
+  return records
+end
+
+---@param path string
+---@return diffs.DiffSpec
+local function unmerged_stage_spec(path)
+  return diffspec.rev_to_rev(':2', ':3', path)
+end
+
+---@param diff_lines string[]
+---@param spec_for_file fun(file: string): diffs.DiffSpec
+---@return table<string, diffs.DiffSpec>
+local function section_specs(diff_lines, spec_for_file)
+  local specs = {}
+  for _, record in ipairs(file_records(diff_lines)) do
+    specs[record.file] = spec_for_file(record.file)
+  end
+  return specs
+end
+
+---@param review diffs.NormalizedGreview
+---@param base_rev string
+---@return string[]?, string?
+local function branch_lines(review, base_rev)
+  return git_lines(review.repo_root, {
+    'diff',
+    '--no-ext-diff',
+    '--no-color',
+    base_rev,
+    'HEAD',
+  })
+end
+
+---@param review diffs.NormalizedGreview
+---@param cached boolean
+---@return string[]?, string?
+local function worktree_edge_lines(review, cached)
+  local args = { 'diff', '--no-ext-diff', '--no-color' }
+  if cached then
+    args[#args + 1] = '--cached'
+  end
+  return git_lines(review.repo_root, args)
+end
+
+---@param review diffs.NormalizedGreview
+---@return string[]?, string?
+local function untracked_paths(review)
+  local paths = vim.fn.systemlist({
+    'git',
+    '-C',
+    review.repo_root,
+    'ls-files',
+    '--others',
+    '--exclude-standard',
+  })
+  if vim.v.shell_error ~= 0 then
+    return nil, table.concat(paths or {}, '\n')
+  end
+
+  table.sort(paths)
+  return paths, nil
+end
+
+---@param repo_root string
+---@param path string
+---@return boolean
+local function is_untracked_binary(repo_root, path)
+  local result = vim.fn.systemlist({
+    'git',
+    '-C',
+    repo_root,
+    'diff',
+    '--no-ext-diff',
+    '--no-color',
+    '--no-index',
+    '--numstat',
+    '--',
+    '/dev/null',
+    path,
+  })
+  if vim.v.shell_error ~= 0 and vim.v.shell_error ~= 1 then
+    return false
+  end
+
+  for _, line in ipairs(result or {}) do
+    if line:match('^%-%s+%-%s+') then
+      return true
+    end
+  end
+  return false
+end
+
+---@param lines string[]
+---@param section table
+---@param specs table<string, diffs.DiffSpec>
+---@param state table
+local function append_section(lines, section, specs, state)
+  local records = file_records(section.lines)
+  if #records == 0 then
+    return
+  end
+
+  local header_lnum = #lines + 1
+  lines[#lines + 1] = ('# %s: %s'):format(section.label, section.description)
+  local section_start = header_lnum
+  for _, line in ipairs(section.lines) do
+    lines[#lines + 1] = line
+  end
+
+  local section_info = {
+    id = section.id,
+    label = section.label,
+    start = section_start,
+    finish = #lines,
+  }
+  state.sections[#state.sections + 1] = section_info
+
+  for _, record in ipairs(records) do
+    local key = section.id .. ':' .. record.file
+    state.records[#state.records + 1] = {
+      key = key,
+      file = record.file,
+      section = section.id,
+      section_label = section.label,
+      diff_spec = specs[record.file],
+      start = section_start + record.start,
+      finish = section_start + record.finish,
+    }
+  end
+end
+
+---@param records table[]
+---@param lnum integer
+---@param file string
+---@return table?
+local function record_for_line(records, lnum, file)
+  for _, record in ipairs(records or {}) do
+    if record.file == file and lnum >= record.start and lnum <= record.finish then
+      return record
+    end
+  end
+  return nil
+end
+
+---@param records table[]
+---@return fun(lnum: integer, file: string): table?
+local function metadata_for_records(records)
+  return function(lnum, file)
+    return record_for_line(records, lnum, file)
+  end
+end
+
+---@param review diffs.NormalizedGreview
+---@param deps diffs.ReviewDeps
+---@return string[]?, string?, table?
+local function run_current_state(review, deps)
+  local base_rev, merge_err = merge_base(review.repo_root, review.base, 'HEAD')
+  if not base_rev then
+    return nil, merge_err, nil
+  end
+
+  local lines = {}
+  local state = {
+    records = {},
+    sections = {},
+  }
+
+  local branch, branch_err = branch_lines(review, base_rev)
+  if not branch then
+    return nil, branch_err ~= '' and branch_err or 'git diff failed for Greview Branch section', nil
+  end
+  local branch_rendered = deps.replace_combined_diffs(branch, review.repo_root)
+  local branch_specs = section_specs(branch_rendered, function(file)
+    return diffspec.rev_to_rev(base_rev, 'HEAD', file)
+  end)
+  append_section(lines, {
+    id = 'branch',
+    label = 'Branch',
+    description = review.base .. '...' .. 'HEAD',
+    lines = branch_rendered,
+  }, branch_specs, state)
+
+  local staged, staged_err = worktree_edge_lines(review, true)
+  if not staged then
+    return nil, staged_err ~= '' and staged_err or 'git diff failed for Greview Staged section', nil
+  end
+  local staged_rendered = deps.replace_combined_diffs(staged, review.repo_root)
+  local staged_unmerged = combined_diff_files(staged)
+  local staged_specs = section_specs(staged_rendered, function(file)
+    return staged_unmerged[file] and unmerged_stage_spec(file) or diffspec.head_to_index(file)
+  end)
+  append_section(lines, {
+    id = 'staged',
+    label = 'Staged',
+    description = 'HEAD -> index',
+    lines = staged_rendered,
+  }, staged_specs, state)
+
+  local unstaged, unstaged_err = worktree_edge_lines(review, false)
+  if not unstaged then
+    return nil,
+      unstaged_err ~= '' and unstaged_err or 'git diff failed for Greview Unstaged section',
+      nil
+  end
+  local unstaged_rendered = deps.replace_combined_diffs(unstaged, review.repo_root)
+  local unstaged_unmerged = combined_diff_files(unstaged)
+  local unstaged_specs = section_specs(unstaged_rendered, function(file)
+    return unstaged_unmerged[file] and unmerged_stage_spec(file) or diffspec.index_to_worktree(file)
+  end)
+  append_section(lines, {
+    id = 'unstaged',
+    label = 'Unstaged',
+    description = 'index -> worktree',
+    lines = unstaged_rendered,
+  }, unstaged_specs, state)
+
+  local untracked, untracked_err = untracked_paths(review)
+  if not untracked then
+    return nil,
+      untracked_err ~= '' and untracked_err or 'git ls-files failed for Greview Untracked section',
+      nil
+  end
+  local untracked_lines = {}
+  local untracked_specs = {}
+  for _, path in ipairs(untracked) do
+    if is_untracked_binary(review.repo_root, path) then
+      dbg('skipping binary untracked %s', path)
+    else
+      local spec = diffspec.index_to_worktree(path)
+      local rendered, render_err = render.file(spec, review.repo_root)
+      if rendered then
+        for _, line in ipairs(rendered) do
+          untracked_lines[#untracked_lines + 1] = line
+        end
+        untracked_specs[path] = spec
+      elseif render_err then
+        dbg('skipping untracked %s: %s', path, render_err)
+      end
+    end
+  end
+  append_section(lines, {
+    id = 'untracked',
+    label = 'Untracked',
+    description = 'empty -> worktree',
+    lines = untracked_lines,
+  }, untracked_specs, state)
+
+  return lines,
+    nil,
+    {
+      metadata_for_line = metadata_for_records(state.records),
+      sections = state.sections,
+      store_hunks = true,
+    }
+end
+
 ---@param review_spec diffs.GreviewSpec?
 ---@param repo_root string
 ---@param path string
+---@param selection? diffs.GeneratedFileSelection
 ---@return diffs.DiffSpec?, diffs.NormalizedGreview?, string?
-function M.diff_spec_for_file(review_spec, repo_root, path)
+function M.diff_spec_for_file(review_spec, repo_root, path, selection)
   if type(path) ~= 'string' or path == '' then
     return nil, nil, 'missing review file path'
   end
@@ -257,6 +567,10 @@ function M.diff_spec_for_file(review_spec, repo_root, path)
   local normalized, normalize_err = M.normalize(review_spec, repo_root)
   if not normalized then
     return nil, nil, normalize_err
+  end
+
+  if selection and selection.diff_spec then
+    return diffspec.new(selection.diff_spec), normalized, nil
   end
 
   if not normalized.target then
@@ -358,6 +672,18 @@ function M.run(review, deps)
   return deps.replace_combined_diffs(result, review.repo_root), nil
 end
 
+---@param review diffs.NormalizedGreview
+---@param deps diffs.ReviewDeps
+---@return string[]?, string?, table?
+function M.render(review, deps)
+  if not review.target then
+    return run_current_state(review, deps)
+  end
+
+  local result, err = M.run(review, deps)
+  return result, err, nil
+end
+
 ---@param spec? diffs.GreviewSpec
 ---@param deps diffs.ReviewDeps
 ---@return integer?
@@ -374,7 +700,7 @@ function M.greview(spec, deps)
     pcall(vim.api.nvim_buf_delete, existing_buf, { force = true })
   end
 
-  local result, diff_err = M.run(review, deps)
+  local result, diff_err, list_opts = M.render(review, deps)
   if not result then
     notify(diff_err, vim.log.levels.ERROR)
     return nil
@@ -409,6 +735,9 @@ function M.greview(spec, deps)
   lists.set_for_unified_buffer(diff_buf, result, {
     title = 'review: ' .. review.display,
     loclist_title = 'review hunks: ' .. review.display,
+    metadata_for_line = list_opts and list_opts.metadata_for_line,
+    sections = list_opts and list_opts.sections,
+    store_hunks = list_opts and list_opts.store_hunks,
   })
 
   deps.attach_generated_diff_buffer(diff_buf)
@@ -434,19 +763,19 @@ end
 ---@param review_spec diffs.GreviewSpec?
 ---@param repo_root string
 ---@param deps diffs.ReviewDeps
----@return string[]?, string?
+---@return string[]?, string?, table?
 local function reload_spec(review_spec, repo_root, deps)
   local normalized, normalize_err = M.normalize(review_spec, repo_root)
   if not normalized then
-    return nil, normalize_err
+    return nil, normalize_err, nil
   end
 
-  return M.run(normalized, deps)
+  return M.render(normalized, deps)
 end
 
 ---@param source diffs.GeneratedBufferSource
 ---@param deps diffs.ReviewDeps
----@return string[]?, string?
+---@return string[]?, string?, table?
 function M.reload_source(source, deps)
   return reload_spec(source.review, source.repo_root, deps)
 end
@@ -455,7 +784,7 @@ end
 ---@param repo_root string
 ---@param path string
 ---@param deps diffs.ReviewDeps
----@return string[]?, string?
+---@return string[]?, string?, table?
 function M.reload(bufnr, repo_root, path, deps)
   local stored_base = get_buf_var(bufnr, 'diffs_review_base')
   local stored_target = get_buf_var(bufnr, 'diffs_review_target')

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -191,6 +191,44 @@ local function create_review_repo(opts)
   }
 end
 
+local function create_current_state_review_repo()
+  local repo_root = vim.fn.tempname()
+  vim.fn.mkdir(repo_root, 'p')
+  test_repos[#test_repos + 1] = repo_root
+
+  vim.fn.systemlist({ 'git', 'init', '-q', repo_root })
+  assert.are.equal(0, vim.v.shell_error)
+  git_cmd(repo_root, { 'config', 'user.email', 'test@example.com' })
+  git_cmd(repo_root, { 'config', 'user.name', 'Test' })
+
+  write_repo_file(repo_root, 'lua/branch.lua', { 'branch base' })
+  write_repo_file(repo_root, 'lua/dup.lua', { 'dup base' })
+  write_repo_file(repo_root, 'lua/staged.lua', { 'staged base' })
+  write_repo_file(repo_root, 'lua/unstaged.lua', { 'unstaged base' })
+  git_cmd(repo_root, { 'add', 'lua' })
+  git_cmd(repo_root, { 'commit', '-qm', 'base' })
+  local base = git_cmd(repo_root, { 'rev-parse', 'HEAD' })[1]
+
+  git_cmd(repo_root, { 'checkout', '-qb', 'topic' })
+  write_repo_file(repo_root, 'lua/branch.lua', { 'branch head' })
+  write_repo_file(repo_root, 'lua/dup.lua', { 'dup head' })
+  git_cmd(repo_root, { 'add', 'lua/branch.lua', 'lua/dup.lua' })
+  git_cmd(repo_root, { 'commit', '-qm', 'branch changes' })
+
+  write_repo_file(repo_root, 'lua/dup.lua', { 'dup staged' })
+  write_repo_file(repo_root, 'lua/staged.lua', { 'staged changed' })
+  git_cmd(repo_root, { 'add', 'lua/dup.lua', 'lua/staged.lua' })
+
+  write_repo_file(repo_root, 'lua/dup.lua', { 'dup unstaged' })
+  write_repo_file(repo_root, 'lua/unstaged.lua', { 'unstaged changed' })
+  write_repo_file(repo_root, 'lua/new.lua', { 'new file' })
+
+  return {
+    repo_root = repo_root,
+    base = base,
+  }
+end
+
 local function create_mode_only_review_repo()
   local repo_root = vim.fn.tempname()
   vim.fn.mkdir(repo_root, 'p')
@@ -323,6 +361,18 @@ end
 local function find_buffer_line(bufnr, text)
   for lnum, line in ipairs(buffer_lines(bufnr)) do
     if line:find(text, 1, true) then
+      return lnum
+    end
+  end
+  return nil
+end
+
+local function find_buffer_line_after(bufnr, after_text, text)
+  local start = find_buffer_line(bufnr, after_text)
+  assert.is_not_nil(start)
+  local lines = buffer_lines(bufnr)
+  for lnum = start + 1, #lines do
+    if lines[lnum]:find(text, 1, true) then
       return lnum
     end
   end
@@ -2259,6 +2309,213 @@ describe('commands', function()
       assert.are.equal('merge-base', vim.api.nvim_buf_get_var(bufnr, 'diffs_review_mode'))
     end)
 
+    it('renders current-state reviews as stacked sections', function()
+      local repo = create_current_state_review_repo()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = repo.base,
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+
+      local text = buffer_text(bufnr)
+      assert.is_true(text:find('# Branch:', 1, true) ~= nil)
+      assert.is_true(text:find('# Staged:', 1, true) ~= nil)
+      assert.is_true(text:find('# Unstaged:', 1, true) ~= nil)
+      assert.is_true(text:find('# Untracked:', 1, true) ~= nil)
+      assert.is_true(text:find('+branch head', 1, true) ~= nil)
+      assert.is_true(text:find('+dup staged', 1, true) ~= nil)
+      assert.is_true(text:find('+dup unstaged', 1, true) ~= nil)
+      assert.is_true(text:find('+new file', 1, true) ~= nil)
+
+      local qf = quickfix_items()
+      assert.are.equal(7, #qf)
+      assert.is_true(qf[1].text:find('[Branch] lua/branch.lua', 1, true) ~= nil)
+      assert.is_true(qf[2].text:find('[Branch] lua/dup.lua', 1, true) ~= nil)
+      assert.is_true(qf[3].text:find('[Staged] lua/dup.lua', 1, true) ~= nil)
+      assert.is_true(qf[4].text:find('[Staged] lua/staged.lua', 1, true) ~= nil)
+      assert.is_true(qf[5].text:find('[Unstaged] lua/dup.lua', 1, true) ~= nil)
+      assert.is_true(qf[6].text:find('[Unstaged] lua/unstaged.lua', 1, true) ~= nil)
+      assert.is_true(qf[7].text:find('[Untracked] lua/new.lua', 1, true) ~= nil)
+
+      assert.are.equal('branch:lua/dup.lua', qf[2].user_data.diffs.key)
+      assert.are.equal('staged:lua/dup.lua', qf[3].user_data.diffs.key)
+      assert.are.equal('unstaged:lua/dup.lua', qf[5].user_data.diffs.key)
+    end)
+
+    it('routes duplicate current-state review paths by section for split projection', function()
+      local repo = create_current_state_review_repo()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = repo.base,
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+      local review_win = vim.api.nvim_get_current_win()
+
+      local branch_line =
+        find_buffer_line_after(bufnr, '# Branch:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
+      assert.is_not_nil(branch_line)
+      vim.api.nvim_win_set_cursor(review_win, { branch_line, 0 })
+      local branch_opened = commands.greview_split({ bufnr = bufnr })
+      assert.is_not_nil(branch_opened)
+      table.insert(test_buffers, branch_opened.left_buf)
+      table.insert(test_buffers, branch_opened.right_buf)
+      assert.are.same(
+        diffspec.rev_to_rev(repo.base, 'HEAD', 'lua/dup.lua'),
+        vim.api.nvim_buf_get_var(branch_opened.right_buf, 'diffs_spec')
+      )
+
+      vim.api.nvim_set_current_win(review_win)
+      local staged_line =
+        find_buffer_line_after(bufnr, '# Staged:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
+      assert.is_not_nil(staged_line)
+      vim.api.nvim_win_set_cursor(review_win, { staged_line, 0 })
+      local staged_opened = commands.greview_split({ bufnr = bufnr })
+      assert.is_not_nil(staged_opened)
+      table.insert(test_buffers, staged_opened.left_buf)
+      table.insert(test_buffers, staged_opened.right_buf)
+      assert.are.same(
+        diffspec.head_to_index('lua/dup.lua'),
+        vim.api.nvim_buf_get_var(staged_opened.right_buf, 'diffs_spec')
+      )
+
+      vim.api.nvim_set_current_win(review_win)
+      local unstaged_line =
+        find_buffer_line_after(bufnr, '# Unstaged:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
+      assert.is_not_nil(unstaged_line)
+      vim.api.nvim_win_set_cursor(review_win, { unstaged_line, 0 })
+      local unstaged_opened = commands.greview_split({ bufnr = bufnr })
+      assert.is_not_nil(unstaged_opened)
+      table.insert(test_buffers, unstaged_opened.left_buf)
+      table.insert(test_buffers, unstaged_opened.right_buf)
+      assert.are.same(
+        diffspec.index_to_worktree('lua/dup.lua'),
+        vim.api.nvim_buf_get_var(unstaged_opened.right_buf, 'diffs_spec')
+      )
+    end)
+
+    it('follows duplicate current-state review paths by section identity', function()
+      local repo = create_current_state_review_repo()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = repo.base,
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+      local review_win = vim.api.nvim_get_current_win()
+
+      local branch_line =
+        find_buffer_line_after(bufnr, '# Branch:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
+      assert.is_not_nil(branch_line)
+      vim.api.nvim_win_set_cursor(review_win, { branch_line, 0 })
+      local opened = commands.greview_split({ bufnr = bufnr })
+      assert.is_not_nil(opened)
+      table.insert(test_buffers, opened.left_buf)
+      table.insert(test_buffers, opened.right_buf)
+
+      local staged_line =
+        find_buffer_line_after(bufnr, '# Staged:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
+      assert.is_not_nil(staged_line)
+      vim.api.nvim_set_current_win(review_win)
+      vim.api.nvim_win_set_cursor(review_win, { staged_line, 0 })
+      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
+
+      local followed_right
+      vim.wait(100, function()
+        local ok, right = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_review_split_buf')
+        if not ok or right == opened.right_buf or not vim.api.nvim_buf_is_valid(right) then
+          return false
+        end
+        local spec = vim.api.nvim_buf_get_var(right, 'diffs_spec')
+        if spec.left and spec.left.kind == 'tree' and spec.left.rev == 'HEAD' then
+          followed_right = right
+          return true
+        end
+        return false
+      end)
+
+      assert.is_not_nil(followed_right)
+      table.insert(test_buffers, followed_right)
+      table.insert(test_buffers, vim.api.nvim_buf_get_var(followed_right, 'diffs_split_peer'))
+      assert.are.same(
+        diffspec.head_to_index('lua/dup.lua'),
+        vim.api.nvim_buf_get_var(followed_right, 'diffs_spec')
+      )
+    end)
+
+    it('skips binary untracked files in current-state reviews', function()
+      local repo_root = create_repo()
+      write_repo_file(repo_root, 'lua/new.lua', { 'new text' })
+      write_binary_file(repo_root .. '/bin.dat', 'binary\\000new')
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = 'HEAD',
+        repo = repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+
+      local text = buffer_text(bufnr)
+      assert.is_true(text:find('# Untracked:', 1, true) ~= nil)
+      assert.is_true(text:find('diff --git a/lua/new.lua b/lua/new.lua', 1, true) ~= nil)
+      assert.is_true(text:find('+new text', 1, true) ~= nil)
+      assert.is_false(text:find('bin.dat', 1, true) ~= nil)
+
+      local qf = quickfix_items()
+      assert.are.equal(1, #qf)
+      assert.is_true(qf[1].text:find('[Untracked] lua/new.lua', 1, true) ~= nil)
+    end)
+
+    it('routes current-state conflict reviews to read-only unmerged stage specs', function()
+      local repo_root = create_conflicted_repo()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview({
+        base = 'HEAD',
+        repo = repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+
+      local text = buffer_text(bufnr)
+      assert.is_false(text:find('# Staged:', 1, true) ~= nil)
+      assert.is_false(text:find('* Unmerged path', 1, true) ~= nil)
+      assert.is_true(text:find('# Unstaged:', 1, true) ~= nil)
+      assert.is_true(text:find('diff --git a/file.txt b/file.txt', 1, true) ~= nil)
+      assert.is_true(text:find('-line 2 theirs', 1, true) ~= nil)
+      assert.is_true(text:find('+line 2 ours', 1, true) ~= nil)
+      assert.is_false(helpers.has_keymap(bufnr, 'do'))
+      assert.is_false(helpers.has_keymap(bufnr, 'dp'))
+
+      local qf = quickfix_items()
+      assert.are.equal(1, #qf)
+      assert.is_true(qf[1].text:find('[Unstaged] file.txt', 1, true) ~= nil)
+      assert.are.equal('unstaged', qf[1].user_data.diffs.section)
+      assert.are.same(diffspec.rev_to_rev(':2', ':3', 'file.txt'), qf[1].user_data.diffs.diff_spec)
+
+      local header_line = find_buffer_line(bufnr, '# Unstaged:')
+      assert.is_not_nil(header_line)
+      vim.api.nvim_win_set_cursor(0, { header_line, 0 })
+      local opened = commands.greview_split({ bufnr = bufnr })
+      assert.is_not_nil(opened)
+      table.insert(test_buffers, opened.left_buf)
+      table.insert(test_buffers, opened.right_buf)
+      assert.are.same(
+        diffspec.rev_to_rev(':2', ':3', 'file.txt'),
+        vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_spec')
+      )
+      assert.is_true(buffer_text(opened.left_buf):find('line 2 theirs', 1, true) ~= nil)
+      assert.is_true(buffer_text(opened.right_buf):find('line 2 ours', 1, true) ~= nil)
+    end)
+
     it(
       'uses quickfix as the review file index and loclist as the active file hunk index',
       function()
@@ -2801,7 +3058,7 @@ describe('commands', function()
       )
     end)
 
-    it('opens a base-only review file as base tree to worktree', function()
+    it('opens a base-only current-state review file as the selected section edge', function()
       local repo = create_review_repo({ commit_target = false })
       mock_runtime_attach(function() end)
 
@@ -2822,7 +3079,7 @@ describe('commands', function()
       table.insert(test_buffers, opened.right_buf)
 
       assert.are.same(
-        diffspec.rev_to_worktree(repo.base, 'lua/two.lua'),
+        diffspec.index_to_worktree('lua/two.lua'),
         vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_spec')
       )
     end)

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -699,17 +699,23 @@ describe('read_buffer', function()
       assert.is_truthy(vim.tbl_contains(captured_cmd, '--cached'))
     end)
 
-    it('runs git diff with base ref for review label', function()
-      local captured_cmd
+    it('reloads base-only review labels as current-state stacked sections', function()
+      local captured_cmds = {}
       mock_systemlist(function(cmd)
         if cmd[4] == 'rev-parse' then
           return { 'commit' }
         end
+        if cmd[4] == 'merge-base' then
+          return { 'base-sha' }
+        end
         if cmd[4] ~= 'diff' then
           return {}
         end
-        captured_cmd = cmd
-        return review_diff_lines()
+        captured_cmds[#captured_cmds + 1] = cmd
+        if cmd[7] == 'base-sha' then
+          return review_diff_lines()
+        end
+        return {}
       end)
 
       local bufnr = create_diffs_buffer('diffs://review:origin/main', {
@@ -717,14 +723,21 @@ describe('read_buffer', function()
       })
       commands.read_buffer(bufnr)
 
-      assert.is_not_nil(captured_cmd)
-      assert.are.equal('git', captured_cmd[1])
-      assert.are.equal('/home/test/repo', captured_cmd[3])
-      assert.are.equal('diff', captured_cmd[4])
-      assert.are.equal('origin/main', captured_cmd[#captured_cmd])
+      assert.are.equal(3, #captured_cmds)
+      assert.are.same({
+        'git',
+        '-C',
+        '/home/test/repo',
+        'diff',
+        '--no-ext-diff',
+        '--no-color',
+        'base-sha',
+        'HEAD',
+      }, captured_cmds[1])
 
       local lines = buffer_lines(bufnr)
-      assert.are.equal('diff --git a/file.lua b/file.lua', lines[1])
+      assert.are.equal('# Branch: origin/main...HEAD', lines[1])
+      assert.are.equal('diff --git a/file.lua b/file.lua', lines[2])
     end)
 
     it('runs merge-base review reload from stored review vars', function()


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #310.

## Solution

The solution renders base-only `:Greview` as stacked Branch, Staged, Unstaged, and Untracked sections; preserves section-aware quickfix, loclist, split, follow, and per-hunk action metadata; and handles current-state conflict and binary-untracked edge cases without falling back to unsafe/stageable views.
