### PR TITLE
fix: initialize generated diff metadata before filetype

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -404,6 +404,10 @@ local function set_generated_diff_buffer_options(bufnr)
   vim.api.nvim_set_option_value('bufhidden', 'delete', { buf = bufnr })
   vim.api.nvim_set_option_value('swapfile', false, { buf = bufnr })
   vim.api.nvim_set_option_value('modifiable', false, { buf = bufnr })
+end
+
+---@param bufnr integer
+local function set_generated_diff_buffer_filetype(bufnr)
   vim.api.nvim_set_option_value('filetype', 'diff', { buf = bufnr })
 end
 
@@ -431,7 +435,6 @@ local function create_generated_diff_buffer(opts)
   local bufnr = vim.api.nvim_create_buf(false, true)
   local display_lines, rail_info = rails.annotate(opts.lines)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, display_lines)
-  set_generated_diff_buffer_options(bufnr)
   vim.api.nvim_buf_set_name(bufnr, opts.name)
   set_diff_rails_var(bufnr, rail_info)
 
@@ -450,6 +453,9 @@ local function create_generated_diff_buffer(opts)
       vim.api.nvim_buf_set_var(bufnr, name, value)
     end
   end
+
+  set_generated_diff_buffer_options(bufnr)
+  set_generated_diff_buffer_filetype(bufnr)
 
   return bufnr
 end
@@ -477,7 +483,6 @@ local function replace_generated_diff_buffer_lines(bufnr, diff_lines, diff_spec)
   local display_lines, rail_info = rails.annotate(diff_lines)
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, display_lines)
-  set_generated_diff_buffer_options(bufnr)
   set_diff_rails_var(bufnr, rail_info)
 
   if diff_spec then
@@ -485,6 +490,9 @@ local function replace_generated_diff_buffer_lines(bufnr, diff_lines, diff_spec)
   else
     clear_diff_hunks_var(bufnr)
   end
+
+  set_generated_diff_buffer_options(bufnr)
+  set_generated_diff_buffer_filetype(bufnr)
 end
 
 ---@param bufnr integer

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -2471,6 +2471,55 @@ describe('commands', function()
       assert.are.equal('merge-base', vim.api.nvim_buf_get_var(bufnr, 'diffs_review_mode'))
     end)
 
+    it('initializes generated review metadata before diff FileType attach', function()
+      local attach_records = {}
+      saved_schedule = vim.schedule
+      vim.schedule = function(callback)
+        callback()
+      end
+
+      local group = vim.api.nvim_create_augroup('DiffsGeneratedReviewFileTypeRegression', {
+        clear = true,
+      })
+      vim.api.nvim_create_autocmd('FileType', {
+        pattern = 'diff',
+        group = group,
+        callback = function(args)
+          runtime.attach(args.buf)
+          local rail_ok, rail_width = pcall(vim.api.nvim_buf_get_var, args.buf, 'diffs_rail_width')
+          local entry = runtime._test.hunk_cache[args.buf]
+          attach_records[#attach_records + 1] = {
+            name = vim.api.nvim_buf_get_name(args.buf),
+            rail_width = rail_ok and rail_width or nil,
+            hunk_count = entry and #entry.hunks or nil,
+          }
+        end,
+      })
+
+      local repo = create_review_repo({ named_refs = true })
+      local ok, bufnr = pcall(function()
+        return commands.greview({
+          base = repo.base,
+          target = repo.target,
+          mode = 'merge-base',
+          repo = repo.repo_root,
+        })
+      end)
+      pcall(vim.api.nvim_del_augroup_by_id, group)
+
+      assert.is_true(ok)
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+
+      local first_attach = attach_records[1]
+      assert.is_not_nil(first_attach)
+      assert.are.equal('diffs://review:review-base...review-topic', first_attach.name)
+      assert.is_number(first_attach.rail_width)
+      assert.is_true(first_attach.rail_width > 0)
+      assert.is_number(first_attach.hunk_count)
+      assert.is_true(first_attach.hunk_count > 0)
+    end)
+
     it('renders current-state reviews as stacked sections', function()
       local repo = create_current_state_review_repo()
       mock_runtime_attach(function() end)


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

## Solution

The solution set generated diff buffer metadata before assigning `filetype=diff`; and keeps generated buffer options intact while preventing early `FileType diff` attach from parsing rail-prefixed lines without `diffs_rail_width`.
