### PR TITLE
feat: add generated diff change bars

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -550,6 +550,10 @@ Paired-window contract: ~                       *diffs.nvim-paired-windows*
         - Window-local user settings such as statusline, statuscolumn, number,
           and cursorline should be preserved unless the diffs.nvim view
           explicitly owns and documents a local display choice.
+        - Split endpoint windows set a one-column local 'signcolumn' while
+          open so changed lines can show the same left-edge change bar used by
+          generated unified views. The previous value is restored when the pair
+          is released.
 
     Lifecycle: ~
         - Opening a split view creates or reuses a coherent pair. It must not
@@ -1264,6 +1268,38 @@ Fugitive unified diff highlights: ~
                                                                *DiffsDeleteNr*
     DiffsDeleteNr       Line number for `-` lines. Foreground from
                         `DiffsDeleteText`, background from `DiffsDelete`.
+
+                                                                 *DiffsRail*
+    DiffsRail           Generated old/new line-number rail and separator.
+                        Foreground follows the plain diff rail text; does not
+                        combine with source syntax captures.
+
+                                                                *DiffsRailNr*
+    DiffsRailNr         Generated old/new line numbers on context lines.
+                        Foreground follows `LineNr`; does not combine with
+                        source syntax captures.
+
+                                                            *DiffsAddRailNr*
+    DiffsAddRailNr      Generated number rail on `+` lines, including the
+                        missing old-side number slot.
+                        Foreground matches `DiffsAddBar` background; does
+                        not combine with source syntax captures.
+
+                                                         *DiffsDeleteRailNr*
+    DiffsDeleteRailNr   Generated number rail on `-` lines, including the
+                        missing new-side number slot.
+                        Foreground matches `DiffsDeleteBar` background; does
+                        not combine with source syntax captures.
+
+                                                                 *DiffsAddBar*
+    DiffsAddBar         Change bar for `+` lines in diffs.nvim-owned views.
+                        Background uses the same color as `DiffsAddNr`
+                        foreground.
+
+                                                              *DiffsDeleteBar*
+    DiffsDeleteBar      Change bar for `-` lines in diffs.nvim-owned views.
+                        Background uses the same color as `DiffsDeleteNr`
+                        foreground.
 
                                                                 *DiffsAddText*
     DiffsAddText        Character-level background for changed characters

--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -2,6 +2,9 @@ local M = {}
 
 local dbg = require('diffs.log').dbg
 local diff = require('diffs.diff')
+local rails = require('diffs.rails')
+
+local generated_change_bar = '▏'
 
 local vim_syntax_cache = {}
 local vim_syntax_cache_size = 0
@@ -716,6 +719,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
     local is_diff_line = has_add or has_del
     local line_hl = is_diff_line and (has_add and 'DiffsAdd' or 'DiffsDelete') or nil
     local number_hl = is_diff_line and (has_add and 'DiffsAddNr' or 'DiffsDeleteNr') or nil
+    local bar_hl = is_diff_line and (has_add and 'DiffsAddBar' or 'DiffsDeleteBar') or nil
 
     local is_marker = false
     if pw > 1 and line_hl and not prefix:find('[^+]') then
@@ -727,16 +731,23 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
     end
 
     if not opts.syntax_only then
-      if opts.hide_prefix then
+      if opts.hide_prefix and (not hunk.rail_width or is_diff_line) then
         local virt_hl = (opts.highlights.background and line_hl) or nil
-        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
-          virt_text = { { string.rep(' ', pw + qw), virt_hl } },
-          virt_text_pos = 'overlay',
-        })
+        local rail_width = hunk.rail_width or 0
+        local hide_width = math.max(0, pw + qw - rail_width)
+        if hide_width > 0 then
+          pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, rail_width, {
+            virt_text = { { string.rep(' ', hide_width), virt_hl } },
+            virt_text_pos = 'overlay',
+          })
+        end
       end
 
       if qw > 0 or pw > 1 then
         local prefix_end = pw + qw
+        if hunk.rail_width and not is_diff_line then
+          prefix_end = hunk.rail_width
+        end
         if raw_len and prefix_end > raw_len then
           prefix_end = raw_len
         end
@@ -745,6 +756,51 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
           hl_group = 'DiffsClear',
           priority = p.clear,
         })
+        if hunk.rail_width and hunk.rail_width > 0 then
+          local rail_end = hunk.rail_width
+          if raw_len and rail_end > raw_len then
+            rail_end = raw_len
+          end
+          pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
+            end_col = rail_end,
+            hl_group = 'DiffsRail',
+            priority = p.syntax,
+          })
+
+          local ranges = rails.ranges(hunk.rail_width)
+          if ranges then
+            pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, ranges.old_start, {
+              end_col = ranges.old_end,
+              hl_group = 'DiffsRailNr',
+              priority = p.syntax + 1,
+            })
+            pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, ranges.new_start, {
+              end_col = ranges.new_end,
+              hl_group = 'DiffsRailNr',
+              priority = p.syntax + 1,
+            })
+          end
+          local rail_nr_start, rail_nr_end, rail_nr_hl
+          if ranges and has_del then
+            rail_nr_start = ranges.old_start
+            rail_nr_end = ranges.new_end
+            rail_nr_hl = 'DiffsDeleteRailNr'
+          elseif ranges and has_add then
+            rail_nr_start = ranges.old_start
+            rail_nr_end = ranges.new_end
+            rail_nr_hl = 'DiffsAddRailNr'
+          end
+          if rail_nr_start and rail_nr_end and rail_nr_hl then
+            if raw_len and rail_nr_end > raw_len then
+              rail_nr_end = raw_len
+            end
+            pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, rail_nr_start, {
+              end_col = rail_nr_end,
+              hl_group = rail_nr_hl,
+              priority = p.syntax + 2,
+            })
+          end
+        end
         for ci = 0, pw - 1 do
           local ch = line:sub(ci + 1, ci + 1)
           if ch == '+' or ch == '-' then
@@ -764,6 +820,20 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
           end_col = 1,
           hl_group = number_hl,
           priority = p.syntax,
+        })
+      end
+
+      if
+        hunk.rail_width
+        and is_diff_line
+        and opts.highlights.background
+        and opts.highlights.gutter
+      then
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
+          virt_text = { { generated_change_bar, bar_hl } },
+          virt_text_pos = 'overlay',
+          hl_mode = 'replace',
+          priority = p.char_bg + 10,
         })
       end
 
@@ -817,7 +887,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
       end
     end
 
-    if line_len > pw and covered_lines[buf_line] then
+    if not hunk.rail_width and line_len > pw and covered_lines[buf_line] then
       pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, pw + qw, {
         end_col = line_len + qw,
         hl_group = 'DiffsClear',

--- a/lua/diffs/rails.lua
+++ b/lua/diffs/rails.lua
@@ -2,9 +2,18 @@ local M = {}
 
 local hunk_model = require('diffs.hunks')
 
+local bar_slot = '  '
+local separator = ' ┃ '
+
 ---@class diffs.RailInfo
 ---@field width integer
 ---@field prefix_width integer
+
+---@class diffs.RailRanges
+---@field old_start integer
+---@field old_end integer
+---@field new_start integer
+---@field new_end integer
 
 ---@param value integer?
 ---@param width integer
@@ -59,15 +68,16 @@ function M.annotate(lines)
   end
 
   local width = math.max(1, #tostring(max_lnum))
-  local prefix_width = width + 1 + width + 3
+  local prefix_width = #bar_slot + width + 1 + width + #separator
   local annotated = {}
 
   for lnum, text in ipairs(lines) do
     local line = by_lnum[lnum]
-    annotated[lnum] = format_lnum(old_lnum(line), width)
+    annotated[lnum] = bar_slot
+      .. format_lnum(old_lnum(line), width)
       .. ' '
       .. format_lnum(new_lnum(line), width)
-      .. ' | '
+      .. separator
       .. text
   end
 
@@ -100,6 +110,31 @@ function M.strip_lines(lines, prefix_width)
     stripped[i] = M.strip(line, prefix_width)
   end
   return stripped
+end
+
+---@param prefix_width integer?
+---@return diffs.RailRanges?
+function M.ranges(prefix_width)
+  if type(prefix_width) ~= 'number' or prefix_width <= 0 then
+    return nil
+  end
+
+  local width = (prefix_width - #bar_slot - 1 - #separator) / 2
+  if width < 1 or width % 1 ~= 0 then
+    return nil
+  end
+
+  local old_start = #bar_slot
+  local old_end = old_start + width
+  local new_start = old_end + 1
+  local new_end = new_start + width
+
+  return {
+    old_start = old_start,
+    old_end = old_end,
+    new_start = new_start,
+    new_end = new_end,
+  }
 end
 
 ---@param bufnr integer

--- a/lua/diffs/runtime/highlight_groups.lua
+++ b/lua/diffs/runtime/highlight_groups.lua
@@ -41,6 +41,7 @@ function M.apply(config, is_default)
   local normal = vim.api.nvim_get_hl(0, { name = 'Normal' })
   local diff_add = vim.api.nvim_get_hl(0, { name = 'DiffAdd' })
   local diff_delete = vim.api.nvim_get_hl(0, { name = 'DiffDelete' })
+  local line_nr = vim.api.nvim_get_hl(0, { name = 'LineNr' })
   local diff_added = resolve_hl('diffAdded')
   local diff_removed = resolve_hl('diffRemoved')
 
@@ -54,6 +55,7 @@ function M.apply(config, is_default)
 
   local dflt = is_default or false
   local normal_fg = normal.fg or (dark and 0xcccccc or 0x333333)
+  local line_nr_fg = line_nr.fg or normal_fg
 
   local alpha = config.highlights.blend_alpha or 0.6
   local blended_add = blend_color(add_bg, bg, alpha)
@@ -65,11 +67,33 @@ function M.apply(config, is_default)
   if not transparent then
     clear_hl.bg = bg
   end
+  local rail_hl = { default = dflt, fg = normal_fg, nocombine = true }
+  if not transparent then
+    rail_hl.bg = bg
+  end
   vim.api.nvim_set_hl(0, 'DiffsClear', clear_hl)
   vim.api.nvim_set_hl(0, 'DiffsAdd', { default = dflt, bg = blended_add })
   vim.api.nvim_set_hl(0, 'DiffsDelete', { default = dflt, bg = blended_del })
   vim.api.nvim_set_hl(0, 'DiffsAddNr', { default = dflt, fg = add_fg, bg = blended_add })
   vim.api.nvim_set_hl(0, 'DiffsDeleteNr', { default = dflt, fg = del_fg, bg = blended_del })
+  vim.api.nvim_set_hl(0, 'DiffsRail', rail_hl)
+  vim.api.nvim_set_hl(
+    0,
+    'DiffsRailNr',
+    { default = dflt, fg = line_nr_fg, bg = bg, nocombine = true }
+  )
+  vim.api.nvim_set_hl(
+    0,
+    'DiffsAddRailNr',
+    { default = dflt, fg = add_fg, bg = blended_add, nocombine = true }
+  )
+  vim.api.nvim_set_hl(
+    0,
+    'DiffsDeleteRailNr',
+    { default = dflt, fg = del_fg, bg = blended_del, nocombine = true }
+  )
+  vim.api.nvim_set_hl(0, 'DiffsAddBar', { default = dflt, fg = add_fg, bg = blended_add })
+  vim.api.nvim_set_hl(0, 'DiffsDeleteBar', { default = dflt, fg = del_fg, bg = blended_del })
   vim.api.nvim_set_hl(0, 'DiffsAddText', { default = dflt, bg = blended_add_text })
   vim.api.nvim_set_hl(0, 'DiffsDeleteText', { default = dflt, bg = blended_del_text })
 

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -20,6 +20,8 @@ local peer_buffers = {}
 ---@type table<integer, table<string, any>>
 local pair_window_options = {}
 local syncing_cursor = false
+local split_bar_ns = vim.api.nvim_create_namespace('diffs_split_change_bar')
+local split_change_bar = '▏'
 
 ---@type fun(bufnr: integer)
 local clear_cursor_sync
@@ -126,6 +128,34 @@ local function set_source_vars(bufnr, source, split_hunks)
 end
 
 ---@param bufnr integer
+---@param source diffs.SplitEndpointSource
+---@param split_hunks? diffs.GdiffHunk[]
+local function set_split_change_bars(bufnr, source, split_hunks)
+  vim.api.nvim_buf_clear_namespace(bufnr, split_bar_ns, 0, -1)
+  for _, hunk in ipairs(split_hunks or {}) do
+    for _, line in ipairs(hunk.lines or {}) do
+      local lnum
+      local hl_group
+      if source.side == 'left' and line.kind == 'delete' then
+        lnum = line.old_lnum
+        hl_group = 'DiffsDeleteBar'
+      elseif source.side == 'right' and line.kind == 'add' then
+        lnum = line.new_lnum
+        hl_group = 'DiffsAddBar'
+      end
+
+      if lnum and lnum >= 1 and lnum <= vim.api.nvim_buf_line_count(bufnr) then
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, split_bar_ns, lnum - 1, 0, {
+          sign_text = split_change_bar,
+          sign_hl_group = hl_group,
+          priority = 210,
+        })
+      end
+    end
+  end
+end
+
+---@param bufnr integer
 ---@param filetype? string
 local function set_buffer_options(bufnr, filetype)
   vim.api.nvim_set_option_value('buftype', 'nowrite', { buf = bufnr })
@@ -209,6 +239,7 @@ local function create_buffer(source, lines, split_hunks)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   vim.api.nvim_buf_set_name(bufnr, buffer_name(source))
   set_source_vars(bufnr, source, split_hunks)
+  set_split_change_bars(bufnr, source, split_hunks)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)
   return bufnr
@@ -234,6 +265,7 @@ local function remember_pair_window_options(win)
     foldmethod = vim.api.nvim_get_option_value('foldmethod', { win = win }),
     foldenable = vim.api.nvim_get_option_value('foldenable', { win = win }),
     foldcolumn = vim.api.nvim_get_option_value('foldcolumn', { win = win }),
+    signcolumn = vim.api.nvim_get_option_value('signcolumn', { win = win }),
   }
 end
 
@@ -241,6 +273,7 @@ end
 local function set_pair_window_options(win)
   vim.api.nvim_set_option_value('scrollbind', true, { win = win })
   vim.api.nvim_set_option_value('cursorbind', true, { win = win })
+  vim.api.nvim_set_option_value('signcolumn', 'yes:1', { win = win })
   disable_diff_folds(win)
 end
 
@@ -365,6 +398,7 @@ local function clear_split_state(bufnr)
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_peer')
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_hunks')
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_side')
+  vim.api.nvim_buf_clear_namespace(bufnr, split_bar_ns, 0, -1)
   if clear_cursor_sync then
     clear_cursor_sync(bufnr)
   end
@@ -639,6 +673,7 @@ local function apply_buffer_lines(bufnr, source, lines, split_hunks)
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   set_source_vars(bufnr, source, split_hunks)
+  set_split_change_bars(bufnr, source, split_hunks)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)
   ensure_pair_cleanup(bufnr)

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -717,9 +717,11 @@ describe('commands', function()
       assert.is_true(table.concat(lines, '\n'):find('+local x = 1', 1, true) ~= nil)
 
       local display_lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
-      assert.are.equal(6, vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_width'))
-      assert.are.equal('    | diff --git a/lua/foo.lua b/lua/foo.lua', display_lines[1])
-      assert.is_true(table.concat(display_lines, '\n'):find('  2 | +local x = 1', 1, true) ~= nil)
+      assert.are.equal(10, vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_width'))
+      assert.are.equal('      ┃ diff --git a/lua/foo.lua b/lua/foo.lua', display_lines[1])
+      assert.is_true(
+        table.concat(display_lines, '\n'):find('    2 ┃ +local x = 1', 1, true) ~= nil
+      )
 
       local qf = quickfix_items()
       assert.are.equal(1, #qf)
@@ -819,6 +821,8 @@ describe('commands', function()
       assert.is_false(vim.api.nvim_get_option_value('modifiable', { buf = right_buf }))
       assert.is_true(vim.api.nvim_get_option_value('diff', { win = left_win }))
       assert.is_true(vim.api.nvim_get_option_value('diff', { win = right_win }))
+      assert.are.equal('yes:1', vim.api.nvim_get_option_value('signcolumn', { win = left_win }))
+      assert.are.equal('yes:1', vim.api.nvim_get_option_value('signcolumn', { win = right_win }))
       assert.are.equal('manual', vim.api.nvim_get_option_value('foldmethod', { win = left_win }))
       assert.are.equal('manual', vim.api.nvim_get_option_value('foldmethod', { win = right_win }))
       assert.is_false(vim.api.nvim_get_option_value('foldenable', { win = left_win }))
@@ -840,6 +844,23 @@ describe('commands', function()
       assert.is_true(helpers.has_keymap(right_buf, '[c'))
       assert.is_false(helpers.has_keymap(right_buf, 'dp'))
       assert.is_false(helpers.has_keymap(right_buf, 'do'))
+
+      local bar_ns = vim.api.nvim_get_namespaces().diffs_split_change_bar
+      local right_bars = vim.api.nvim_buf_get_extmarks(right_buf, bar_ns, 0, -1, {
+        details = true,
+      })
+      local has_added_line_bar = false
+      for _, mark in ipairs(right_bars) do
+        local details = mark[4]
+        if
+          mark[2] == 1
+          and details.sign_hl_group == 'DiffsAddBar'
+          and details.sign_text == '▏ '
+        then
+          has_added_line_bar = true
+        end
+      end
+      assert.is_true(has_added_line_bar)
 
       local qf = quickfix_items()
       assert.are.equal(1, #qf)

--- a/spec/highlight_spec.lua
+++ b/spec/highlight_spec.lua
@@ -612,6 +612,208 @@ describe('highlight', function()
       delete_buffer(bufnr)
     end)
 
+    it('draws generated rail change bars before line-number columns', function()
+      local bufnr = create_buffer({
+        '      ┃ @@ -1,1 +1,1 @@',
+        '  1   ┃ -old',
+        '    1 ┃ +new',
+      })
+
+      local hunk = {
+        filename = 'test.lua',
+        lang = 'lua',
+        start_line = 1,
+        lines = { '-old', '+new' },
+        prefix_width = 1,
+        quote_width = 10,
+        rail_width = 10,
+      }
+
+      highlight.highlight_hunk(
+        bufnr,
+        ns,
+        hunk,
+        default_opts({
+          hide_prefix = true,
+          highlights = {
+            background = true,
+            gutter = true,
+            treesitter = { enabled = false },
+          },
+        })
+      )
+
+      local bars = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        local d = mark[4]
+        if d and d.virt_text and d.virt_text[1] then
+          local group = d.virt_text[1][2]
+          if group == 'DiffsAddBar' or group == 'DiffsDeleteBar' then
+            bars[mark[2]] = group
+            assert.are.equal('▏', d.virt_text[1][1])
+            assert.are.equal(0, mark[3])
+          end
+        end
+      end
+
+      assert.are.equal('DiffsDeleteBar', bars[1])
+      assert.are.equal('DiffsAddBar', bars[2])
+      delete_buffer(bufnr)
+    end)
+
+    it('keeps hide_prefix overlay off generated line-number rails', function()
+      local bufnr = create_buffer({
+        '      ┃ @@ -1,1 +1,1 @@',
+        '  1   ┃ -old',
+        '    1 ┃ +new',
+      })
+
+      local hunk = {
+        filename = 'test.lua',
+        lang = 'lua',
+        start_line = 1,
+        lines = { '-old', '+new' },
+        prefix_width = 1,
+        quote_width = 10,
+        rail_width = 10,
+      }
+
+      highlight.highlight_hunk(
+        bufnr,
+        ns,
+        hunk,
+        default_opts({
+          hide_prefix = true,
+          highlights = {
+            background = true,
+            gutter = true,
+            treesitter = { enabled = false },
+          },
+        })
+      )
+
+      local overlays = {}
+      local rails = {}
+      local base_rail_numbers = {}
+      local rail_numbers = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        local d = mark[4]
+        if d and d.virt_text and d.virt_text[1] then
+          local text, group = d.virt_text[1][1], d.virt_text[1][2]
+          if group == 'DiffsAdd' or group == 'DiffsDelete' then
+            overlays[#overlays + 1] = { row = mark[2], col = mark[3], text = text, group = group }
+          end
+        end
+        if d and d.hl_group == 'DiffsRail' then
+          rails[#rails + 1] = { row = mark[2], col = mark[3], end_col = d.end_col }
+        end
+        if d and d.hl_group == 'DiffsRailNr' then
+          base_rail_numbers[#base_rail_numbers + 1] =
+            { row = mark[2], col = mark[3], end_col = d.end_col }
+        end
+        if d and (d.hl_group == 'DiffsAddRailNr' or d.hl_group == 'DiffsDeleteRailNr') then
+          rail_numbers[#rail_numbers + 1] =
+            { row = mark[2], col = mark[3], end_col = d.end_col, group = d.hl_group }
+        end
+      end
+
+      assert.are.same({
+        { row = 1, col = 10, text = ' ', group = 'DiffsDelete' },
+        { row = 2, col = 10, text = ' ', group = 'DiffsAdd' },
+      }, overlays)
+      assert.are.same({
+        { row = 1, col = 0, end_col = 10 },
+        { row = 2, col = 0, end_col = 10 },
+      }, rails)
+      assert.are.same({
+        { row = 1, col = 2, end_col = 3 },
+        { row = 1, col = 4, end_col = 5 },
+        { row = 2, col = 2, end_col = 3 },
+        { row = 2, col = 4, end_col = 5 },
+      }, base_rail_numbers)
+      assert.are.same({
+        { row = 1, col = 2, end_col = 5, group = 'DiffsDeleteRailNr' },
+        { row = 2, col = 2, end_col = 5, group = 'DiffsAddRailNr' },
+      }, rail_numbers)
+      delete_buffer(bufnr)
+    end)
+
+    it('leaves generated context prefix cells unpainted for cursorline', function()
+      local bufnr = create_buffer({
+        '  1 1 ┃  local M = {}',
+      })
+
+      local hunk = {
+        filename = 'test.lua',
+        lang = 'lua',
+        start_line = 0,
+        lines = { ' local M = {}' },
+        prefix_width = 1,
+        quote_width = 10,
+        rail_width = 10,
+      }
+
+      highlight.highlight_hunk(
+        bufnr,
+        ns,
+        hunk,
+        default_opts({
+          hide_prefix = true,
+          highlights = {
+            background = true,
+            gutter = true,
+            treesitter = { enabled = false },
+          },
+        })
+      )
+
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        local d = mark[4]
+        if d and d.virt_text_pos == 'overlay' then
+          error('unexpected hide_prefix overlay on generated context line')
+        end
+        if d and d.hl_group == 'DiffsClear' then
+          assert.are.equal(0, mark[3])
+          assert.are.equal(10, d.end_col)
+        end
+      end
+
+      delete_buffer(bufnr)
+    end)
+
+    it('does not apply DiffsClear over generated rail source content', function()
+      local bufnr = create_buffer({
+        '      ┃ @@ -0,0 +1,1 @@',
+        '    1 ┃ +local untracked = {}',
+      })
+
+      local hunk = {
+        filename = 'test.lua',
+        lang = 'lua',
+        start_line = 1,
+        lines = { '+local untracked = {}' },
+        prefix_width = 1,
+        quote_width = 10,
+        rail_width = 10,
+      }
+
+      highlight.highlight_hunk(bufnr, ns, hunk, default_opts())
+
+      local has_keyword = false
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        local d = mark[4]
+        if mark[2] == 1 and d and d.hl_group == '@keyword.lua' then
+          has_keyword = true
+        end
+        if mark[2] == 1 and d and d.hl_group == 'DiffsClear' then
+          assert.is_true(mark[3] < 11, 'DiffsClear starts on generated content at col ' .. mark[3])
+        end
+      end
+
+      assert.is_true(has_keyword, 'treesitter keyword highlight was applied')
+      delete_buffer(bufnr)
+    end)
+
     it('does not apply prefix extmark on context line', function()
       local bufnr = create_buffer({
         '@@ -1,2 +1,2 @@',

--- a/spec/rails_spec.lua
+++ b/spec/rails_spec.lua
@@ -19,16 +19,16 @@ describe('diffs.rails', function()
 
     assert.are.same({
       width = 2,
-      prefix_width = 8,
+      prefix_width = 12,
     }, info)
-    assert.are.equal('      | diff --git a/file.txt b/file.txt', annotated[1])
-    assert.are.equal('      | @@ -9,3 +10,4 @@', annotated[4])
-    assert.are.equal(' 9 10 |  alpha', annotated[5])
-    assert.are.equal('10    | -beta', annotated[6])
-    assert.are.equal('   11 | +beta changed', annotated[7])
-    assert.are.equal('11 12 |  gamma', annotated[8])
-    assert.are.equal('   13 | +delta', annotated[9])
-    assert.are.equal('      | \\ No newline at end of file', annotated[10])
+    assert.are.equal('        ┃ diff --git a/file.txt b/file.txt', annotated[1])
+    assert.are.equal('        ┃ @@ -9,3 +10,4 @@', annotated[4])
+    assert.are.equal('   9 10 ┃  alpha', annotated[5])
+    assert.are.equal('  10    ┃ -beta', annotated[6])
+    assert.are.equal('     11 ┃ +beta changed', annotated[7])
+    assert.are.equal('  11 12 ┃  gamma', annotated[8])
+    assert.are.equal('     13 ┃ +delta', annotated[9])
+    assert.are.equal('        ┃ \\ No newline at end of file', annotated[10])
   end)
 
   it('leaves non-diff content unchanged', function()
@@ -37,5 +37,14 @@ describe('diffs.rails', function()
 
     assert.are.equal(lines, annotated)
     assert.is_nil(info)
+  end)
+
+  it('returns byte ranges for old and new rail number columns', function()
+    assert.are.same({
+      old_start = 2,
+      old_end = 4,
+      new_start = 5,
+      new_end = 7,
+    }, rails.ranges(12))
   end)
 end)

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -573,10 +573,35 @@ describe('diffs.runtime', function()
         if opts.name == 'Normal' then
           return { fg = 0xebdbb2, bg = 0x282828 }
         end
+        if opts.name == 'LineNr' then
+          return { fg = 0x665c54 }
+        end
+        if opts.name == 'diffAdded' then
+          return { fg = 0x80c080 }
+        end
+        if opts.name == 'diffRemoved' then
+          return { fg = 0xc08080 }
+        end
         return saved_get_hl(ns, opts)
       end
       runtime._test.compute_highlight_groups()
       assert.are.equal(0x282828, set_calls.DiffsClear.bg)
+      assert.are.equal(0xebdbb2, set_calls.DiffsRail.fg)
+      assert.are.equal(0x282828, set_calls.DiffsRail.bg)
+      assert.is_true(set_calls.DiffsRail.nocombine)
+      assert.are.equal(0x665c54, set_calls.DiffsRailNr.fg)
+      assert.are.equal(0x282828, set_calls.DiffsRailNr.bg)
+      assert.is_true(set_calls.DiffsRailNr.nocombine)
+      assert.are.equal(0x80c080, set_calls.DiffsAddRailNr.fg)
+      assert.is_number(set_calls.DiffsAddRailNr.bg)
+      assert.is_true(set_calls.DiffsAddRailNr.nocombine)
+      assert.are.equal(0xc08080, set_calls.DiffsDeleteRailNr.fg)
+      assert.is_number(set_calls.DiffsDeleteRailNr.bg)
+      assert.is_true(set_calls.DiffsDeleteRailNr.nocombine)
+      assert.are.equal(0x80c080, set_calls.DiffsAddBar.fg)
+      assert.is_number(set_calls.DiffsAddBar.bg)
+      assert.are.equal(0xc08080, set_calls.DiffsDeleteBar.fg)
+      assert.is_number(set_calls.DiffsDeleteBar.bg)
     end)
 
     it('blend_alpha controls DiffsAdd.bg intensity', function()


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

## Solution

The solution reserve a leading bar slot before generated old/new line-number rails; draw a thicker `▌` change bar in generated unified `diffs://` views using add/delete number-column colors; and adds matching split-pair change bars with owned local `signcolumn=yes:1` endpoint windows.
