### PR TITLE
Add Greview layout command surface

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -417,21 +417,21 @@ syntax highlighting warning.
 ==============================================================================
 COMMANDS                                                 *diffs.nvim-commands*
 
-Generated workspace boundaries: ~
+diffs.nvim view boundaries: ~
 
 diffs.nvim only replaces layout for buffers it creates and can model as
-explicit endpoints. Today that means generated |:Gdiff| buffers, |:Greview|
+explicit endpoints. Today that means `diffs://` |:Gdiff| buffers, |:Greview|
 buffers, experimental split views, and plugin-owned launches from integrations
-such as Fugitive status maps. Generated commit views and any other future layout
+such as Fugitive status maps. Commit views and any other future layout
 replacements must follow the same rule: first model the source endpoints, then
 own the layout.
 
 Ordinary `git`, `gitcommit`, `diff`, `extra_filetypes`, picker previews, and
 third-party integration buffers remain highlight-only. diffs.nvim may attach
 syntax, backgrounds, and intra-line highlights to those buffers, but it must not
-replace their layout unless the user invoked a generated diffs.nvim view.
+replace their layout unless the user invoked a diffs.nvim-owned view.
 
-:Gdiff [object]                                                       *:Gdiff*
+:Gdiff [++layout=unified|split] [object]                             *:Gdiff*
     Open a unified diff of the current file against a Fugitive-style object.
     Displays in a horizontal split below the current window.
 
@@ -439,20 +439,20 @@ replace their layout unless the user invoked a generated diffs.nvim view.
     code language, plus diff header highlighting for `diff --git`, `---`,
     `+++`, and `@@` lines.
 
-    Generated `diffs://` unified buffers include old and new line-number rails
-    before the unified diff text. A blank rail cell means that line does not
-    exist on that side of the diff.
+    `diffs://` unified buffers include old and new line-number columns before
+    the unified diff text. A blank cell means that line does not exist on that
+    side of the diff.
 
     In the default unified layout, if a `diffs://` window already exists in the
     current tabpage, the new diff replaces its buffer instead of creating
     another split.
 
-    This is a generated diff workspace, not Fugitive `:Gdiffsplit` parity.
+    This is a diffs.nvim-owned view, not Fugitive `:Gdiffsplit` parity.
     diffs.nvim owns the `diffs://` buffers, hunk metadata, and plugin actions.
     The default unified layout does not enter native Vim `&diff` mode, open
     writable Fugitive object buffers, or emulate `:Gdiffsplit` window lifecycle.
     The experimental `++layout=split` variant uses native `&diff` alignment for
-    generated old/new endpoint windows, but disables diff folds as layout.
+    old/new endpoint windows, but disables diff folds as layout.
 
     Plain direct |:Gdiff| from a worktree file compares the index to the
     worktree and shows only unstaged changes. Staged-only changes report no
@@ -465,10 +465,11 @@ replace their layout unless the user invoked a generated diffs.nvim view.
     object argument and through Fugitive status-row context.
 
     Parameters: ~
+        ++layout=unified (optional) Open the default unified `diffs://` view.
+        ++layout=split (optional) Open the current single-file comparison as
+                    experimental paired old/new endpoint windows.
         ++novertical (optional) Force a horizontal split. Useful with |:Gvdiff|
                     or command wrappers.
-        ++layout=split (optional) Open the current single-file comparison as
-                    experimental paired old/new generated endpoint windows.
         {object}    (string, optional) Fugitive-style object to diff against.
                     Defaults to the current file in the index.
 
@@ -509,7 +510,7 @@ replace their layout unless the user invoked a generated diffs.nvim view.
                                                  explicit warning.
     Unmerged file     :2: (ours) -> :3:          Plain |:Gdiff|, or an
                       (theirs)                   explicit index object, opens
-                                                 a generated merge diff. Native
+                                                 a merge diff view. Native
                                                  3-way `:Gdiffsplit!` windows
                                                  are not emulated.
     Merge-stage       :1:/:2:/:3: object         Not supported by |:Gdiff|
@@ -520,40 +521,40 @@ replace their layout unless the user invoked a generated diffs.nvim view.
     applying a partial mutation. Mutation maps are capability-scoped: `dp`
     appears only for supported index -> worktree hunks/ranges, and `do`
     appears only for supported tree -> index hunks/ranges. Read-only and
-    unsupported generated buffers do not expose mutation maps.
+    unsupported `diffs://` buffers do not expose mutation maps.
 
-    Native expectations outside this generated-buffer contract, such as
+    Native expectations outside this diffs.nvim-owned buffer contract, such as
     `:Gdiffsplit!`, 3-way `&diff` windows, writable Fugitive object buffers,
     and `dq`, are not emulated.
 
-Generated paired-window contract: ~             *diffs.nvim-paired-windows*
+Paired-window contract: ~                       *diffs.nvim-paired-windows*
 
-    The `++layout=split` view is the generated split rendering of a single
+    The `++layout=split` view is the split rendering of a single
     |:Gdiff| file comparison. It is not a parser for arbitrary diff text and it
     must only apply when diffs.nvim owns explicit endpoint metadata.
 
-    The contract below describes the target behavior for generated paired
+    The contract below describes the target behavior for paired
     windows. It is an implementation target for the experimental split view, not
     a claim that every current release implements each item.
 
     Model: ~
         - The left window displays the old endpoint and the right window
           displays the new endpoint.
-        - Both buffers are generated `diffs://` endpoint buffers with stored
+        - Both buffers are `diffs://` endpoint buffers with stored
           repo root, DiffSpec, endpoint side, and source path metadata.
         - Both endpoint buffers are read-only views. Edits happen in real source
-          buffers opened from the generated view.
+          buffers opened from the diffs.nvim view.
         - Native `&diff` alignment may provide filler rows, but diff folds are
-          not the layout mechanism and should be disabled for generated split
+          not the layout mechanism and should be disabled for split
           windows.
         - Window-local user settings such as statusline, statuscolumn, number,
-          and cursorline should be preserved unless the generated view
+          and cursorline should be preserved unless the diffs.nvim view
           explicitly owns and documents a local display choice.
 
     Lifecycle: ~
         - Opening a split view creates or reuses a coherent pair. It must not
           leave stale endpoint buffers with duplicate `diffs://` names.
-        - `q` closes the pair, not just the current endpoint. Both generated
+        - `q` closes the pair, not just the current endpoint. Both
           endpoint buffers should be deleted.
         - Manually closing, wiping, or deleting either endpoint should not leave
           an actionable half-pair. The remaining side should be closed or
@@ -575,7 +576,7 @@ Generated paired-window contract: ~             *diffs.nvim-paired-windows*
         - Moving to a hunk should keep the paired windows aligned. If an
           endpoint has no real line for that side of the hunk, land on the
           nearest aligned row rather than inventing buffer text.
-        - Wrapping behavior should match unified generated |:Gdiff| hunk
+        - Wrapping behavior should match unified |:Gdiff| hunk
           navigation.
 
     Source opening: ~
@@ -590,7 +591,7 @@ Generated paired-window contract: ~             *diffs.nvim-paired-windows*
         - The paired windows should act as one comparison while still allowing
           the cursor to live on either side.
         - Cursor and scroll sync may be best-effort around native diff filler
-          rows, but it must not mutate generated buffers from decoration or
+          rows, but it must not mutate `diffs://` buffers from decoration or
           redraw callbacks.
         - Sync should not require global options or leave unrelated windows
           scroll-bound after the pair closes.
@@ -599,8 +600,8 @@ Generated paired-window contract: ~             *diffs.nvim-paired-windows*
         - Quickfix and location-list targets for split rows are not settled.
           Until that is decided, split |:Gdiff| should not add new qf/loclist
           behavior beyond existing |:Greview| lists.
-        - Direct editing of the right-side generated worktree endpoint is not
-          part of the contract. Generated endpoint buffers remain read-only
+        - Direct editing of the right-side worktree endpoint is not
+          part of the contract. Endpoint buffers remain read-only
           unless a later API explicitly changes that ownership model.
 
 
@@ -610,7 +611,7 @@ Generated paired-window contract: ~             *diffs.nvim-paired-windows*
 :Ghdiff [object]                                                     *:Ghdiff*
     Like |:Gdiff| but explicitly opens in a horizontal split.
 
-:Greview [review-spec]                                              *:Greview*
+:Greview [++layout=unified|split] [review-spec]                    *:Greview*
     Open a unified review of the repository in a horizontal split.
 
     With no arguments, reviews the current repository state against the
@@ -636,7 +637,15 @@ Generated paired-window contract: ~             *diffs.nvim-paired-windows*
     If a `diffs://` window already exists in the current tabpage, the new
     diff replaces its buffer instead of creating another split.
 
+    With `++layout=split`, |:Greview| still opens the full review buffer and
+    quickfix/location-list indexes. It also opens the first changed file in a
+    paired old/new split view. That pair follows later review-buffer, quickfix,
+    and location-list selection until the pair is closed.
+
     Parameters: ~
+        ++layout=unified (optional) Open the default unified review buffer.
+        ++layout=split (optional) Also open a paired old/new split view for
+                       the first changed review file.
         {review-spec}  (string, optional) One of:
                        - empty: review current repo state against the repo
                          default branch
@@ -648,7 +657,9 @@ Generated paired-window contract: ~             *diffs.nvim-paired-windows*
 
     Examples: >vim
         :Greview
+        :Greview ++layout=split
         :Greview origin/main
+        :Greview ++layout=split origin/main
         :Greview origin/main...refs/forge/pr/42
         :Greview origin/main..feature/topic
 <
@@ -687,11 +698,11 @@ Generated paired-window contract: ~             *diffs.nvim-paired-windows*
 
     Utilities: ~
         `require('diffs.commands').greview_split()` opens the currently
-        selected |:Greview| file in a generated split pair. It uses the review
+        selected |:Greview| file in a paired split view. It uses the review
         buffer cursor, quickfix item, or loclist item as the file selection.
-        Once opened, that Greview-owned pair follows review-map file and hunk
+        Once opened, that Greview-owned pair follows review-buffer file and hunk
         selection until the pair is closed. The review quickfix list remains
-        the authoritative file map.
+        the authoritative file list.
 
         `require('diffs.commands').review_file_at_line(bufnr, lnum)` returns
         the filename at a given line in a review buffer by walking backwards
@@ -710,8 +721,8 @@ MAPPINGS                                                 *diffs.nvim-mappings*
 
                                                 *<Plug>(diffs-gdiff-open-source)*
 <Plug>(diffs-gdiff-open-source)
-                        Open the real worktree file at the current generated
-                        |:Gdiff| hunk location. Generated buffers map this to
+                        Open the real worktree file at the current |:Gdiff|
+                        hunk location. `diffs://` buffers map this to
                         <CR> by default. Map this plug key yourself if you want
                         another alias: >lua
                             vim.keymap.set('n', 'go',
@@ -721,9 +732,9 @@ MAPPINGS                                                 *diffs.nvim-mappings*
                                              *<Plug>(diffs-greview-open-split)*
 <Plug>(diffs-greview-open-split)
                         Open the currently selected |:Greview| file in a
-                        generated split pair. The review buffer remains the
+                        paired split view. The review buffer remains the
                         full-repo map; this action opens one file pair for
-                        focused inspection and follows later review-map
+                        focused inspection and follows later review-buffer
                         selections until that pair is closed.
 
 Example configuration: >lua
@@ -796,12 +807,12 @@ Diff buffer mappings: ~
                                                                 *diffs.nvim-q*
     q               Close the diff window. Available in all `diffs://`
                     buffers created by |:Gdiff|, |:Gvdiff|, |:Ghdiff|,
-                    or the fugitive status keymaps. In generated paired split
+                    or the fugitive status keymaps. In paired split
                     views, close the pair; see |diffs.nvim-paired-windows|.
-    ]c              Jump to the next hunk boundary in unified generated |:Gdiff|
+    ]c              Jump to the next hunk boundary in unified |:Gdiff|
                     buffers.
-    [c              Jump to the previous hunk boundary in unified generated
-                    |:Gdiff| buffers.
+    [c              Jump to the previous hunk boundary in unified |:Gdiff|
+                    buffers.
     <CR>            Open the real worktree file at the current |:Gdiff| hunk
                     location when the current endpoint row is worktree-backed.
     dp              In Normal mode, stage the current whole hunk when the
@@ -849,7 +860,7 @@ and intra-line diffs. |:Gdiff| opens a unified diff against any revision (see
 Fugitive status keymaps: ~
 
 When inside a `:Git` status buffer, diffs.nvim provides keymaps to open
-generated unified diffs for files or entire sections. These keymaps reuse
+unified `diffs://` views for files or entire sections. These keymaps reuse
 Fugitive status context for endpoint selection; they do not call
 `:Gdiffsplit` or open native Vim diff windows.
 
@@ -881,8 +892,8 @@ no changes. Untracked section headers show a warning since there is no
 meaningful diff.
 
 This status-row behavior is intentionally narrower than Fugitive `:Gdiffsplit`.
-It preserves the useful edge selection model while keeping generated
-`diffs://` buffers read-only, explicit, and owned by diffs.nvim.
+It preserves the useful edge selection model while keeping `diffs://` buffers
+read-only, explicit, and owned by diffs.nvim.
 
 Configuration: ~
                                                    *diffs.nvim.FugitiveConfig*

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -628,6 +628,174 @@ function M.review_file_at_line(buf, lnum)
   return review.file_at_line(buf, lnum)
 end
 
+local layout_options = {
+  '++layout=unified',
+  '++layout=split',
+}
+
+local gdiff_objects = {
+  ':',
+  ':%',
+  ':0:%',
+  '@:%',
+}
+
+local command_names = {
+  Gdiff = true,
+  Gvdiff = true,
+  Ghdiff = true,
+  Greview = true,
+}
+
+---@param value string
+---@param prefix string
+---@return boolean
+local function starts_with(value, prefix)
+  return value:find(prefix, 1, true) == 1
+end
+
+---@param candidates string[]
+---@param arglead string
+---@return string[]
+local function prefix_matches(candidates, arglead)
+  local matches = {}
+  for _, candidate in ipairs(candidates) do
+    if starts_with(candidate, arglead) then
+      matches[#matches + 1] = candidate
+    end
+  end
+  return matches
+end
+
+---@param arglead string
+---@return string[]
+local function complete_gdiff_object(arglead)
+  local matches = prefix_matches(gdiff_objects, arglead)
+  for _, ref in ipairs(review.complete(arglead)) do
+    if not ref:find('..', 1, true) then
+      matches[#matches + 1] = ref
+    end
+  end
+  return matches
+end
+
+---@param arglead string
+---@param cmdline? string
+---@param cursorpos? integer
+---@return { has_layout: boolean, has_value: boolean }
+local function completion_context(arglead, cmdline, cursorpos)
+  local before = cmdline or ''
+  if type(cursorpos) == 'number' and cursorpos > 0 then
+    before = before:sub(1, cursorpos)
+  end
+  if arglead ~= '' and before:sub(-#arglead) == arglead then
+    before = before:sub(1, #before - #arglead)
+  end
+
+  local tokens = vim.split(vim.trim(before), '%s+', { trimempty = true })
+  local command_index = 0
+  for i = #tokens, 1, -1 do
+    if command_names[tokens[i]] then
+      command_index = i
+      break
+    end
+  end
+  if command_index == 0 and #tokens > 0 then
+    command_index = 1
+  end
+
+  local has_layout = false
+  local has_value = false
+  for i = command_index + 1, #tokens do
+    local token = tokens[i]
+    if token:match('^%+%+layout=') then
+      has_layout = true
+    elseif not token:match('^%+%+') then
+      has_value = true
+    end
+  end
+  return {
+    has_layout = has_layout,
+    has_value = has_value,
+  }
+end
+
+---@param arglead string
+---@param cmdline? string
+---@param cursorpos? integer
+---@return string[]
+local function complete_gdiff_command(arglead, cmdline, cursorpos)
+  local context = completion_context(arglead, cmdline, cursorpos)
+  if context.has_value then
+    return {}
+  end
+  if arglead:match('^%+%+') then
+    if context.has_layout then
+      return {}
+    end
+    return prefix_matches(layout_options, arglead)
+  end
+  local matches = {}
+  if arglead == '' and not context.has_layout then
+    vim.list_extend(matches, layout_options)
+  end
+  vim.list_extend(matches, complete_gdiff_object(arglead))
+  return matches
+end
+
+---@param arglead string
+---@param cmdline? string
+---@param cursorpos? integer
+---@return string[]
+local function complete_gdiff_split_command(arglead, cmdline, cursorpos)
+  local context = completion_context(arglead, cmdline, cursorpos)
+  if context.has_value or arglead:match('^%+%+') then
+    return {}
+  end
+  return complete_gdiff_object(arglead)
+end
+
+---@param arglead string
+---@param cmdline? string
+---@param cursorpos? integer
+---@return string[]
+local function complete_greview_command(arglead, cmdline, cursorpos)
+  local context = completion_context(arglead, cmdline, cursorpos)
+  if context.has_value then
+    return {}
+  end
+  if arglead:match('^%+%+') then
+    local matches = {}
+    if not context.has_layout then
+      vim.list_extend(matches, prefix_matches(layout_options, arglead))
+    end
+    vim.list_extend(matches, review.complete(arglead))
+    return matches
+  end
+  local matches = {}
+  if arglead == '' and not context.has_layout then
+    vim.list_extend(matches, layout_options)
+  end
+  vim.list_extend(matches, review.complete(arglead))
+  return matches
+end
+
+---@param args? string
+---@return integer?
+function M.greview_command(args)
+  local parsed, err = review.parse_command_args(args)
+  if not parsed then
+    notify(err, vim.log.levels.ERROR)
+    return nil
+  end
+
+  local bufnr = M.greview(parsed.spec)
+  if bufnr and parsed.layout == 'split' then
+    M.greview_split({ bufnr = bufnr, lnum = 1 })
+  end
+  return bufnr
+end
+
 ---@param repo_root string
 ---@param path string
 ---@return string?
@@ -1434,6 +1602,7 @@ function M.setup()
     M.gdiff(opts.args ~= '' and opts.args or nil, false)
   end, {
     nargs = '*',
+    complete = complete_gdiff_command,
     desc = 'Show unified diff against a Fugitive object',
   })
 
@@ -1441,6 +1610,7 @@ function M.setup()
     M.gdiff(opts.args ~= '' and opts.args or nil, true)
   end, {
     nargs = '*',
+    complete = complete_gdiff_split_command,
     desc = 'Show unified diff against a Fugitive object in vertical split',
   })
 
@@ -1448,27 +1618,28 @@ function M.setup()
     M.gdiff(opts.args ~= '' and opts.args or nil, false)
   end, {
     nargs = '*',
+    complete = complete_gdiff_split_command,
     desc = 'Show unified diff against a Fugitive object in horizontal split',
   })
 
   vim.api.nvim_create_user_command('Greview', function(opts)
-    local spec, err = review.parse_arg(opts.args ~= '' and opts.args or nil)
-    if not spec then
-      notify(err, vim.log.levels.ERROR)
-      return
-    end
-    M.greview(spec)
+    M.greview_command(opts.args ~= '' and opts.args or nil)
   end, {
-    nargs = '?',
-    complete = review.complete,
+    nargs = '*',
+    complete = complete_greview_command,
     desc = 'Review the repo against the default branch or a git review spec',
   })
 end
 
 M._test = {
+  complete_gdiff = complete_gdiff_command,
+  complete_gdiff_object = complete_gdiff_object,
+  complete_gdiff_split = complete_gdiff_split_command,
   complete_greview = review.complete,
+  complete_greview_command = complete_greview_command,
   gdiff_buffer_label = gdiff_buffer_label,
   normalize_greview = review.normalize,
+  parse_greview_command = review.parse_command_args,
   parse_review_arg = review.parse_arg,
 }
 

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -16,6 +16,10 @@ local notify = log.notify
 ---@field mode? string
 ---@field vertical? boolean
 
+---@class diffs.GreviewCommandParseResult
+---@field spec diffs.GreviewSpec
+---@field layout "unified"|"split"
+
 ---@class diffs.NormalizedGreview
 ---@field base string
 ---@field target string?
@@ -40,6 +44,16 @@ local function get_buf_var(bufnr, name)
     return value
   end
   return nil
+end
+
+---@param args? string
+---@return string[]
+local function split_args(args)
+  args = vim.trim(args or '')
+  if args == '' then
+    return {}
+  end
+  return vim.split(args, '%s+', { trimempty = true })
 end
 
 ---@param repo? string
@@ -154,6 +168,36 @@ function M.parse_arg(arg)
   end
 
   return { base = arg }, nil
+end
+
+---@param args? string
+---@return diffs.GreviewCommandParseResult?, string?
+function M.parse_command_args(args)
+  local tokens = split_args(args)
+  local layout = 'unified'
+
+  while tokens[1] and tokens[1]:match('^%+%+layout=') do
+    local value = tokens[1]:match('^%+%+layout=(.+)$')
+    if value ~= 'unified' and value ~= 'split' then
+      return nil, 'unsupported layout ' .. tostring(value)
+    end
+    layout = value
+    table.remove(tokens, 1)
+  end
+
+  if #tokens > 1 then
+    return nil, 'expected at most one review spec'
+  end
+
+  local spec, err = M.parse_arg(tokens[1])
+  if not spec then
+    return nil, err
+  end
+
+  return {
+    spec = spec,
+    layout = layout,
+  }, nil
 end
 
 ---@param spec? diffs.GreviewSpec

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -444,6 +444,63 @@ describe('commands', function()
     end)
   end)
 
+  describe('command completion', function()
+    it('completes Gdiff layout options and Fugitive-style objects', function()
+      mock_repo_root(function()
+        return '/tmp/repo'
+      end)
+      mock_systemlist(function(cmd)
+        assert.are.same({
+          'git',
+          '-C',
+          '/tmp/repo',
+          'for-each-ref',
+          '--format=%(refname:short)',
+          'refs/heads/',
+          'refs/remotes/',
+          'refs/tags/',
+        }, cmd)
+        return { 'origin/main', 'feature/topic' }
+      end)
+
+      assert.are.same({
+        '++layout=unified',
+        '++layout=split',
+      }, commands._test.complete_gdiff('++l'))
+      assert.are.same({
+        '++layout=unified',
+        '++layout=split',
+        ':',
+        ':%',
+        ':0:%',
+        '@:%',
+        'origin/main',
+        'feature/topic',
+      }, commands._test.complete_gdiff('', 'Gdiff ', #'Gdiff '))
+      assert.are.same({
+        ':',
+        ':%',
+        ':0:%',
+        '@:%',
+        'origin/main',
+        'feature/topic',
+      }, commands._test.complete_gdiff('', 'Gdiff ++layout=split ', #'Gdiff ++layout=split '))
+      assert.are.same({}, commands._test.complete_gdiff('', 'Gdiff HEAD ', #'Gdiff HEAD '))
+      assert.are.same({ ':', ':%', ':0:%' }, commands._test.complete_gdiff(':'))
+      assert.are.same({ ':0:%' }, commands._test.complete_gdiff(':0', 'Gdiff :0', #'Gdiff :0'))
+      assert.are.same(
+        { ':0:%' },
+        commands._test.complete_gdiff(':0', 'vertical Gdiff :0', #'vertical Gdiff :0')
+      )
+      assert.are.same({ '@:%' }, commands._test.complete_gdiff('@'))
+      assert.are.same({ 'origin/main' }, commands._test.complete_gdiff('origin/'))
+    end)
+
+    it('keeps Gvdiff and Ghdiff completion focused on objects', function()
+      assert.are.same({}, commands._test.complete_gdiff_split('++l'))
+    end)
+  end)
+
   describe('unified diff generation', function()
     local old_lines = { 'local M = {}', 'return M' }
     local new_lines = { 'local M = {}', 'local x = 1', 'return M' }
@@ -2072,6 +2129,44 @@ describe('commands', function()
       }, spec)
     end)
 
+    it('parses Greview command layout options', function()
+      local parsed =
+        commands._test.parse_greview_command('++layout=split origin/main...refs/pull/42/head')
+
+      assert.are.same({
+        layout = 'split',
+        spec = {
+          base = 'origin/main',
+          target = 'refs/pull/42/head',
+          mode = 'merge-base',
+        },
+      }, parsed)
+    end)
+
+    it('rejects unsupported Greview command layout options', function()
+      local parsed, err = commands._test.parse_greview_command('++layout=tiled origin/main')
+
+      assert.is_nil(parsed)
+      assert.are.equal('unsupported layout tiled', err)
+    end)
+
+    it('treats non-layout plus-prefixed Greview args as review specs', function()
+      local parsed, err = commands._test.parse_greview_command('++topic')
+
+      assert.is_nil(err)
+      assert.are.same({
+        layout = 'unified',
+        spec = { base = '++topic' },
+      }, parsed)
+    end)
+
+    it('rejects multiple Greview command specs', function()
+      local parsed, err = commands._test.parse_greview_command('origin/main feature/topic')
+
+      assert.is_nil(parsed)
+      assert.are.equal('expected at most one review spec', err)
+    end)
+
     it('normalizes default base inside the resolved repo', function()
       local captured_cmds = {}
       mock_repo_root(function(path)
@@ -2141,6 +2236,73 @@ describe('commands', function()
       local matches = commands._test.complete_greview('origin/main..feature/')
 
       assert.are.same({ 'origin/main..feature/a', 'origin/main..feature/b' }, matches)
+    end)
+
+    it('completes Greview command layout options', function()
+      local matches = commands._test.complete_greview_command('++l')
+
+      assert.are.same({
+        '++layout=unified',
+        '++layout=split',
+      }, matches)
+    end)
+
+    it('completes Greview layout options only before a review spec', function()
+      mock_repo_root(function()
+        return '/tmp/repo'
+      end)
+      mock_systemlist(function()
+        return { 'origin/main', 'feature/topic', '++topic' }
+      end)
+
+      assert.are.same({
+        '++layout=unified',
+        '++layout=split',
+        'origin/main',
+        'feature/topic',
+        '++topic',
+      }, commands._test.complete_greview_command('', 'Greview ', #'Greview '))
+      assert.are.same(
+        {
+          'origin/main',
+          'feature/topic',
+          '++topic',
+        },
+        commands._test.complete_greview_command(
+          '',
+          'Greview ++layout=split ',
+          #'Greview ++layout=split '
+        )
+      )
+      assert.are.same(
+        {},
+        commands._test.complete_greview_command('', 'Greview origin/main ', #'Greview origin/main ')
+      )
+      assert.are.same(
+        { 'origin/main' },
+        commands._test.complete_greview_command('origin/', 'Greview origin/', #'Greview origin/')
+      )
+      assert.are.same(
+        { 'origin/main' },
+        commands._test.complete_greview_command(
+          'origin/',
+          'belowright Greview origin/',
+          #'belowright Greview origin/'
+        )
+      )
+      assert.are.same({
+        '++layout=unified',
+        '++layout=split',
+        '++topic',
+      }, commands._test.complete_greview_command('++', 'Greview ++', #'Greview ++'))
+      assert.are.same(
+        { '++topic' },
+        commands._test.complete_greview_command(
+          '++',
+          'Greview ++layout=split ++',
+          #'Greview ++layout=split ++'
+        )
+      )
     end)
   end)
 
@@ -2343,6 +2505,28 @@ describe('commands', function()
       assert.are.equal('branch:lua/dup.lua', qf[2].user_data.diffs.key)
       assert.are.equal('staged:lua/dup.lua', qf[3].user_data.diffs.key)
       assert.are.equal('unstaged:lua/dup.lua', qf[5].user_data.diffs.key)
+    end)
+
+    it('opens the first review file in a split pair for Greview layout split', function()
+      local repo_root = create_repo()
+      vim.fn.writefile({ 'line 1', 'line 2 changed' }, repo_root .. '/file.txt')
+      vim.cmd.edit(vim.fn.fnameescape(repo_root .. '/file.txt'))
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.greview_command('++layout=split HEAD')
+
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+      local right_buf = vim.api.nvim_buf_get_var(bufnr, 'diffs_review_split_buf')
+      assert.is_true(vim.api.nvim_buf_is_valid(right_buf))
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      assert.is_true(vim.api.nvim_buf_is_valid(left_buf))
+      table.insert(test_buffers, right_buf)
+      table.insert(test_buffers, left_buf)
+      assert.are.same(
+        diffspec.index_to_worktree('file.txt'),
+        vim.api.nvim_buf_get_var(right_buf, 'diffs_spec')
+      )
     end)
 
     it('routes duplicate current-state review paths by section for split projection', function()


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #255.

## Solution

The solution adds `:Greview ++layout=unified|split` parsing and dispatch, with split mode opening the normal review buffer plus the first-file old/new split pair; adds command-line completion for `:Gdiff`, `:Gvdiff`, `:Ghdiff`, and `:Greview`, including layout options, supported objects, refs, Ex modifiers, and plus-prefixed Greview refs; updates command docs to describe `diffs://` views, paired split views, and old/new line-number columns without public `generated`/`rails` wording; and related #313.
