### PR TITLE
feat: replace Greview split with two-surface workspace

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -616,7 +616,7 @@ Paired-window contract: ~                       *diffs.nvim-paired-windows*
     Like |:Gdiff| but explicitly opens in a horizontal split.
 
 :Greview [++layout=unified|split] [review-spec]                    *:Greview*
-    Open a unified review of the repository in a horizontal split.
+    Open a repository review.
 
     With no arguments, reviews the current repository state against the
     remote default branch (detected via `git -C <repo> symbolic-ref
@@ -628,11 +628,11 @@ Paired-window contract: ~                       *diffs.nvim-paired-windows*
     using merge-base semantics. With `A..B`, reviews explicit target `B`
     against base `A` as a direct two-endpoint comparison.
 
-    Populates the quickfix list with file entries (one per changed file,
-    with `+N`/`-M` stats) and the location list with hunk entries (one per
-    `@@` header, with filename and hunk number). All entries point into the
-    diff buffer, so ` :cnext`/` :cprev` navigate between files and
-    ` :lnext`/` :lprev` navigate between hunks within the buffer.
+    Without `++layout=split`, populates the quickfix list with file entries
+    (one per changed file, with `+N`/`-M` stats) and the location list with hunk
+    entries (one per `@@` header, with filename and hunk number). All entries
+    point into the diff buffer, so ` :cnext`/` :cprev` navigate between files
+    and ` :lnext`/` :lprev` navigate between hunks within the buffer.
 
     The buffer is named `diffs://review:{review-spec}` where
     `{review-spec}` is the normalized review specification. Reloading with
@@ -641,15 +641,28 @@ Paired-window contract: ~                       *diffs.nvim-paired-windows*
     If a `diffs://` window already exists in the current tabpage, the new
     diff replaces its buffer instead of creating another split.
 
-    With `++layout=split`, |:Greview| still opens the full review buffer and
-    quickfix/location-list indexes. It also opens the first changed file in a
-    paired old/new split view. That pair follows later review-buffer, quickfix,
-    and location-list selection until the pair is closed.
+    With `++layout=split`, |:Greview| opens a two-surface review workspace
+    instead of the full review map. The left window is a read-only generated
+    `diffs://review-split:{review-spec}` buffer for one review file. It keeps
+    unified generated-diff behavior such as `]c`, `[c`, `do`, `dp`, Visual
+    `do`/`dp`, and `:edit` refresh. The right window is the real editable
+    worktree file when the selected edge has an existing worktree target;
+    otherwise it is a read-only `diffs://review-target:{endpoint}:{file}` view
+    of the tree or index target.
+
+    In split layout, the quickfix list remains the repo-wide review file index
+    and the location list is the active file's hunk index. Selecting quickfix
+    or location-list entries with the |diffs.nvim| mapped <CR> updates the
+    existing workspace instead of opening a third review buffer. Native
+    `:cnext`/`:cprev` and `:lnext`/`:lprev` movement is not the split workspace
+    update path. Saving the right-side worktree buffer refreshes the generated
+    diff on the left. Native Vim `&diff` mode is not used for |:Greview| split
+    workspaces.
 
     Parameters: ~
         ++layout=unified (optional) Open the default unified review buffer.
-        ++layout=split (optional) Also open a paired old/new split view for
-                       the first changed review file.
+        ++layout=split (optional) Open the two-surface split workspace for the
+                       first renderable changed review file.
         {review-spec}  (string, optional) One of:
                        - empty: review current repo state against the repo
                          default branch
@@ -702,11 +715,10 @@ Paired-window contract: ~                       *diffs.nvim-paired-windows*
 
     Utilities: ~
         `require('diffs.commands').greview_split()` opens the currently
-        selected |:Greview| file in a paired split view. It uses the review
-        buffer cursor, quickfix item, or loclist item as the file selection.
-        Once opened, that Greview-owned pair follows review-buffer file and hunk
-        selection until the pair is closed. The review quickfix list remains
-        the authoritative file list.
+        selected |:Greview| file in the same two-surface split workspace used
+        by `:Greview ++layout=split`. It uses the review buffer cursor,
+        quickfix item, or loclist item as the file selection, and the review
+        quickfix list remains the authoritative file list.
 
         `require('diffs.commands').review_file_at_line(bufnr, lnum)` returns
         the filename at a given line in a review buffer by walking backwards
@@ -736,10 +748,9 @@ MAPPINGS                                                 *diffs.nvim-mappings*
                                              *<Plug>(diffs-greview-open-split)*
 <Plug>(diffs-greview-open-split)
                         Open the currently selected |:Greview| file in a
-                        paired split view. The review buffer remains the
-                        full-repo map; this action opens one file pair for
-                        focused inspection and follows later review-buffer
-                        selections until that pair is closed.
+                        two-surface split workspace: generated per-file diff on
+                        the left, editable worktree or read-only target view on
+                        the right.
 
 Example configuration: >lua
     vim.keymap.set('n', '<leader>gd', '<Plug>(diffs-gdiff)')

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -16,7 +16,8 @@ local split = require('diffs.split')
 
 local dbg = log.dbg
 local notify = log.notify
-local greview_follow_group = vim.api.nvim_create_augroup('diffs_greview_follow', { clear = false })
+local greview_workspace_group =
+  vim.api.nvim_create_augroup('diffs_greview_workspace', { clear = false })
 
 ---@class diffs.HunkKeymap
 ---@field mode string
@@ -28,18 +29,25 @@ local hunk_keymaps = {}
 ---@type table<integer, integer>
 local hunk_keymap_autocmds = {}
 
----@class diffs.GreviewFollowState
----@field left_buf integer
----@field right_buf integer
----@field file string
----@field key string
----@field hunk_index? integer
+---@class diffs.GreviewWorkspaceState
+---@field diff_buf integer
+---@field diff_win integer?
+---@field target_buf integer?
+---@field target_win integer?
+---@field target_scratch boolean
+---@field review diffs.GreviewSpec
+---@field display string
+---@field repo_root string
+---@field review_lines string[]
+---@field list_opts table?
+---@field selected_key string?
+---@field selected_file string?
+---@field selected_diff_spec diffs.DiffSpec?
+---@field selected_hunk_index integer?
 ---@field autocmds integer[]
----@field pending? boolean
----@field pending_item? table
 
----@type table<integer, diffs.GreviewFollowState>
-local greview_follow_states = {}
+---@type table<integer, diffs.GreviewWorkspaceState>
+local greview_workspaces = {}
 
 ---@param bufnr integer
 ---@param mode string
@@ -312,7 +320,7 @@ end
 
 ---@class diffs.GeneratedBufferSource
 ---@field version integer
----@field kind "file"|"file_pair"|"section"|"review"|"unmerged"|"split_endpoint"
+---@field kind "file"|"file_pair"|"section"|"review"|"review_file"|"unmerged"|"split_endpoint"
 ---@field repo_root string
 ---@field spec? diffs.DiffSpec
 ---@field edge? "staged"|"unstaged"
@@ -320,6 +328,9 @@ end
 ---@field old_path? string
 ---@field section? "staged"|"unstaged"
 ---@field review? diffs.GreviewSpec
+---@field review_display? string
+---@field selected_key? string
+---@field selected_file? string
 ---@field working_path? string
 ---@field side? "left"|"right"
 ---@field filetype? string
@@ -370,6 +381,17 @@ local function normalize_source(source)
   elseif source.kind == 'review' then
     if type(source.review) ~= 'table' then
       error('expected review spec')
+    end
+  elseif source.kind == 'review_file' then
+    if type(source.review) ~= 'table' then
+      error('expected review file spec')
+    end
+    if source.spec == nil then
+      error('expected review file diff spec')
+    end
+    source.spec = diffspec.new(source.spec)
+    if type(source.path) ~= 'string' or source.path == '' then
+      error('expected review file path')
     end
   elseif source.kind == 'unmerged' then
     if type(source.path) ~= 'string' or source.path == '' then
@@ -493,6 +515,7 @@ local function replace_generated_diff_buffer_lines(bufnr, diff_lines, diff_spec)
 
   set_generated_diff_buffer_options(bufnr)
   set_generated_diff_buffer_filetype(bufnr)
+  runtime.refresh(bufnr)
 end
 
 ---@param bufnr integer
@@ -604,6 +627,16 @@ local function render_source(source)
       return nil, nil, review_err, nil
     end
     return review_lines, nil, 'review', list_opts
+  end
+
+  if source.kind == 'review_file' then
+    local diff_lines, read_err = render.file(source.spec, source.repo_root, {
+      empty_on_missing = true,
+    })
+    if not diff_lines then
+      return nil, nil, read_err, nil
+    end
+    return diff_lines, source.spec, 'review:' .. (source.selected_key or source.path), nil
   end
 
   local abs_path = source.repo_root .. '/' .. source.path
@@ -788,6 +821,9 @@ local function complete_greview_command(arglead, cmdline, cursorpos)
   return matches
 end
 
+---@type fun(spec?: diffs.GreviewSpec, opts?: { selection?: diffs.GeneratedFileSelection, replace_win?: integer }): integer?
+local open_greview_workspace
+
 ---@param args? string
 ---@return integer?
 function M.greview_command(args)
@@ -797,10 +833,11 @@ function M.greview_command(args)
     return nil
   end
 
-  local bufnr = M.greview(parsed.spec)
-  if bufnr and parsed.layout == 'split' then
-    M.greview_split({ bufnr = bufnr, lnum = 1 })
+  if parsed.layout == 'split' then
+    return open_greview_workspace(parsed.spec)
   end
+
+  local bufnr = M.greview(parsed.spec)
   return bufnr
 end
 
@@ -831,59 +868,6 @@ local function restore_window(win)
   end
 end
 
----@param review_buf integer
-local function stop_greview_follow(review_buf)
-  local state = greview_follow_states[review_buf]
-  if state then
-    for _, id in ipairs(state.autocmds or {}) do
-      pcall(vim.api.nvim_del_autocmd, id)
-    end
-  end
-  greview_follow_states[review_buf] = nil
-  if vim.api.nvim_buf_is_valid(review_buf) then
-    pcall(vim.api.nvim_buf_del_var, review_buf, 'diffs_review_split_buf')
-  end
-end
-
----@param review_buf integer
----@return integer?
-local function stored_greview_pair_buf(review_buf)
-  local state = greview_follow_states[review_buf]
-  if state then
-    return state.right_buf
-  end
-
-  local previous = get_buf_var(review_buf, 'diffs_review_split_buf')
-  if type(previous) == 'number' then
-    return previous
-  end
-  return nil
-end
-
----@param review_buf integer
-local function close_owned_greview_pair(review_buf)
-  local previous = stored_greview_pair_buf(review_buf)
-  stop_greview_follow(review_buf)
-  if type(previous) == 'number' and vim.api.nvim_buf_is_valid(previous) then
-    split.close_pair(previous)
-  end
-end
-
----@param state diffs.GreviewFollowState?
----@return boolean
-local function greview_pair_valid(state)
-  if
-    not state
-    or not vim.api.nvim_buf_is_valid(state.left_buf)
-    or not vim.api.nvim_buf_is_valid(state.right_buf)
-  then
-    return false
-  end
-
-  return get_buf_var(state.left_buf, 'diffs_split_peer') == state.right_buf
-    and get_buf_var(state.right_buf, 'diffs_split_peer') == state.left_buf
-end
-
 ---@class diffs.GreviewSplitOpts
 ---@field bufnr? integer
 ---@field lnum? integer
@@ -891,10 +875,9 @@ end
 
 ---@class diffs.GreviewSplitContext
 ---@field review_buf integer
+---@field replace_win integer
 ---@field selected diffs.GeneratedFileSelection
----@field diff_spec diffs.DiffSpec
 ---@field repo_root string
----@field diff_lines string[]
 
 ---@param opts? diffs.GreviewSplitOpts
 ---@return diffs.GreviewSplitContext?, string?, integer?, integer?
@@ -928,248 +911,762 @@ local function greview_split_context(opts)
     return nil, 'selected file is not from a Greview buffer', vim.log.levels.WARN, nil
   end
 
-  local diff_spec, normalized, spec_err =
-    review.diff_spec_for_file(source.review, source.repo_root, selected.file, selected)
-  if not diff_spec then
-    return nil, spec_err or 'cannot build Greview split diff spec', vim.log.levels.ERROR, review_buf
-  end
-
-  local repo_root = normalized and normalized.repo_root or source.repo_root
-  local diff_lines, render_err = render.file(diff_spec, repo_root)
-  if not diff_lines then
-    return nil, render_err or 'cannot render Greview split file', vim.log.levels.ERROR, review_buf
-  end
-  if #diff_lines == 0 then
-    return nil, 'no changes for ' .. diffspec.label(diff_spec), vim.log.levels.INFO, review_buf
+  local review_win = first_window_for_buffer(review_buf)
+  if not review_win then
+    return nil,
+      'selected Greview buffer is not visible; open the review buffer before splitting it',
+      vim.log.levels.WARN,
+      review_buf
   end
 
   return {
     review_buf = review_buf,
+    replace_win = review_win,
     selected = selected,
-    diff_spec = diff_spec,
-    repo_root = repo_root,
-    diff_lines = diff_lines,
+    repo_root = source.repo_root,
   },
     nil,
     nil,
     review_buf
 end
 
----@type fun(review_buf: integer, item?: table)
-local schedule_greview_follow
+---@param normalized diffs.NormalizedGreview
+---@return diffs.GreviewSpec
+local function stored_review_spec(normalized)
+  return {
+    base = normalized.base,
+    target = normalized.target,
+    mode = normalized.mode,
+  }
+end
+
+---@param review_spec diffs.GreviewSpec
+---@param repo_root string
+---@param selected diffs.GeneratedFileSelection
+---@return diffs.DiffSpec?, diffs.NormalizedGreview?, string?
+local function selected_review_diff_spec(review_spec, repo_root, selected)
+  return review.diff_spec_for_file(review_spec, repo_root, selected.file, selected)
+end
+
+---@param state diffs.GreviewWorkspaceState
+local function clear_greview_workspace_autocmds(state)
+  for _, id in ipairs(state.autocmds or {}) do
+    pcall(vim.api.nvim_del_autocmd, id)
+  end
+  state.autocmds = {}
+end
+
+---@param bufnr integer
+local function close_greview_workspace(bufnr)
+  local state = greview_workspaces[bufnr]
+  if not state then
+    pcall(vim.api.nvim_win_close, 0, true)
+    return
+  end
+
+  clear_greview_workspace_autocmds(state)
+  greview_workspaces[bufnr] = nil
+
+  local focus_win
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    if vim.api.nvim_win_is_valid(win) then
+      local buf = vim.api.nvim_win_get_buf(win)
+      if buf ~= state.diff_buf and buf ~= state.target_buf then
+        focus_win = win
+        break
+      end
+    end
+  end
+
+  for _, win in ipairs({ state.target_win, state.diff_win }) do
+    if type(win) == 'number' and vim.api.nvim_win_is_valid(win) then
+      pcall(vim.api.nvim_win_close, win, true)
+    end
+  end
+
+  if
+    state.target_scratch
+    and type(state.target_buf) == 'number'
+    and vim.api.nvim_buf_is_valid(state.target_buf)
+  then
+    pcall(vim.api.nvim_buf_delete, state.target_buf, { force = true })
+  end
+  if vim.api.nvim_buf_is_valid(state.diff_buf) then
+    pcall(vim.api.nvim_buf_delete, state.diff_buf, { force = true })
+  end
+
+  if focus_win and vim.api.nvim_win_is_valid(focus_win) then
+    vim.api.nvim_set_current_win(focus_win)
+  elseif #vim.api.nvim_list_wins() > 0 then
+    pcall(vim.cmd.enew)
+  end
+end
+
+---@param state diffs.GreviewWorkspaceState
+---@param wins table<integer, boolean>
+---@return boolean
+local function greview_workspace_visible_in_wins(state, wins)
+  for _, win in ipairs({ state.diff_win, state.target_win }) do
+    if type(win) == 'number' and wins[win] then
+      return true
+    end
+  end
+
+  for win in pairs(wins) do
+    if vim.api.nvim_win_is_valid(win) then
+      local buf = vim.api.nvim_win_get_buf(win)
+      if buf == state.diff_buf or buf == state.target_buf then
+        return true
+      end
+    end
+  end
+  return false
+end
+
+---@param display string
+local function close_existing_greview_workspace(display)
+  local current_wins = {}
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    current_wins[win] = true
+  end
+
+  local to_close = {}
+  for bufnr, state in pairs(greview_workspaces) do
+    if greview_workspace_visible_in_wins(state, current_wins) then
+      to_close[#to_close + 1] = bufnr
+    end
+  end
+  for _, bufnr in ipairs(to_close) do
+    close_greview_workspace(bufnr)
+  end
+
+  local existing_buf = vim.fn.bufnr('diffs://review-split:' .. display)
+  if existing_buf ~= -1 and vim.api.nvim_buf_is_valid(existing_buf) then
+    pcall(vim.api.nvim_buf_delete, existing_buf, { force = true })
+  end
+end
+
+---@param win integer
+---@param lnum integer
+local function set_window_lnum(win, lnum)
+  if not vim.api.nvim_win_is_valid(win) then
+    return
+  end
+  local bufnr = vim.api.nvim_win_get_buf(win)
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  vim.api.nvim_win_set_cursor(win, { math.max(1, math.min(lnum, line_count)), 0 })
+end
+
+---@param hunk diffs.GdiffHunk
+---@return integer
+local function hunk_right_lnum(hunk)
+  local range = hunk.new_range
+  return math.max(1, range and range.start or 1)
+end
+
+---@param state diffs.GreviewWorkspaceState
+---@return diffs.GdiffHunk[]
+local function greview_workspace_hunks(state)
+  local hunks = get_buf_var(state.diff_buf, 'diffs_hunks')
+  return type(hunks) == 'table' and hunks or {}
+end
+
+---@param state diffs.GreviewWorkspaceState
+---@param hunk_index integer?
+---@return diffs.GdiffHunk?
+local function greview_workspace_hunk(state, hunk_index)
+  local hunks = greview_workspace_hunks(state)
+  return hunks[hunk_index or 1]
+end
+
+---@param state diffs.GreviewWorkspaceState
+---@param hunk diffs.GdiffHunk?
+local function move_greview_workspace_to_hunk(state, hunk)
+  if not hunk then
+    return
+  end
+
+  local diff_win = type(state.diff_win) == 'number'
+      and vim.api.nvim_win_is_valid(state.diff_win)
+      and state.diff_win
+    or first_window_for_buffer(state.diff_buf)
+  if diff_win then
+    set_window_lnum(diff_win, hunk.buffer_range.start)
+  end
+  if type(state.target_win) == 'number' and vim.api.nvim_win_is_valid(state.target_win) then
+    set_window_lnum(state.target_win, hunk_right_lnum(hunk))
+  end
+  state.selected_hunk_index = hunk.index
+end
+
+---@param bufnr integer
+---@param direction "next"|"prev"
+local function greview_workspace_goto_hunk(bufnr, direction)
+  local state = greview_workspaces[bufnr]
+  if not state then
+    return
+  end
+
+  local hunks = greview_workspace_hunks(state)
+  if #hunks == 0 then
+    return
+  end
+
+  local diff_win = type(state.diff_win) == 'number'
+      and vim.api.nvim_win_is_valid(state.diff_win)
+      and state.diff_win
+    or first_window_for_buffer(state.diff_buf)
+  local cursor_line = diff_win and vim.api.nvim_win_get_cursor(diff_win)[1] or 1
+  local hunk
+  if direction == 'next' then
+    hunk = hunk_model.next_hunk(hunks, cursor_line) or hunks[1]
+    if hunk == hunks[1] and hunk.buffer_range.start <= cursor_line then
+      notify('wrapped to first hunk', vim.log.levels.INFO)
+    end
+  else
+    hunk = hunk_model.prev_hunk(hunks, cursor_line) or hunks[#hunks]
+    if hunk == hunks[#hunks] and hunk.buffer_range.start >= cursor_line then
+      notify('wrapped to last hunk', vim.log.levels.INFO)
+    end
+  end
+
+  move_greview_workspace_to_hunk(state, hunk)
+end
+
+---@param bufnr integer
+local function set_greview_workspace_keymaps(bufnr)
+  vim.keymap.set('n', 'q', function()
+    close_greview_workspace(bufnr)
+  end, { buffer = bufnr, desc = 'Close Greview split workspace' })
+  vim.keymap.set('n', ']c', function()
+    greview_workspace_goto_hunk(bufnr, 'next')
+  end, { buffer = bufnr, desc = 'Next diff hunk' })
+  vim.keymap.set('n', '[c', function()
+    greview_workspace_goto_hunk(bufnr, 'prev')
+  end, { buffer = bufnr, desc = 'Previous diff hunk' })
+end
+
+---@param state diffs.GreviewWorkspaceState
+---@param selected diffs.GeneratedFileSelection
+---@param diff_spec diffs.DiffSpec
+---@return diffs.GeneratedBufferSource
+local function review_file_source(state, selected, diff_spec)
+  return {
+    version = 1,
+    kind = 'review_file',
+    repo_root = state.repo_root,
+    review = state.review,
+    review_display = state.display,
+    selected_key = selected.key,
+    selected_file = selected.file,
+    path = selected.file,
+    spec = diff_spec,
+  }
+end
+
+---@param bufnr integer
+---@param state diffs.GreviewWorkspaceState
+---@param selected diffs.GeneratedFileSelection
+---@param diff_spec diffs.DiffSpec
+---@param diff_lines string[]
+local function replace_review_file_buffer(bufnr, state, selected, diff_spec, diff_lines)
+  set_diff_spec_var(bufnr, diff_spec)
+  vim.api.nvim_buf_set_var(bufnr, 'diffs_repo_root', state.repo_root)
+  vim.api.nvim_buf_set_var(bufnr, 'diffs_source', review_file_source(state, selected, diff_spec))
+  replace_generated_diff_buffer_lines(bufnr, diff_lines, diff_spec)
+  lists.set_for_unified_buffer(bufnr, diff_lines, {
+    title = 'review: ' .. (selected.key or selected.file),
+    loclist_title = 'review hunks: ' .. (selected.key or selected.file),
+    diff_spec = diff_spec,
+    quickfix = false,
+  })
+  M.setup_diff_buf(bufnr)
+  set_greview_workspace_keymaps(bufnr)
+  runtime.attach(bufnr)
+end
+
+---@param repo_root string
+---@param path string
+---@return string
+local function worktree_path(repo_root, path)
+  return repo_root .. '/' .. path
+end
+
+---@param endpoint diffs.Endpoint
+---@return string
+local function endpoint_name(endpoint)
+  endpoint = diffspec.endpoint(endpoint)
+  if endpoint.kind == diffspec.endpoint_kind.tree then
+    return endpoint.rev
+  end
+  return endpoint.kind
+end
+
+---@param lines diffs.ContentLines|string[]
+---@return string[]
+local function plain_lines(lines)
+  local result = {}
+  for i, line in ipairs(lines or {}) do
+    result[i] = line
+  end
+  return result
+end
+
+---@param state diffs.GreviewWorkspaceState
+---@return integer
+local function ensure_target_window(state)
+  if type(state.target_win) == 'number' and vim.api.nvim_win_is_valid(state.target_win) then
+    return state.target_win
+  end
+
+  local diff_win = type(state.diff_win) == 'number'
+      and vim.api.nvim_win_is_valid(state.diff_win)
+      and state.diff_win
+    or first_window_for_buffer(state.diff_buf)
+  if diff_win then
+    vim.api.nvim_set_current_win(diff_win)
+  end
+  vim.cmd('rightbelow vsplit')
+  state.target_win = vim.api.nvim_get_current_win()
+  return state.target_win
+end
+
+---@param state diffs.GreviewWorkspaceState
+---@param diff_spec diffs.DiffSpec
+---@param selected diffs.GeneratedFileSelection
+---@return boolean
+local function open_workspace_target(state, diff_spec, selected)
+  local target_win = ensure_target_window(state)
+  local previous_win = vim.api.nvim_get_current_win()
+  vim.api.nvim_set_current_win(target_win)
+  pcall(vim.api.nvim_set_option_value, 'diff', false, { win = target_win })
+
+  local target = diffspec.endpoint(diff_spec.right)
+  local path = worktree_path(state.repo_root, selected.file)
+  local previous_target_buf = state.target_buf
+  local previous_target_scratch = state.target_scratch
+
+  if target.kind == diffspec.endpoint_kind.worktree and vim.fn.filereadable(path) == 1 then
+    vim.cmd.edit(vim.fn.fnameescape(path))
+    state.target_buf = vim.api.nvim_get_current_buf()
+    state.target_scratch = false
+    if
+      previous_target_scratch
+      and type(previous_target_buf) == 'number'
+      and previous_target_buf ~= state.target_buf
+      and vim.api.nvim_buf_is_valid(previous_target_buf)
+    then
+      pcall(vim.api.nvim_buf_delete, previous_target_buf, { force = true })
+    end
+  else
+    local lines, err = render.read_endpoint(target, path, { empty_on_missing = true })
+    if not lines then
+      notify(err or 'cannot read review target', vim.log.levels.WARN)
+      restore_window(previous_win)
+      return false
+    end
+    local target_buf = previous_target_scratch and previous_target_buf or nil
+    if type(target_buf) ~= 'number' or not vim.api.nvim_buf_is_valid(target_buf) then
+      target_buf = vim.api.nvim_create_buf(false, true)
+    end
+    local target_name = 'diffs://review-target:' .. endpoint_name(target) .. ':' .. selected.file
+    local existing = vim.fn.bufnr(target_name)
+    if existing ~= -1 and existing ~= target_buf and vim.api.nvim_buf_is_valid(existing) then
+      pcall(vim.api.nvim_buf_delete, existing, { force = true })
+    end
+    vim.api.nvim_set_option_value('modifiable', true, { buf = target_buf })
+    vim.api.nvim_buf_set_lines(target_buf, 0, -1, false, plain_lines(lines))
+    vim.api.nvim_buf_set_name(target_buf, target_name)
+    vim.api.nvim_set_option_value('buftype', 'nowrite', { buf = target_buf })
+    vim.api.nvim_set_option_value('bufhidden', 'delete', { buf = target_buf })
+    vim.api.nvim_set_option_value('swapfile', false, { buf = target_buf })
+    vim.api.nvim_set_option_value('modifiable', false, { buf = target_buf })
+    local ft = filetype_for_path(state.repo_root, selected.file)
+    if ft then
+      vim.api.nvim_set_option_value('filetype', ft, { buf = target_buf })
+    end
+    vim.api.nvim_win_set_buf(target_win, target_buf)
+    state.target_buf = target_buf
+    state.target_scratch = true
+  end
+
+  restore_window(previous_win)
+  return true
+end
+
+---@param review_spec diffs.GreviewSpec
+---@param repo_root string
+---@param selected diffs.GeneratedFileSelection
+---@return diffs.DiffSpec?, string[]?, string?, integer?
+local function render_review_file_selection(review_spec, repo_root, selected)
+  local diff_spec, _, spec_err = selected_review_diff_spec(review_spec, repo_root, selected)
+  if not diff_spec then
+    return nil, nil, spec_err or 'cannot build Greview split diff spec', vim.log.levels.ERROR
+  end
+
+  local diff_lines, render_err = render.file(diff_spec, repo_root, { empty_on_missing = true })
+  if not diff_lines then
+    return nil, nil, render_err or 'cannot render Greview split file', vim.log.levels.ERROR
+  end
+  if #diff_lines == 0 then
+    return nil, nil, 'no changes for ' .. diffspec.label(diff_spec), vim.log.levels.INFO
+  end
+  return diff_spec, diff_lines, nil, nil
+end
+
+---@param list_opts table?
+---@return diffs.GeneratedListOptions
+local function review_generated_list_opts(list_opts)
+  return {
+    metadata_for_line = list_opts and list_opts.metadata_for_line,
+    sections = list_opts and list_opts.sections,
+    store_hunks = list_opts and list_opts.store_hunks,
+  }
+end
+
+---@param review_spec diffs.GreviewSpec
+---@param repo_root string
+---@param review_lines string[]
+---@param list_opts table?
+---@return diffs.GeneratedFileSelection?, diffs.DiffSpec?, string[]?, string?, integer?
+local function first_renderable_review_file(review_spec, repo_root, review_lines, list_opts)
+  local last_err
+  local last_level
+  for _, selected in
+    ipairs(lists.generated_files(review_lines, review_generated_list_opts(list_opts)))
+  do
+    local diff_spec, diff_lines, err, level =
+      render_review_file_selection(review_spec, repo_root, selected)
+    if diff_spec and diff_lines then
+      return selected, diff_spec, diff_lines, nil, nil
+    end
+    last_err = err
+    last_level = level
+  end
+
+  return nil,
+    nil,
+    nil,
+    last_err or 'no renderable Greview file selected',
+    last_level or vim.log.levels.INFO
+end
+
+---@param item table?
+---@return diffs.GeneratedFileSelection?
+local function review_selection_from_item(item)
+  if type(item) ~= 'table' or type(item.user_data) ~= 'table' then
+    return nil
+  end
+  local data = item.user_data.diffs
+  if type(data) ~= 'table' or type(data.file) ~= 'string' or data.file == '' then
+    return nil
+  end
+  return {
+    bufnr = item.bufnr,
+    file = data.file,
+    key = data.key or data.file,
+    section = data.section,
+    section_label = data.section_label,
+    diff_spec = data.diff_spec,
+    lnum = item.lnum,
+    hunk_index = data.hunk,
+  }
+end
+
+local attach_greview_workspace_autocmds
+local refresh_greview_workspace_after_write
+
+---@param state diffs.GreviewWorkspaceState
+---@param selected diffs.GeneratedFileSelection
+---@param opts? { restore_focus?: boolean, restore_win?: integer, refresh_index?: boolean }
+---@return boolean
+local function show_greview_workspace_selection(state, selected, opts)
+  opts = opts or {}
+  local restore_win = opts.restore_win or vim.api.nvim_get_current_win()
+  local diff_spec, _, spec_err = selected_review_diff_spec(state.review, state.repo_root, selected)
+  if not diff_spec then
+    notify(spec_err or 'cannot build Greview split diff spec', vim.log.levels.ERROR)
+    return false
+  end
+
+  local diff_lines, render_err =
+    render.file(diff_spec, state.repo_root, { empty_on_missing = true })
+  if not diff_lines then
+    notify(render_err or 'cannot render Greview split file', vim.log.levels.ERROR)
+    return false
+  end
+
+  replace_review_file_buffer(state.diff_buf, state, selected, diff_spec, diff_lines)
+  if opts.refresh_index then
+    lists.set_review_workspace_quickfix(state.diff_buf, state.review_lines, {
+      title = 'review: ' .. state.display,
+      loclist_title = 'review hunks: ' .. state.display,
+      metadata_for_line = state.list_opts and state.list_opts.metadata_for_line,
+      sections = state.list_opts and state.list_opts.sections,
+      store_hunks = state.list_opts and state.list_opts.store_hunks,
+    })
+  end
+
+  local hunk = greview_workspace_hunk(state, selected.hunk_index)
+  if not open_workspace_target(state, diff_spec, selected) then
+    return false
+  end
+  state.selected_key = selected.key or selected.file
+  state.selected_file = selected.file
+  state.selected_diff_spec = diff_spec
+  state.selected_hunk_index = selected.hunk_index
+  move_greview_workspace_to_hunk(state, hunk)
+  attach_greview_workspace_autocmds(state)
+
+  if opts.restore_focus then
+    restore_window(restore_win)
+  elseif type(state.diff_win) == 'number' and vim.api.nvim_win_is_valid(state.diff_win) then
+    vim.api.nvim_set_current_win(state.diff_win)
+  end
+  return true
+end
+
+---@param state diffs.GreviewWorkspaceState
+local function refresh_greview_workspace_index(state)
+  local normalized, normalize_err = review.normalize(state.review, state.repo_root)
+  if not normalized then
+    notify(normalize_err or 'cannot normalize Greview split', vim.log.levels.WARN)
+    return
+  end
+  local review_lines, render_err, list_opts = review.render(normalized, review_deps())
+  if not review_lines then
+    notify(render_err or 'cannot refresh Greview split', vim.log.levels.WARN)
+    return
+  end
+  state.review_lines = review_lines
+  state.list_opts = list_opts
+  lists.set_review_workspace_quickfix(state.diff_buf, review_lines, {
+    title = 'review: ' .. state.display,
+    loclist_title = 'review hunks: ' .. state.display,
+    metadata_for_line = list_opts and list_opts.metadata_for_line,
+    sections = list_opts and list_opts.sections,
+    store_hunks = list_opts and list_opts.store_hunks,
+  })
+end
+
+---@param state diffs.GreviewWorkspaceState
+attach_greview_workspace_autocmds = function(state)
+  clear_greview_workspace_autocmds(state)
+  state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd('BufWipeout', {
+    group = greview_workspace_group,
+    buffer = state.diff_buf,
+    once = true,
+    callback = function(args)
+      local current = greview_workspaces[args.buf]
+      if current then
+        clear_greview_workspace_autocmds(current)
+        greview_workspaces[args.buf] = nil
+      end
+    end,
+  })
+  if
+    type(state.target_buf) == 'number'
+    and vim.api.nvim_buf_is_valid(state.target_buf)
+    and not state.target_scratch
+  then
+    local diff_buf = state.diff_buf
+    state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd('BufWritePost', {
+      group = greview_workspace_group,
+      buffer = state.target_buf,
+      callback = function()
+        refresh_greview_workspace_after_write(diff_buf)
+      end,
+    })
+  end
+end
+
+refresh_greview_workspace_after_write = function(diff_buf)
+  local state = greview_workspaces[diff_buf]
+  if not state or not state.selected_file then
+    return
+  end
+  refresh_greview_workspace_index(state)
+  show_greview_workspace_selection(state, {
+    bufnr = state.diff_buf,
+    file = state.selected_file,
+    key = state.selected_key,
+    diff_spec = state.selected_diff_spec,
+    hunk_index = state.selected_hunk_index,
+  }, { restore_focus = true, refresh_index = false })
+end
 
 local function refresh_greview_jump_callback()
   lists.set_generated_jump_callback(function(item)
-    if type(item) == 'table' and type(item.bufnr) == 'number' then
-      schedule_greview_follow(item.bufnr, item)
+    local selected = review_selection_from_item(item)
+    if not selected or type(selected.bufnr) ~= 'number' then
+      return
     end
+    local state = greview_workspaces[selected.bufnr]
+    if not state then
+      return
+    end
+    vim.schedule(function()
+      show_greview_workspace_selection(state, selected, {
+        restore_focus = true,
+        restore_win = vim.api.nvim_get_current_win(),
+      })
+    end)
   end)
 end
 
----@param review_buf integer
----@param opened { left_buf: integer, right_buf: integer, left_win: integer, right_win: integer }
----@param selected diffs.GeneratedFileSelection
-local function start_greview_follow(review_buf, opened, selected)
-  refresh_greview_jump_callback()
-  stop_greview_follow(review_buf)
-
-  ---@type diffs.GreviewFollowState
-  local state = {
-    left_buf = opened.left_buf,
-    right_buf = opened.right_buf,
-    file = selected.file,
-    key = selected.key or selected.file,
-    hunk_index = selected.hunk_index,
-    autocmds = {},
-  }
-  greview_follow_states[review_buf] = state
-  vim.api.nvim_buf_set_var(review_buf, 'diffs_review_split_buf', opened.right_buf)
-
-  state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd({ 'BufEnter', 'CursorMoved' }, {
-    group = greview_follow_group,
-    buffer = review_buf,
-    callback = function(args)
-      if get_buf_var(args.buf, 'diffs_generated_jump_in_progress') then
-        return
-      end
-      schedule_greview_follow(args.buf)
-    end,
-  })
-  state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd('BufWipeout', {
-    group = greview_follow_group,
-    buffer = review_buf,
-    once = true,
-    callback = function(args)
-      stop_greview_follow(args.buf)
-    end,
-  })
-
-  local function stop_if_owned_pair(args)
-    local current = greview_follow_states[review_buf]
-    if current and (args.buf == current.left_buf or args.buf == current.right_buf) then
-      stop_greview_follow(review_buf)
-    end
-  end
-
-  state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd('BufWipeout', {
-    group = greview_follow_group,
-    buffer = opened.left_buf,
-    once = true,
-    callback = stop_if_owned_pair,
-  })
-  state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd('BufWipeout', {
-    group = greview_follow_group,
-    buffer = opened.right_buf,
-    once = true,
-    callback = stop_if_owned_pair,
-  })
-end
-
----@param context diffs.GreviewSplitContext
----@param opts? { restore_focus?: boolean, restore_win?: integer }
----@return { left_buf: integer, right_buf: integer, left_win: integer, right_win: integer }?, string?, integer?
-local function open_greview_split_pair(context, opts)
+open_greview_workspace = function(spec, opts)
   opts = opts or {}
-
-  local review_buf = context.review_buf
-  local review_win = first_window_for_buffer(review_buf)
-  if not review_win then
-    return nil, 'cannot open Greview split without a visible review buffer', vim.log.levels.WARN
+  local normalized, normalize_err = review.normalize(spec)
+  if not normalized then
+    notify(normalize_err, vim.log.levels.ERROR)
+    return nil
   end
-  split.release_pair_window_options(review_win)
-  clear_generated_diff_window_bindings(review_win)
-
-  local previous = stored_greview_pair_buf(review_buf)
-  stop_greview_follow(review_buf)
-  if type(previous) == 'number' and vim.api.nvim_buf_is_valid(previous) then
-    split.close_pair(previous)
+  local review_lines, render_err, list_opts = review.render(normalized, review_deps())
+  if not review_lines then
+    notify(render_err, vim.log.levels.ERROR)
+    return nil
   end
-
-  review_win = first_window_for_buffer(review_buf)
-  if not review_win then
-    return nil, 'cannot open Greview split without a visible review buffer', vim.log.levels.WARN
+  if #review_lines == 0 then
+    notify('no diff against ' .. normalized.display, vim.log.levels.INFO)
+    return nil
   end
 
-  local restore_win = opts.restore_win or vim.api.nvim_get_current_win()
-  vim.api.nvim_set_current_win(review_win)
-  vim.cmd('belowright split')
-  local launcher_win = vim.api.nvim_get_current_win()
-
-  local opened, split_err = split.open({
-    spec = context.diff_spec,
-    repo_root = context.repo_root,
-    filetype = filetype_for_path(context.repo_root, context.selected.file),
-    diff_lines = context.diff_lines,
-    hunk_index = context.selected.hunk_index,
-    quickfix = false,
-  })
-  if not opened then
-    if vim.api.nvim_win_is_valid(launcher_win) then
-      pcall(vim.api.nvim_win_close, launcher_win, true)
+  local review_spec = stored_review_spec(normalized)
+  local first = opts.selection
+  local diff_spec
+  local diff_lines
+  if first then
+    local err, level
+    diff_spec, diff_lines, err, level =
+      render_review_file_selection(review_spec, normalized.repo_root, first)
+    if not diff_spec or not diff_lines then
+      notify(err or 'cannot render Greview split file', level or vim.log.levels.ERROR)
+      return nil
     end
-    restore_window(restore_win)
-    return nil, split_err or 'cannot open Greview split', vim.log.levels.ERROR
+  else
+    local err, level
+    first, diff_spec, diff_lines, err, level =
+      first_renderable_review_file(review_spec, normalized.repo_root, review_lines, list_opts)
+    if not first or not diff_spec or not diff_lines then
+      notify(err or 'no Greview file selected', level or vim.log.levels.INFO)
+      return nil
+    end
   end
-
-  start_greview_follow(review_buf, opened, context.selected)
-  if opts.restore_focus then
-    restore_window(restore_win)
-  end
-  return opened, nil, nil
-end
-
----@param review_buf integer
----@param item? table
-local function follow_greview_selection(review_buf, item)
-  local state = greview_follow_states[review_buf]
-  if not state then
-    return
-  end
-
-  if not vim.api.nvim_buf_is_valid(review_buf) or not greview_pair_valid(state) then
-    stop_greview_follow(review_buf)
-    return
+  if not first then
+    notify('no Greview file selected', vim.log.levels.INFO)
+    return nil
   end
 
   local restore_win = vim.api.nvim_get_current_win()
-  local context = greview_split_context({ bufnr = review_buf, item = item })
-  if not context then
-    close_owned_greview_pair(review_buf)
-    restore_window(restore_win)
-    return
-  end
-
-  local selected = context.selected
-  if (selected.key or selected.file) == (state.key or state.file) then
-    if selected.hunk_index then
-      if split.move_pair_to_hunk_index(state.right_buf, selected.hunk_index) then
-        state.hunk_index = selected.hunk_index
-      end
-    elseif selected.hunk_index ~= state.hunk_index then
-      state.hunk_index = nil
+  close_existing_greview_workspace(normalized.display)
+  local replace_win = opts.replace_win
+  if type(replace_win) == 'number' then
+    if not vim.api.nvim_win_is_valid(replace_win) then
+      notify('Greview split replacement window is no longer valid', vim.log.levels.WARN)
+      return nil
     end
+    vim.api.nvim_set_current_win(replace_win)
+  else
     restore_window(restore_win)
-    return
   end
 
-  local opened = open_greview_split_pair(context, {
-    restore_focus = true,
-    restore_win = restore_win,
+  local diff_buf = create_generated_diff_buffer({
+    name = 'diffs://review-split:' .. normalized.display,
+    lines = diff_lines,
+    repo_root = normalized.repo_root,
+    diff_spec = diff_spec,
+    source = {
+      version = 1,
+      kind = 'review_file',
+      repo_root = normalized.repo_root,
+      review = review_spec,
+      review_display = normalized.display,
+      selected_key = first.key,
+      selected_file = first.file,
+      path = first.file,
+      spec = diff_spec,
+    },
   })
-  if not opened then
-    close_owned_greview_pair(review_buf)
-  end
-  restore_window(restore_win)
-end
 
-schedule_greview_follow = function(review_buf, item)
-  local state = greview_follow_states[review_buf]
-  if not state then
-    return
+  local diff_win = vim.api.nvim_get_current_win()
+  clear_generated_diff_window_bindings(diff_win)
+  pcall(vim.api.nvim_set_option_value, 'diff', false, { win = diff_win })
+  vim.api.nvim_win_set_buf(diff_win, diff_buf)
+  local state = {
+    diff_buf = diff_buf,
+    diff_win = diff_win,
+    review = review_spec,
+    display = normalized.display,
+    repo_root = normalized.repo_root,
+    review_lines = review_lines,
+    list_opts = list_opts,
+    selected_key = first.key or first.file,
+    selected_file = first.file,
+    selected_diff_spec = diff_spec,
+    selected_hunk_index = first.hunk_index,
+    target_scratch = false,
+    autocmds = {},
+  }
+  greview_workspaces[diff_buf] = state
+
+  lists.set_review_workspace_quickfix(diff_buf, review_lines, {
+    title = 'review: ' .. normalized.display,
+    loclist_title = 'review hunks: ' .. normalized.display,
+    metadata_for_line = list_opts and list_opts.metadata_for_line,
+    sections = list_opts and list_opts.sections,
+    store_hunks = list_opts and list_opts.store_hunks,
+  })
+  lists.set_for_unified_buffer(diff_buf, diff_lines, {
+    title = 'review: ' .. (first.key or first.file),
+    loclist_title = 'review hunks: ' .. (first.key or first.file),
+    diff_spec = diff_spec,
+    quickfix = false,
+  })
+  attach_generated_diff_buffer(diff_buf)
+  set_greview_workspace_keymaps(diff_buf)
+  refresh_greview_jump_callback()
+  if not open_workspace_target(state, diff_spec, first) then
+    close_greview_workspace(diff_buf)
+    return nil
   end
-  state.pending_item = item or state.pending_item
-  if state.pending then
-    return
+  move_greview_workspace_to_hunk(state, greview_workspace_hunk(state, first.hunk_index))
+  attach_greview_workspace_autocmds(state)
+
+  if diff_win and vim.api.nvim_win_is_valid(diff_win) then
+    vim.api.nvim_set_current_win(diff_win)
   end
 
-  state.pending = true
-  vim.schedule(function()
-    local current = greview_follow_states[review_buf]
-    if not current then
-      return
-    end
-    local pending_item = current.pending_item
-    current.pending = false
-    current.pending_item = nil
-    follow_greview_selection(review_buf, pending_item)
-  end)
+  return diff_buf
 end
 
 ---@param opts? diffs.GreviewSplitOpts
----@return { left_buf: integer, right_buf: integer, left_win: integer, right_win: integer }?
+---@return integer?
 function M.greview_split(opts)
   local restore_win = vim.api.nvim_get_current_win()
-  local context, err, level, review_buf = greview_split_context(opts)
+  local context, err, level = greview_split_context(opts)
   if not context then
-    if review_buf then
-      close_owned_greview_pair(review_buf)
-      restore_window(restore_win)
-    end
+    restore_window(restore_win)
     notify(err or 'cannot open Greview split', level or vim.log.levels.WARN)
     return nil
   end
 
-  local opened, split_err, split_level = open_greview_split_pair(context, {
-    restore_focus = true,
-    restore_win = restore_win,
-  })
-  if not opened then
+  local source, source_err = get_source_var(context.review_buf)
+  if source_err or not source or source.kind ~= 'review' then
     restore_window(restore_win)
-    notify(split_err or 'cannot open Greview split', split_level or vim.log.levels.ERROR)
+    notify(
+      source_err and ('invalid diffs_source metadata: ' .. tostring(source_err))
+        or 'selected file is not from a Greview buffer',
+      vim.log.levels.WARN
+    )
     return nil
   end
 
-  return opened
+  local review_spec = vim.deepcopy(source.review)
+  review_spec.repo = context.repo_root
+  return open_greview_workspace(review_spec, {
+    selection = context.selected,
+    replace_win = context.replace_win,
+  })
 end
 
 ---@param args? string
@@ -1590,6 +2087,40 @@ function M.read_buffer(bufnr)
     debug_label = debug_label or ((label or '?') .. ':' .. (path or '?'))
   end
 
+  if source and source.kind == 'review_file' then
+    local state = greview_workspaces[bufnr]
+    if state then
+      local selected_file = source.selected_file or source.path
+      if not selected_file then
+        notify('cannot reload Greview split buffer without selected file', vim.log.levels.WARN)
+        return
+      end
+      refresh_greview_workspace_index(state)
+      show_greview_workspace_selection(state, {
+        bufnr = bufnr,
+        file = selected_file,
+        key = source.selected_key or selected_file,
+        diff_spec = state.selected_diff_spec or source.spec,
+        hunk_index = state.selected_hunk_index,
+      }, { restore_focus = true, refresh_index = false })
+      dbg('reloaded Greview split buffer %d (%s)', bufnr, debug_label)
+      return
+    end
+
+    replace_generated_diff_buffer_lines(bufnr, diff_lines, stored_spec)
+    lists.set_for_unified_buffer(bufnr, diff_lines, {
+      title = 'review: ' .. (source.selected_key or source.path),
+      loclist_title = 'review hunks: ' .. (source.selected_key or source.path),
+      diff_spec = stored_spec,
+      quickfix = false,
+    })
+    M.setup_diff_buf(bufnr)
+    set_greview_workspace_keymaps(bufnr)
+    dbg('reloaded Greview split buffer %d (%s)', bufnr, debug_label)
+    runtime.attach(bufnr)
+    return
+  end
+
   replace_generated_diff_buffer_lines(bufnr, diff_lines, stored_spec)
   lists.set_for_unified_buffer(bufnr, diff_lines, {
     title = 'diff: ' .. (debug_label or name:gsub('^diffs://', '')),
@@ -1646,6 +2177,10 @@ M._test = {
   complete_greview = review.complete,
   complete_greview_command = complete_greview_command,
   gdiff_buffer_label = gdiff_buffer_label,
+  close_greview_workspace = close_greview_workspace,
+  greview_workspace_state = function(bufnr)
+    return greview_workspaces[bufnr]
+  end,
   normalize_greview = review.normalize,
   parse_greview_command = review.parse_command_args,
   parse_review_arg = review.parse_arg,

--- a/lua/diffs/lists.lua
+++ b/lua/diffs/lists.lua
@@ -19,6 +19,7 @@ local group = vim.api.nvim_create_augroup('diffs_generated_lists', { clear = fal
 ---@field metadata_for_line? fun(lnum: integer, file: string): table?
 ---@field sections? table[]
 ---@field store_hunks? boolean
+---@field quickfix? boolean
 
 ---@param bufnr integer
 ---@param name string
@@ -392,6 +393,24 @@ local function file_hunk_index(hunks, target)
   return nil
 end
 
+---@param state table
+---@param entry table
+---@return diffs.GeneratedFileSelection
+local function selection_from_entry(state, entry)
+  local hunk = entry.hunks[1]
+  return {
+    bufnr = 0,
+    file = entry.file,
+    key = (hunk and hunk_key(hunk)) or entry.key,
+    section = (hunk and hunk.section) or entry.section,
+    section_label = (hunk and hunk.section_label) or entry.section_label,
+    diff_spec = (hunk and hunk.diff_spec) or entry.diff_spec,
+    lnum = entry.lnum,
+    hunk = hunk,
+    hunk_index = file_hunk_index(state.hunks, hunk),
+  }
+end
+
 ---@param item table?
 ---@return table?
 local function item_diffs_data(item)
@@ -462,6 +481,23 @@ local function set_loclist(win, title, items)
     items = items,
     quickfixtextfunc = 'v:lua._diffs_qftf',
   })
+end
+
+---@param diff_lines string[]
+---@param opts? diffs.GeneratedListOptions
+---@return { hunks: diffs.GdiffHunk[], entries: table[], sections: table[]?, loclist_title: string }
+local function list_state(diff_lines, opts)
+  opts = opts or {}
+  local diff_spec = opts.diff_spec
+  local hunks = hunk_model.parse(diff_lines, diff_spec)
+  local entries = file_entries(hunks, diff_lines, opts)
+  local title = opts.title or 'diffs'
+  return {
+    hunks = hunks,
+    entries = entries,
+    sections = opts.sections,
+    loclist_title = opts.loclist_title or (title .. ' hunks'),
+  }
 end
 
 ---@param bufnr integer
@@ -748,28 +784,79 @@ end
 ---@param opts? diffs.GeneratedListOptions
 function M.set_for_unified_buffer(bufnr, diff_lines, opts)
   opts = opts or {}
-  local diff_spec = opts.diff_spec or buffer_diff_spec(bufnr)
-  local hunks = hunk_model.parse(diff_lines, diff_spec)
-  local entries = file_entries(hunks, diff_lines, opts)
   local title = opts.title or 'diffs'
-  local loclist_title = opts.loclist_title or (title .. ' hunks')
+  opts.diff_spec = opts.diff_spec or buffer_diff_spec(bufnr)
+  local state = list_state(diff_lines, opts)
 
   if opts.store_hunks then
-    vim.api.nvim_buf_set_var(bufnr, 'diffs_hunks', hunks)
+    vim.api.nvim_buf_set_var(bufnr, 'diffs_hunks', state.hunks)
   end
 
   generated_list_state[bufnr] = {
-    hunks = hunks,
-    entries = entries,
-    sections = opts.sections,
-    loclist_title = loclist_title,
+    hunks = state.hunks,
+    entries = state.entries,
+    sections = state.sections,
+    loclist_title = state.loclist_title,
     win_files = {},
   }
   ensure_generated_autocmds(bufnr)
 
-  set_quickfix(title, quickfix_items(bufnr, entries))
+  if opts.quickfix ~= false then
+    set_quickfix(title, quickfix_items(bufnr, state.entries))
+  end
   for _, win in ipairs(windows_for_buffer(bufnr)) do
     refresh_loclist_for_window(bufnr, win, true)
+  end
+end
+
+---@param diff_lines string[]
+---@param opts? diffs.GeneratedListOptions
+---@return diffs.GeneratedFileSelection?
+function M.first_generated_file(diff_lines, opts)
+  local state = list_state(diff_lines, opts)
+  local entry = state.entries[1]
+  if not entry then
+    return nil
+  end
+  return selection_from_entry(state, entry)
+end
+
+---@param diff_lines string[]
+---@param opts? diffs.GeneratedListOptions
+---@return diffs.GeneratedFileSelection[]
+function M.generated_files(diff_lines, opts)
+  local state = list_state(diff_lines, opts)
+  local files = {}
+  for _, entry in ipairs(state.entries) do
+    files[#files + 1] = selection_from_entry(state, entry)
+  end
+  return files
+end
+
+---@param bufnr integer
+---@param diff_lines string[]
+---@param opts? diffs.GeneratedListOptions
+function M.set_review_workspace_quickfix(bufnr, diff_lines, opts)
+  opts = opts or {}
+  local title = opts.title or 'review'
+  local state = list_state(diff_lines, opts)
+  set_quickfix(title, quickfix_items(bufnr, state.entries))
+end
+
+---@param bufnr integer
+---@param diff_lines string[]
+---@param opts? diffs.GeneratedListOptions
+function M.set_loclist_for_buffer(bufnr, diff_lines, opts)
+  opts = opts or {}
+  local state = list_state(diff_lines, {
+    diff_spec = opts.diff_spec or buffer_diff_spec(bufnr),
+    title = opts.title,
+    loclist_title = opts.loclist_title,
+  })
+  local title = state.loclist_title
+  local entry = state.entries[1]
+  for _, win in ipairs(windows_for_buffer(bufnr)) do
+    set_loclist(win, title, loclist_items(bufnr, state.hunks, entry))
   end
 end
 

--- a/lua/diffs/rails.lua
+++ b/lua/diffs/rails.lua
@@ -4,6 +4,7 @@ local hunk_model = require('diffs.hunks')
 
 local bar_slot = '  '
 local separator = ' ┃ '
+local compact_separator = separator:gsub('%s+$', '')
 
 ---@class diffs.RailInfo
 ---@field width integer
@@ -43,6 +44,31 @@ local function new_lnum(line)
   return nil
 end
 
+---@param line diffs.GdiffHunkLine?
+---@param text string
+---@return boolean
+local function is_empty_context_line(line, text)
+  return line ~= nil and line.kind == 'context' and text == ' '
+end
+
+---@param line string
+---@param start_col integer
+---@param end_col integer
+---@return boolean
+local function has_number(line, start_col, end_col)
+  return line:sub(start_col + 1, end_col):find('%d') ~= nil
+end
+
+---@param line string
+---@param prefix_width integer
+---@return boolean
+local function has_context_rails(line, prefix_width)
+  local ranges = M.ranges(prefix_width)
+  return ranges ~= nil
+    and has_number(line, ranges.old_start, ranges.old_end)
+    and has_number(line, ranges.new_start, ranges.new_end)
+end
+
 ---@param lines string[]
 ---@return table<integer, diffs.GdiffHunkLine>, integer
 local function collect_lines(lines)
@@ -73,12 +99,14 @@ function M.annotate(lines)
 
   for lnum, text in ipairs(lines) do
     local line = by_lnum[lnum]
+    local line_separator = is_empty_context_line(line, text) and compact_separator or separator
+    local display_text = is_empty_context_line(line, text) and '' or text
     annotated[lnum] = bar_slot
       .. format_lnum(old_lnum(line), width)
       .. ' '
       .. format_lnum(new_lnum(line), width)
-      .. separator
-      .. text
+      .. line_separator
+      .. display_text
   end
 
   return annotated, {
@@ -94,7 +122,11 @@ function M.strip(line, prefix_width)
   if type(prefix_width) ~= 'number' or prefix_width <= 0 then
     return line
   end
-  return line:sub(prefix_width + 1)
+  local stripped = line:sub(prefix_width + 1)
+  if stripped == '' and has_context_rails(line, prefix_width) then
+    return ' '
+  end
+  return stripped
 end
 
 ---@param lines string[]

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -256,23 +256,6 @@ local function create_mode_only_review_repo()
   }
 end
 
-local function create_mixed_mode_review_repo()
-  local repo = create_mode_only_review_repo()
-
-  git_cmd(repo.repo_root, { 'checkout', '-f', 'mode-base' })
-  write_repo_file(repo.repo_root, 'lua/changed.lua', { 'old' })
-  git_cmd(repo.repo_root, { 'add', 'lua/changed.lua' })
-  git_cmd(repo.repo_root, { 'commit', '-qm', 'add changed file' })
-
-  git_cmd(repo.repo_root, { 'checkout', '-f', 'mode-topic' })
-  git_cmd(repo.repo_root, { 'rebase', 'mode-base' })
-  write_repo_file(repo.repo_root, 'lua/changed.lua', { 'new' })
-  git_cmd(repo.repo_root, { 'add', 'lua/changed.lua' })
-  git_cmd(repo.repo_root, { 'commit', '-qm', 'change file' })
-
-  return repo
-end
-
 local function edit_file(path)
   vim.cmd('edit ' .. vim.fn.fnameescape(path))
   local bufnr = vim.api.nvim_get_current_buf()
@@ -321,23 +304,6 @@ local function find_quickfix_window()
     local buf = vim.api.nvim_win_get_buf(win)
     if vim.api.nvim_get_option_value('buftype', { buf = buf }) == 'quickfix' then
       return win
-    end
-  end
-  return nil
-end
-
----@param loclist boolean
----@return integer?
-local function find_list_window(loclist)
-  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
-    local info = vim.fn.getwininfo(win)[1]
-    if type(info) == 'table' and info.quickfix == 1 then
-      if loclist and info.loclist == 1 then
-        return win
-      end
-      if not loclist and info.loclist == 0 then
-        return win
-      end
     end
   end
   return nil
@@ -2577,131 +2543,419 @@ describe('commands', function()
       assert.are.equal('unstaged:lua/dup.lua', qf[5].user_data.diffs.key)
     end)
 
-    it('opens the first review file in a split pair for Greview layout split', function()
+    local function main_windows()
+      local wins = {}
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local buf = vim.api.nvim_win_get_buf(win)
+        if vim.api.nvim_get_option_value('buftype', { buf = buf }) ~= 'quickfix' then
+          wins[#wins + 1] = win
+        end
+      end
+      return wins
+    end
+
+    local function visible_review_map()
+      for _, win in ipairs(main_windows()) do
+        local name = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(win))
+        if name:match('^diffs://review:') then
+          return win
+        end
+      end
+      return nil
+    end
+
+    local function track_workspace(bufnr)
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+      local state = commands._test.greview_workspace_state(bufnr)
+      assert.is_not_nil(state)
+      assert.are.equal(bufnr, state.diff_buf)
+      if state.target_buf then
+        table.insert(test_buffers, state.target_buf)
+      end
+      return state
+    end
+
+    local function run_buf_keymap(bufnr, lhs)
+      for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, 'n')) do
+        if keymap.lhs == lhs and keymap.callback then
+          keymap.callback()
+          return
+        end
+      end
+      error('missing buffer keymap: ' .. lhs)
+    end
+
+    local function assert_target_at_hunk(state, hunk_index)
+      local hunks = vim.api.nvim_buf_get_var(state.diff_buf, 'diffs_hunks')
+      local hunk = hunks[hunk_index]
+      assert.is_not_nil(hunk)
+      local target_lnum = math.max(1, hunk.new_range.start)
+      assert.are.same({ target_lnum, 0 }, vim.api.nvim_win_get_cursor(state.target_win))
+    end
+
+    local function create_mode_first_review_repo()
+      local repo_root = vim.fn.tempname()
+      vim.fn.mkdir(repo_root, 'p')
+      test_repos[#test_repos + 1] = repo_root
+
+      vim.fn.systemlist({ 'git', 'init', '-q', repo_root })
+      assert.are.equal(0, vim.v.shell_error)
+      git_cmd(repo_root, { 'config', 'user.email', 'test@example.com' })
+      git_cmd(repo_root, { 'config', 'user.name', 'Test' })
+      git_cmd(repo_root, { 'config', 'core.filemode', 'true' })
+
+      write_repo_file(repo_root, 'aaa-mode.sh', { '#!/bin/sh', 'echo mode' })
+      write_repo_file(repo_root, 'zzz-changed.lua', { 'old' })
+      git_cmd(repo_root, { 'add', 'aaa-mode.sh', 'zzz-changed.lua' })
+      git_cmd(repo_root, { 'commit', '-qm', 'base' })
+      git_cmd(repo_root, { 'branch', 'mode-base' })
+
+      git_cmd(repo_root, { 'checkout', '-qb', 'mode-topic' })
+      git_cmd(repo_root, { 'update-index', '--chmod=+x', 'aaa-mode.sh' })
+      write_repo_file(repo_root, 'zzz-changed.lua', { 'new' })
+      git_cmd(repo_root, { 'add', 'aaa-mode.sh', 'zzz-changed.lua' })
+      git_cmd(repo_root, { 'commit', '-qm', 'mode and content' })
+
+      return repo_root
+    end
+
+    it('opens Greview layout split as exactly two visible surfaces', function()
       local repo_root = create_repo()
       vim.fn.writefile({ 'line 1', 'line 2 changed' }, repo_root .. '/file.txt')
-      vim.cmd.edit(vim.fn.fnameescape(repo_root .. '/file.txt'))
+      edit_file(repo_root .. '/file.txt')
       mock_runtime_attach(function() end)
 
-      local bufnr = commands.greview_command('++layout=split HEAD')
+      local diff_buf = commands.greview_command('++layout=split HEAD')
+      local state = track_workspace(diff_buf)
 
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-      local right_buf = vim.api.nvim_buf_get_var(bufnr, 'diffs_review_split_buf')
-      assert.is_true(vim.api.nvim_buf_is_valid(right_buf))
-      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
-      assert.is_true(vim.api.nvim_buf_is_valid(left_buf))
-      table.insert(test_buffers, right_buf)
-      table.insert(test_buffers, left_buf)
+      assert.are.equal('diffs://review-split:HEAD', vim.api.nvim_buf_get_name(diff_buf))
       assert.are.same(
         diffspec.index_to_worktree('file.txt'),
-        vim.api.nvim_buf_get_var(right_buf, 'diffs_spec')
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      assert.are.equal(repo_root .. '/file.txt', vim.api.nvim_buf_get_name(state.target_buf))
+      assert.is_false(state.target_scratch)
+      assert.are.equal(2, #main_windows())
+      assert.is_nil(visible_review_map())
+      assert.is_false(vim.api.nvim_get_option_value('diff', { win = state.diff_win }))
+      assert.is_false(vim.api.nvim_get_option_value('diff', { win = state.target_win }))
+      assert.is_true(buffer_text(diff_buf):find('+line 2 changed', 1, true) ~= nil)
+
+      local qf = quickfix_items()
+      assert.are.equal(1, #qf)
+      assert.are.equal(diff_buf, qf[1].bufnr)
+      assert.is_true(qf[1].text:find('file.txt', 1, true) ~= nil)
+
+      local loc = loclist_items(state.diff_win)
+      assert.are.equal(1, #loc)
+      assert.are.equal(diff_buf, loc[1].bufnr)
+      assert.is_true(loc[1].text:find('file.txt', 1, true) ~= nil)
+    end)
+
+    it('replaces the visible review buffer even when another window is current', function()
+      local repo = create_review_repo()
+      mock_runtime_attach(function() end)
+
+      local review_buf = commands.greview({
+        base = repo.base,
+        target = repo.target,
+        mode = 'direct',
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(review_buf)
+      table.insert(test_buffers, review_buf)
+      local review_win = find_window_for_buffer(review_buf)
+      assert.is_not_nil(review_win)
+
+      vim.cmd('rightbelow vsplit')
+      local source_buf = edit_file(repo.repo_root .. '/lua/one.lua')
+      local source_win = vim.api.nvim_get_current_win()
+
+      local diff_buf = commands.greview_split({ bufnr = review_buf })
+      local state = track_workspace(diff_buf)
+
+      assert.are.equal(review_win, state.diff_win)
+      assert.are.equal(source_buf, vim.api.nvim_win_get_buf(source_win))
+      assert.is_nil(find_window_for_buffer(review_buf))
+      assert.is_not_nil(find_window_for_buffer(state.diff_buf))
+      assert.is_not_nil(find_window_for_buffer(state.target_buf))
+    end)
+
+    it('warns instead of splitting when the selected review buffer is hidden', function()
+      local repo = create_review_repo()
+      local notifications = capture_notifications()
+      mock_runtime_attach(function() end)
+
+      local review_buf = commands.greview({
+        base = repo.base,
+        target = repo.target,
+        mode = 'direct',
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(review_buf)
+      table.insert(test_buffers, review_buf)
+      vim.api.nvim_set_option_value('bufhidden', 'hide', { buf = review_buf })
+
+      local source_buf = edit_file(repo.repo_root .. '/lua/one.lua')
+      local source_win = vim.api.nvim_get_current_win()
+
+      local opened = commands.greview_split({ bufnr = review_buf })
+
+      assert.is_nil(opened)
+      assert.are.equal(source_buf, vim.api.nvim_win_get_buf(source_win))
+      assert.is_true(
+        notifications[#notifications].message:find(
+          'selected Greview buffer is not visible',
+          1,
+          true
+        ) ~= nil
       )
     end)
 
-    it('routes duplicate current-state review paths by section for split projection', function()
-      local repo = create_current_state_review_repo()
-      mock_runtime_attach(function() end)
-
-      local bufnr = commands.greview({
-        base = repo.base,
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-      local review_win = vim.api.nvim_get_current_win()
-
-      local branch_line =
-        find_buffer_line_after(bufnr, '# Branch:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
-      assert.is_not_nil(branch_line)
-      vim.api.nvim_win_set_cursor(review_win, { branch_line, 0 })
-      local branch_opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(branch_opened)
-      table.insert(test_buffers, branch_opened.left_buf)
-      table.insert(test_buffers, branch_opened.right_buf)
-      assert.are.same(
-        diffspec.rev_to_rev(repo.base, 'HEAD', 'lua/dup.lua'),
-        vim.api.nvim_buf_get_var(branch_opened.right_buf, 'diffs_spec')
-      )
-
-      vim.api.nvim_set_current_win(review_win)
-      local staged_line =
-        find_buffer_line_after(bufnr, '# Staged:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
-      assert.is_not_nil(staged_line)
-      vim.api.nvim_win_set_cursor(review_win, { staged_line, 0 })
-      local staged_opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(staged_opened)
-      table.insert(test_buffers, staged_opened.left_buf)
-      table.insert(test_buffers, staged_opened.right_buf)
-      assert.are.same(
-        diffspec.head_to_index('lua/dup.lua'),
-        vim.api.nvim_buf_get_var(staged_opened.right_buf, 'diffs_spec')
-      )
-
-      vim.api.nvim_set_current_win(review_win)
-      local unstaged_line =
-        find_buffer_line_after(bufnr, '# Unstaged:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
-      assert.is_not_nil(unstaged_line)
-      vim.api.nvim_win_set_cursor(review_win, { unstaged_line, 0 })
-      local unstaged_opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(unstaged_opened)
-      table.insert(test_buffers, unstaged_opened.left_buf)
-      table.insert(test_buffers, unstaged_opened.right_buf)
-      assert.are.same(
-        diffspec.index_to_worktree('lua/dup.lua'),
-        vim.api.nvim_buf_get_var(unstaged_opened.right_buf, 'diffs_spec')
-      )
-    end)
-
-    it('follows duplicate current-state review paths by section identity', function()
-      local repo = create_current_state_review_repo()
-      mock_runtime_attach(function() end)
-
-      local bufnr = commands.greview({
-        base = repo.base,
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-      local review_win = vim.api.nvim_get_current_win()
-
-      local branch_line =
-        find_buffer_line_after(bufnr, '# Branch:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
-      assert.is_not_nil(branch_line)
-      vim.api.nvim_win_set_cursor(review_win, { branch_line, 0 })
-      local opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(opened)
-      table.insert(test_buffers, opened.left_buf)
-      table.insert(test_buffers, opened.right_buf)
-
-      local staged_line =
-        find_buffer_line_after(bufnr, '# Staged:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
-      assert.is_not_nil(staged_line)
-      vim.api.nvim_set_current_win(review_win)
-      vim.api.nvim_win_set_cursor(review_win, { staged_line, 0 })
-      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
-
-      local followed_right
-      vim.wait(100, function()
-        local ok, right = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_review_split_buf')
-        if not ok or right == opened.right_buf or not vim.api.nvim_buf_is_valid(right) then
-          return false
-        end
-        local spec = vim.api.nvim_buf_get_var(right, 'diffs_spec')
-        if spec.left and spec.left.kind == 'tree' and spec.left.rev == 'HEAD' then
-          followed_right = right
-          return true
-        end
-        return false
+    it('closes an existing Greview split workspace before opening another spec', function()
+      local repo = create_review_repo()
+      mock_repo_root(function()
+        return repo.repo_root
       end)
+      mock_runtime_attach(function() end)
 
-      assert.is_not_nil(followed_right)
-      table.insert(test_buffers, followed_right)
-      table.insert(test_buffers, vim.api.nvim_buf_get_var(followed_right, 'diffs_split_peer'))
-      assert.are.same(
-        diffspec.head_to_index('lua/dup.lua'),
-        vim.api.nvim_buf_get_var(followed_right, 'diffs_spec')
+      local first =
+        commands.greview_command(('++layout=split %s..%s'):format(repo.base, repo.target))
+      local first_state = track_workspace(first)
+      local first_target_win = first_state.target_win
+
+      local second =
+        commands.greview_command(('++layout=split %s...%s'):format(repo.base, repo.target))
+      local second_state = track_workspace(second)
+
+      assert.is_false(vim.api.nvim_buf_is_valid(first))
+      assert.is_false(vim.api.nvim_win_is_valid(first_target_win))
+      assert.is_nil(commands._test.greview_workspace_state(first))
+      assert.is_not_nil(commands._test.greview_workspace_state(second))
+      assert.are.equal(2, #main_windows())
+      assert.are.equal(
+        'diffs://review-split:' .. repo.base .. '...' .. repo.target,
+        vim.api.nvim_buf_get_name(second)
       )
+      assert.is_not_nil(find_window_for_buffer(second_state.diff_buf))
+      assert.is_not_nil(find_window_for_buffer(second_state.target_buf))
+    end)
+
+    it('skips unsupported default review entries when opening direct split workspaces', function()
+      local repo_root = create_mode_first_review_repo()
+      edit_file(repo_root .. '/zzz-changed.lua')
+      mock_runtime_attach(function() end)
+
+      local diff_buf = commands.greview_command('++layout=split mode-base..mode-topic')
+      track_workspace(diff_buf)
+
+      assert.are.same(
+        diffspec.rev_to_rev('mode-base', 'mode-topic', 'zzz-changed.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      assert.is_true(buffer_text(diff_buf):find('+new', 1, true) ~= nil)
+    end)
+
+    it('routes current-state duplicate paths by section in the two-surface workspace', function()
+      local repo = create_current_state_review_repo()
+      mock_runtime_attach(function() end)
+
+      local function open_section(header, expected_spec, target_scratch)
+        local review_buf = commands.greview({
+          base = repo.base,
+          repo = repo.repo_root,
+        })
+        assert.is_not_nil(review_buf)
+        table.insert(test_buffers, review_buf)
+
+        local line =
+          find_buffer_line_after(review_buf, header, 'diff --git a/lua/dup.lua b/lua/dup.lua')
+        assert.is_not_nil(line)
+        vim.api.nvim_win_set_cursor(0, { line, 0 })
+
+        local diff_buf = commands.greview_split({ bufnr = review_buf })
+        local state = track_workspace(diff_buf)
+        assert.are.same(expected_spec, vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec'))
+        assert.are.equal(target_scratch, state.target_scratch)
+        assert.is_not_nil(find_window_for_buffer(state.diff_buf))
+        assert.is_not_nil(find_window_for_buffer(state.target_buf))
+        assert.is_nil(find_window_for_buffer(review_buf))
+        assert.is_nil(visible_review_map())
+        commands._test.close_greview_workspace(diff_buf)
+      end
+
+      open_section('# Branch:', diffspec.rev_to_rev(repo.base, 'HEAD', 'lua/dup.lua'), true)
+      open_section('# Staged:', diffspec.head_to_index('lua/dup.lua'), true)
+      open_section('# Unstaged:', diffspec.index_to_worktree('lua/dup.lua'), false)
+    end)
+
+    it('uses quickfix for review files and loclist for active-file hunks', function()
+      local repo = create_review_repo()
+      edit_file(repo.repo_root .. '/lua/one.lua')
+      mock_runtime_attach(function() end)
+
+      local diff_buf =
+        commands.greview_command(('++layout=split %s..%s'):format(repo.base, repo.target))
+      local state = track_workspace(diff_buf)
+      assert.are.same(
+        diffspec.rev_to_rev(repo.base, repo.target, 'lua/one.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+
+      local qf = quickfix_items()
+      assert.are.equal(2, #qf)
+      assert.are.equal(diff_buf, qf[1].bufnr)
+      assert.are.equal(diff_buf, qf[2].bufnr)
+
+      vim.cmd('copen')
+      local qf_win = find_quickfix_window()
+      assert.is_not_nil(qf_win)
+      vim.api.nvim_set_current_win(qf_win)
+      vim.api.nvim_win_set_cursor(qf_win, { 2, 0 })
+      vim.cmd('normal \r')
+
+      vim.wait(100, function()
+        return commands._test.greview_workspace_state(diff_buf).selected_file == 'lua/two.lua'
+      end)
+      state = commands._test.greview_workspace_state(diff_buf)
+      assert.are.same(
+        diffspec.rev_to_rev(repo.base, repo.target, 'lua/two.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      assert.is_true(state.target_scratch)
+      assert.is_true(buffer_text(diff_buf):find('+line 11 changed', 1, true) ~= nil)
+      assert_target_at_hunk(state, 1)
+
+      vim.api.nvim_set_current_win(state.diff_win)
+      vim.cmd('lopen')
+      local loc_win = find_loclist_window_for_window(state.diff_win)
+      assert.is_not_nil(loc_win)
+      local loc = loclist_items(state.diff_win)
+      assert.are.equal(2, #loc)
+      vim.api.nvim_set_current_win(loc_win)
+      vim.api.nvim_win_set_cursor(loc_win, { 2, 0 })
+      vim.cmd('normal \r')
+
+      vim.wait(100, function()
+        return vim.api.nvim_win_get_cursor(state.diff_win)[1] == loc[2].lnum
+      end)
+      assert.are.same({ loc[2].lnum, 0 }, vim.api.nvim_win_get_cursor(state.diff_win))
+      assert_target_at_hunk(state, 2)
+
+      vim.api.nvim_set_current_win(state.diff_win)
+      run_buf_keymap(diff_buf, '[c')
+      assert_target_at_hunk(state, 1)
+      run_buf_keymap(diff_buf, ']c')
+      assert_target_at_hunk(state, 2)
+    end)
+
+    it('refreshes the generated diff when the editable target is written', function()
+      local repo_root = create_repo()
+      vim.fn.writefile({ 'line 1', 'line 2 changed' }, repo_root .. '/file.txt')
+      edit_file(repo_root .. '/file.txt')
+      mock_runtime_attach(function() end)
+
+      local diff_buf = commands.greview_command('++layout=split HEAD')
+      local state = track_workspace(diff_buf)
+
+      vim.api.nvim_set_current_win(state.target_win)
+      vim.api.nvim_buf_set_lines(state.target_buf, 1, 2, false, { 'line 2 saved' })
+      vim.cmd.write()
+
+      vim.wait(100, function()
+        return buffer_text(diff_buf):find('+line 2 saved', 1, true) ~= nil
+      end)
+      assert.is_true(buffer_text(diff_buf):find('+line 2 saved', 1, true) ~= nil)
+      assert.is_false(buffer_text(diff_buf):find('+line 2 changed', 1, true) ~= nil)
+    end)
+
+    it('invalidates generated highlighting after same-size untracked target saves', function()
+      local repo_root = create_repo()
+      write_repo_file(repo_root, 'untracked.lua', { 'return "one"' })
+      edit_file(repo_root .. '/file.txt')
+      saved_schedule = vim.schedule
+      vim.schedule = function(callback)
+        callback()
+      end
+
+      local diff_buf = commands.greview_command('++layout=split HEAD')
+      local state = track_workspace(diff_buf)
+      assert.are.equal('untracked.lua', state.selected_file)
+
+      runtime.attach(diff_buf)
+      runtime._test.ensure_cache(diff_buf)
+      assert.is_not_nil(runtime._test.hunk_cache[diff_buf])
+
+      vim.api.nvim_set_current_win(state.target_win)
+      vim.api.nvim_buf_set_lines(state.target_buf, 0, -1, false, { 'return "two"' })
+      vim.cmd.write()
+
+      vim.wait(100, function()
+        return buffer_text(diff_buf):find('+return "two"', 1, true) ~= nil
+      end)
+      runtime._test.ensure_cache(diff_buf)
+      runtime._test.process_pending_clear(diff_buf)
+
+      local entry = runtime._test.hunk_cache[diff_buf]
+      assert.is_not_nil(entry)
+      assert.are.equal(vim.api.nvim_buf_get_changedtick(diff_buf), entry.tick)
+      assert.is_false(entry.pending_clear)
+      assert.is_true(#entry.hunks > 0)
+    end)
+
+    it('refreshes read-only target buffers through the Greview split reload path', function()
+      local repo = create_current_state_review_repo()
+      mock_runtime_attach(function() end)
+
+      local review_buf = commands.greview({
+        base = repo.base,
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(review_buf)
+      table.insert(test_buffers, review_buf)
+
+      local staged_line =
+        find_buffer_line_after(review_buf, '# Staged:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
+      assert.is_not_nil(staged_line)
+      vim.api.nvim_win_set_cursor(0, { staged_line, 0 })
+
+      local diff_buf = commands.greview_split({ bufnr = review_buf })
+      local state = track_workspace(diff_buf)
+      assert.is_true(state.target_scratch)
+      assert.is_true(buffer_text(state.target_buf):find('dup staged', 1, true) ~= nil)
+
+      write_repo_file(repo.repo_root, 'lua/dup.lua', { 'dup restaged' })
+      git_cmd(repo.repo_root, { 'add', 'lua/dup.lua' })
+      write_repo_file(repo.repo_root, 'lua/dup.lua', { 'dup unstaged again' })
+
+      commands.read_buffer(diff_buf)
+
+      vim.wait(100, function()
+        return buffer_text(state.target_buf):find('dup restaged', 1, true) ~= nil
+      end)
+      assert.is_true(buffer_text(diff_buf):find('+dup restaged', 1, true) ~= nil)
+      assert.is_true(buffer_text(state.target_buf):find('dup restaged', 1, true) ~= nil)
+    end)
+
+    it('closes both Greview split surfaces from the generated diff buffer', function()
+      local repo_root = create_repo()
+      vim.fn.writefile({ 'line 1', 'line 2 changed' }, repo_root .. '/file.txt')
+      edit_file(repo_root .. '/file.txt')
+      mock_runtime_attach(function() end)
+
+      local diff_buf = commands.greview_command('++layout=split HEAD')
+      local state = track_workspace(diff_buf)
+      local diff_win = state.diff_win
+      local target_win = state.target_win
+
+      run_buf_keymap(diff_buf, 'q')
+
+      assert.is_false(vim.api.nvim_buf_is_valid(diff_buf))
+      assert.is_true(vim.api.nvim_win_is_valid(diff_win))
+      assert.are_not.equal(diff_buf, vim.api.nvim_win_get_buf(diff_win))
+      assert.is_false(vim.api.nvim_win_is_valid(target_win))
+      assert.is_nil(commands._test.greview_workspace_state(diff_buf))
     end)
 
     it('skips binary untracked files in current-state reviews', function()
@@ -2728,7 +2982,7 @@ describe('commands', function()
       assert.is_true(qf[1].text:find('[Untracked] lua/new.lua', 1, true) ~= nil)
     end)
 
-    it('routes current-state conflict reviews to read-only unmerged stage specs', function()
+    it('routes current-state conflict reviews to read-only unmerged target views', function()
       local repo_root = create_conflicted_repo()
       mock_runtime_attach(function() end)
 
@@ -2741,632 +2995,60 @@ describe('commands', function()
 
       local text = buffer_text(bufnr)
       assert.is_false(text:find('# Staged:', 1, true) ~= nil)
-      assert.is_false(text:find('* Unmerged path', 1, true) ~= nil)
       assert.is_true(text:find('# Unstaged:', 1, true) ~= nil)
-      assert.is_true(text:find('diff --git a/file.txt b/file.txt', 1, true) ~= nil)
       assert.is_true(text:find('-line 2 theirs', 1, true) ~= nil)
       assert.is_true(text:find('+line 2 ours', 1, true) ~= nil)
-      assert.is_false(helpers.has_keymap(bufnr, 'do'))
-      assert.is_false(helpers.has_keymap(bufnr, 'dp'))
 
       local qf = quickfix_items()
       assert.are.equal(1, #qf)
-      assert.is_true(qf[1].text:find('[Unstaged] file.txt', 1, true) ~= nil)
       assert.are.equal('unstaged', qf[1].user_data.diffs.section)
       assert.are.same(diffspec.rev_to_rev(':2', ':3', 'file.txt'), qf[1].user_data.diffs.diff_spec)
 
       local header_line = find_buffer_line(bufnr, '# Unstaged:')
       assert.is_not_nil(header_line)
       vim.api.nvim_win_set_cursor(0, { header_line, 0 })
-      local opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(opened)
-      table.insert(test_buffers, opened.left_buf)
-      table.insert(test_buffers, opened.right_buf)
+      local diff_buf = commands.greview_split({ bufnr = bufnr })
+      local state = track_workspace(diff_buf)
+
       assert.are.same(
         diffspec.rev_to_rev(':2', ':3', 'file.txt'),
-        vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_spec')
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
       )
-      assert.is_true(buffer_text(opened.left_buf):find('line 2 theirs', 1, true) ~= nil)
-      assert.is_true(buffer_text(opened.right_buf):find('line 2 ours', 1, true) ~= nil)
-    end)
-
-    it(
-      'uses quickfix as the review file index and loclist as the active file hunk index',
-      function()
-        mock_repo_root(function(path)
-          assert.are.equal('/tmp/repo/.', path)
-          return '/tmp/repo'
-        end)
-        mock_systemlist(function(cmd)
-          if cmd[4] == 'rev-parse' then
-            return { 'commit' }
-          end
-          if cmd[4] == 'merge-base' then
-            return { 'merge-base-commit' }
-          end
-          if cmd[4] ~= 'diff' then
-            return {}
-          end
-          return {
-            'diff --git a/lua/one.lua b/lua/one.lua',
-            '--- a/lua/one.lua',
-            '+++ b/lua/one.lua',
-            '@@ -1 +1 @@',
-            '-old one',
-            '+new one',
-            'diff --git a/lua/two.lua b/lua/two.lua',
-            '--- a/lua/two.lua',
-            '+++ b/lua/two.lua',
-            '@@ -1 +1 @@',
-            '-old two',
-            '+new two',
-            '@@ -5 +5 @@',
-            '-older two',
-            '+newer two',
-          }
-        end)
-        mock_runtime_attach(function() end)
-
-        local bufnr = commands.greview({
-          base = 'origin/main',
-          target = 'refs/forge/pr/42',
-          mode = 'merge-base',
-          repo = '/tmp/repo',
-        })
-        table.insert(test_buffers, bufnr)
-
-        local qf = quickfix_items()
-        assert.are.equal(2, #qf)
-        assert.are.equal(bufnr, qf[1].bufnr)
-        assert.are.equal(1, qf[1].lnum)
-        assert.is_true(qf[1].text:find('lua/one.lua', 1, true) ~= nil)
-        assert.are.equal(bufnr, qf[2].bufnr)
-        assert.are.equal(7, qf[2].lnum)
-        assert.is_true(qf[2].text:find('lua/two.lua', 1, true) ~= nil)
-
-        local loc = loclist_items()
-        assert.are.equal(1, #loc)
-        assert.are.equal(4, loc[1].lnum)
-        assert.is_true(loc[1].text:find('lua/one.lua', 1, true) ~= nil)
-
-        vim.api.nvim_win_set_cursor(0, { 7, 0 })
-        vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
-
-        loc = loclist_items()
-        assert.are.equal(2, #loc)
-        assert.are.equal(10, loc[1].lnum)
-        assert.are.equal(13, loc[2].lnum)
-        assert.is_true(loc[1].text:find('lua/two.lua', 1, true) ~= nil)
-        assert.is_true(loc[2].text:find('lua/two.lua', 1, true) ~= nil)
-      end
-    )
-
-    it(
-      'opens the cursor-selected review file in a split pair without replacing the review map',
-      function()
-        local repo = create_review_repo()
-        mock_runtime_attach(function() end)
-
-        local bufnr = commands.greview({
-          base = repo.base,
-          target = repo.target,
-          mode = 'direct',
-          repo = repo.repo_root,
-        })
-        assert.is_not_nil(bufnr)
-        table.insert(test_buffers, bufnr)
-
-        local review_win = vim.api.nvim_get_current_win()
-        local second_hunk_line = find_buffer_line(bufnr, '+line 11 changed')
-        assert.is_not_nil(second_hunk_line)
-        vim.api.nvim_win_set_cursor(review_win, { second_hunk_line, 0 })
-
-        local opened = commands.greview_split({ bufnr = bufnr })
-        assert.is_not_nil(opened)
-        table.insert(test_buffers, opened.left_buf)
-        table.insert(test_buffers, opened.right_buf)
-
-        assert.are.equal(bufnr, vim.api.nvim_win_get_buf(review_win))
-        assert.is_not_nil(find_window_for_buffer(bufnr))
-        assert.are.equal(
-          'diffs://review:' .. repo.base .. '..' .. repo.target,
-          vim.api.nvim_buf_get_name(bufnr)
-        )
-        assert.are.equal(
-          'diffs://split:left:' .. repo.base .. ':lua/two.lua',
-          vim.api.nvim_buf_get_name(opened.left_buf)
-        )
-        assert.are.equal(
-          'diffs://split:right:' .. repo.target .. ':lua/two.lua',
-          vim.api.nvim_buf_get_name(opened.right_buf)
-        )
-        assert.are.same(
-          diffspec.rev_to_rev(repo.base, repo.target, 'lua/two.lua'),
-          vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_spec')
-        )
-        assert.are.equal(
-          'lua',
-          vim.api.nvim_get_option_value('filetype', { buf = opened.left_buf })
-        )
-        assert.are.equal(
-          'lua',
-          vim.api.nvim_get_option_value('filetype', { buf = opened.right_buf })
-        )
-
-        local split_hunks = vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_split_hunks')
-        assert.are.equal(2, #split_hunks)
-        assert.are.same(
-          { split_hunks[2].new_range.start, 0 },
-          vim.api.nvim_win_get_cursor(opened.right_win)
-        )
-
-        local qf = quickfix_items()
-        assert.are.equal(2, #qf)
-        assert.are.equal(bufnr, qf[1].bufnr)
-        assert.are.equal(bufnr, qf[2].bufnr)
-      end
-    )
-
-    it('opens the quickfix-selected review file independent of review cursor position', function()
-      local repo = create_review_repo()
-      mock_runtime_attach(function() end)
-
-      local bufnr = commands.greview({
-        base = repo.base,
-        target = repo.target,
-        mode = 'direct',
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-
-      local first_file_line = find_buffer_line(bufnr, '+new one')
-      assert.is_not_nil(first_file_line)
-      vim.api.nvim_win_set_cursor(0, { first_file_line, 0 })
-
-      vim.cmd('copen')
-      local qf_win = find_quickfix_window()
-      assert.is_not_nil(qf_win)
-      vim.api.nvim_set_current_win(qf_win)
-      vim.api.nvim_win_set_cursor(qf_win, { 2, 0 })
-
-      local opened = commands.greview_split()
-      assert.is_not_nil(opened)
-      table.insert(test_buffers, opened.left_buf)
-      table.insert(test_buffers, opened.right_buf)
-
-      assert.are.same(
-        diffspec.rev_to_rev(repo.base, repo.target, 'lua/two.lua'),
-        vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_spec')
-      )
-      assert.is_not_nil(find_window_for_buffer(bufnr))
-    end)
-
-    it('preserves the review quickfix when reloading an auxiliary review split pair', function()
-      local repo = create_review_repo()
-      mock_runtime_attach(function() end)
-
-      local bufnr = commands.greview({
-        base = repo.base,
-        target = repo.target,
-        mode = 'direct',
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-
-      local two_line = find_buffer_line(bufnr, '+line 2 changed')
-      assert.is_not_nil(two_line)
-      vim.api.nvim_win_set_cursor(0, { two_line, 0 })
-
-      local opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(opened)
-      table.insert(test_buffers, opened.left_buf)
-      table.insert(test_buffers, opened.right_buf)
-
-      local qf = quickfix_items()
-      assert.are.equal(2, #qf)
-      assert.are.equal(bufnr, qf[1].bufnr)
-      assert.are.equal(bufnr, qf[2].bufnr)
-
-      commands.read_buffer(opened.right_buf)
-
-      qf = quickfix_items()
-      assert.are.equal(2, #qf)
-      assert.are.equal(bufnr, qf[1].bufnr)
-      assert.are.equal(bufnr, qf[2].bufnr)
-    end)
-
-    it('replaces the previous review split pair when another review file is selected', function()
-      local repo = create_review_repo()
-      mock_runtime_attach(function() end)
-
-      local bufnr = commands.greview({
-        base = repo.base,
-        target = repo.target,
-        mode = 'direct',
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-      local review_win = vim.api.nvim_get_current_win()
-
-      local two_line = find_buffer_line(bufnr, '+line 2 changed')
-      assert.is_not_nil(two_line)
-      vim.api.nvim_win_set_cursor(review_win, { two_line, 0 })
-      local first_opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(first_opened)
-      table.insert(test_buffers, first_opened.left_buf)
-      table.insert(test_buffers, first_opened.right_buf)
-
-      vim.api.nvim_set_current_win(review_win)
-      local one_line = find_buffer_line(bufnr, '+new one')
-      assert.is_not_nil(one_line)
-      vim.api.nvim_win_set_cursor(review_win, { one_line, 0 })
-      local second_opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(second_opened)
-      table.insert(test_buffers, second_opened.left_buf)
-      table.insert(test_buffers, second_opened.right_buf)
-
-      assert.is_false(vim.api.nvim_buf_is_valid(first_opened.left_buf))
-      assert.is_false(vim.api.nvim_buf_is_valid(first_opened.right_buf))
-      assert.are.same(
-        diffspec.rev_to_rev(repo.base, repo.target, 'lua/one.lua'),
-        vim.api.nvim_buf_get_var(second_opened.right_buf, 'diffs_spec')
-      )
-    end)
-
-    it('follows review file transitions after the split pair is opened once', function()
-      local repo = create_review_repo()
-      mock_runtime_attach(function() end)
-
-      local bufnr = commands.greview({
-        base = repo.base,
-        target = repo.target,
-        mode = 'direct',
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-      local review_win = vim.api.nvim_get_current_win()
-
-      local two_line = find_buffer_line(bufnr, '+line 2 changed')
-      assert.is_not_nil(two_line)
-      vim.api.nvim_win_set_cursor(review_win, { two_line, 0 })
-      local opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(opened)
-      table.insert(test_buffers, opened.left_buf)
-      table.insert(test_buffers, opened.right_buf)
-
-      vim.api.nvim_set_current_win(review_win)
-      local one_line = find_buffer_line(bufnr, '+new one')
-      assert.is_not_nil(one_line)
-      vim.api.nvim_win_set_cursor(review_win, { one_line, 0 })
-      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
-
-      local followed_right
-      vim.wait(100, function()
-        local ok, right = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_review_split_buf')
-        if not ok or right == opened.right_buf or not vim.api.nvim_buf_is_valid(right) then
-          return false
-        end
-        local spec = vim.api.nvim_buf_get_var(right, 'diffs_spec')
-        if spec.scope and spec.scope.path == 'lua/one.lua' then
-          followed_right = right
-          return true
-        end
-        return false
-      end)
-
-      assert.is_not_nil(followed_right)
-      table.insert(test_buffers, followed_right)
-      table.insert(test_buffers, vim.api.nvim_buf_get_var(followed_right, 'diffs_split_peer'))
-      assert.is_false(vim.api.nvim_buf_is_valid(opened.left_buf))
-      assert.is_false(vim.api.nvim_buf_is_valid(opened.right_buf))
-      assert.are.equal(review_win, vim.api.nvim_get_current_win())
-
-      local qf = quickfix_items()
-      assert.are.equal(2, #qf)
-      assert.are.equal(bufnr, qf[1].bufnr)
-      assert.are.equal(bufnr, qf[2].bufnr)
-    end)
-
-    it('moves same-file review hunk transitions through the existing split pair', function()
-      local repo = create_review_repo()
-      mock_runtime_attach(function() end)
-
-      local bufnr = commands.greview({
-        base = repo.base,
-        target = repo.target,
-        mode = 'direct',
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-      local review_win = vim.api.nvim_get_current_win()
-
-      local first_hunk_line = find_buffer_line(bufnr, '+line 2 changed')
-      assert.is_not_nil(first_hunk_line)
-      vim.api.nvim_win_set_cursor(review_win, { first_hunk_line, 0 })
-      local opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(opened)
-      table.insert(test_buffers, opened.left_buf)
-      table.insert(test_buffers, opened.right_buf)
-      local split_hunks = vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_split_hunks')
-
-      vim.api.nvim_set_current_win(review_win)
-      local second_hunk_line = find_buffer_line(bufnr, '+line 11 changed')
-      assert.is_not_nil(second_hunk_line)
-      vim.api.nvim_win_set_cursor(review_win, { second_hunk_line, 0 })
-      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
-
-      vim.wait(100, function()
-        return vim.api.nvim_win_get_cursor(opened.right_win)[1] == split_hunks[2].new_range.start
-      end)
-
-      assert.are.equal(opened.right_buf, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_split_buf'))
-      assert.are.same(
-        { split_hunks[2].old_range.start, 0 },
-        vim.api.nvim_win_get_cursor(opened.left_win)
-      )
-      assert.are.same(
-        { split_hunks[2].new_range.start, 0 },
-        vim.api.nvim_win_get_cursor(opened.right_win)
-      )
-      assert.are.equal(review_win, vim.api.nvim_get_current_win())
-    end)
-
-    it('updates the owned split pair after review quickfix and loclist jumps', function()
-      local repo = create_review_repo()
-      mock_runtime_attach(function() end)
-
-      local bufnr = commands.greview({
-        base = repo.base,
-        target = repo.target,
-        mode = 'direct',
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-
-      local one_line = find_buffer_line(bufnr, '+new one')
-      assert.is_not_nil(one_line)
-      vim.api.nvim_win_set_cursor(0, { one_line, 0 })
-      local opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(opened)
-      table.insert(test_buffers, opened.left_buf)
-      table.insert(test_buffers, opened.right_buf)
-
-      vim.cmd('copen')
-      local qf_win = find_list_window(false)
-      assert.is_not_nil(qf_win)
-      vim.api.nvim_set_current_win(qf_win)
-      vim.api.nvim_win_set_cursor(qf_win, { 2, 0 })
-      vim.cmd('normal \r')
-
-      local followed_right
-      vim.wait(100, function()
-        local ok, right = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_review_split_buf')
-        if not ok or right == opened.right_buf or not vim.api.nvim_buf_is_valid(right) then
-          return false
-        end
-        local spec = vim.api.nvim_buf_get_var(right, 'diffs_spec')
-        if spec.scope and spec.scope.path == 'lua/two.lua' then
-          followed_right = right
-          return true
-        end
-        return false
-      end)
-
-      assert.is_not_nil(followed_right)
-      table.insert(test_buffers, followed_right)
-      local followed_left = vim.api.nvim_buf_get_var(followed_right, 'diffs_split_peer')
-      table.insert(test_buffers, followed_left)
-
-      local review_win = find_window_for_buffer(bufnr)
-      assert.is_not_nil(review_win)
-      vim.api.nvim_set_current_win(review_win)
-      vim.cmd('lopen')
-      local loc_win = find_loclist_window_for_window(review_win)
-      assert.is_not_nil(loc_win)
-      vim.api.nvim_set_current_win(loc_win)
-      vim.api.nvim_win_set_cursor(loc_win, { 2, 0 })
-      vim.cmd('normal \r')
-
-      local right_win = find_window_for_buffer(followed_right)
-      local left_win = find_window_for_buffer(followed_left)
-      local split_hunks = vim.api.nvim_buf_get_var(followed_right, 'diffs_split_hunks')
-      vim.wait(100, function()
-        return right_win
-          and vim.api.nvim_win_is_valid(right_win)
-          and vim.api.nvim_win_get_cursor(right_win)[1] == split_hunks[2].new_range.start
-      end)
-
-      assert.are.equal(followed_right, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_split_buf'))
-      assert.are.same({ split_hunks[2].old_range.start, 0 }, vim.api.nvim_win_get_cursor(left_win))
-      assert.are.same({ split_hunks[2].new_range.start, 0 }, vim.api.nvim_win_get_cursor(right_win))
-    end)
-
-    it('stops following after the owned split pair is closed', function()
-      local repo = create_review_repo()
-      mock_runtime_attach(function() end)
-
-      local bufnr = commands.greview({
-        base = repo.base,
-        target = repo.target,
-        mode = 'direct',
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-      local review_win = vim.api.nvim_get_current_win()
-
-      local two_line = find_buffer_line(bufnr, '+line 2 changed')
-      assert.is_not_nil(two_line)
-      vim.api.nvim_win_set_cursor(review_win, { two_line, 0 })
-      local opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(opened)
-
-      split.close_pair(opened.right_buf)
-      assert.is_false(vim.api.nvim_buf_is_valid(opened.left_buf))
-      assert.is_false(vim.api.nvim_buf_is_valid(opened.right_buf))
-      assert.is_false(has_buf_var(bufnr, 'diffs_review_split_buf'))
-
-      vim.api.nvim_set_current_win(review_win)
-      local one_line = find_buffer_line(bufnr, '+new one')
-      assert.is_not_nil(one_line)
-      vim.api.nvim_win_set_cursor(review_win, { one_line, 0 })
-      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
-
-      assert.is_false(has_buf_var(bufnr, 'diffs_review_split_buf'))
-    end)
-
-    it('closes stale review split pairs for unsupported auto-follow selections', function()
-      local repo = create_mixed_mode_review_repo()
-      local notifications = capture_notifications()
-      mock_runtime_attach(function() end)
-
-      local bufnr = commands.greview({
-        base = repo.base,
-        target = repo.target,
-        mode = 'direct',
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-      local review_win = vim.api.nvim_get_current_win()
-
-      local changed_line = find_buffer_line(bufnr, '+new')
-      assert.is_not_nil(changed_line)
-      vim.api.nvim_win_set_cursor(review_win, { changed_line, 0 })
-      local opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(opened)
-
-      local mode_line = find_buffer_line(bufnr, 'diff --git a/scripts/tool.sh b/scripts/tool.sh')
-      assert.is_not_nil(mode_line)
-      vim.api.nvim_set_current_win(review_win)
-      vim.api.nvim_win_set_cursor(review_win, { mode_line, 0 })
-      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
-
-      vim.wait(100, function()
-        return not vim.api.nvim_buf_is_valid(opened.right_buf)
-          and not has_buf_var(bufnr, 'diffs_review_split_buf')
-      end)
-
-      assert.is_false(vim.api.nvim_buf_is_valid(opened.left_buf))
-      assert.is_false(vim.api.nvim_buf_is_valid(opened.right_buf))
-      assert.is_false(has_buf_var(bufnr, 'diffs_review_split_buf'))
-      assert.are.equal(0, #notifications)
-    end)
-
-    it('keeps Greview follow compatible with split-pair cursor sync', function()
-      local repo = create_review_repo()
-      mock_runtime_attach(function() end)
-
-      local bufnr = commands.greview({
-        base = repo.base,
-        target = repo.target,
-        mode = 'direct',
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-      local review_win = vim.api.nvim_get_current_win()
-
-      local first_hunk_line = find_buffer_line(bufnr, '+line 2 changed')
-      assert.is_not_nil(first_hunk_line)
-      vim.api.nvim_win_set_cursor(review_win, { first_hunk_line, 0 })
-      local opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(opened)
-      table.insert(test_buffers, opened.left_buf)
-      table.insert(test_buffers, opened.right_buf)
-      local split_hunks = vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_split_hunks')
-
-      vim.api.nvim_set_current_win(opened.right_win)
-      split.goto_next(opened.right_buf)
-      assert.are.same(
-        { split_hunks[2].old_range.start, 0 },
-        vim.api.nvim_win_get_cursor(opened.left_win)
-      )
-      assert.are.same(
-        { split_hunks[2].new_range.start, 0 },
-        vim.api.nvim_win_get_cursor(opened.right_win)
-      )
-
-      vim.api.nvim_set_current_win(review_win)
-      vim.api.nvim_win_set_cursor(review_win, { first_hunk_line, 0 })
-      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
-
-      vim.wait(100, function()
-        return vim.api.nvim_win_get_cursor(opened.right_win)[1] == split_hunks[1].new_range.start
-      end)
-
-      assert.are.equal(opened.right_buf, vim.api.nvim_buf_get_var(bufnr, 'diffs_review_split_buf'))
-      assert.are.same(
-        { split_hunks[1].old_range.start, 0 },
-        vim.api.nvim_win_get_cursor(opened.left_win)
-      )
-      assert.are.same(
-        { split_hunks[1].new_range.start, 0 },
-        vim.api.nvim_win_get_cursor(opened.right_win)
-      )
+      assert.is_true(state.target_scratch)
+      assert.is_true(buffer_text(diff_buf):find('line 2 theirs', 1, true) ~= nil)
+      assert.is_true(buffer_text(state.target_buf):find('line 2 ours', 1, true) ~= nil)
     end)
 
     it('opens a base-only current-state review file as the selected section edge', function()
       local repo = create_review_repo({ commit_target = false })
+      edit_file(repo.repo_root .. '/lua/two.lua')
       mock_runtime_attach(function() end)
 
-      local bufnr = commands.greview({
-        base = repo.base,
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-
-      local two_line = find_buffer_line(bufnr, '+line 2 changed')
-      assert.is_not_nil(two_line)
-      vim.api.nvim_win_set_cursor(0, { two_line, 0 })
-
-      local opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(opened)
-      table.insert(test_buffers, opened.left_buf)
-      table.insert(test_buffers, opened.right_buf)
+      local diff_buf = commands.greview_command(('++layout=split %s'):format(repo.base))
+      track_workspace(diff_buf)
 
       assert.are.same(
-        diffspec.index_to_worktree('lua/two.lua'),
-        vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_spec')
+        diffspec.index_to_worktree('lua/one.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
       )
     end)
 
     it('opens a merge-base review file from the resolved merge base to the target tree', function()
       local repo = create_review_repo({ named_refs = true })
+      edit_file(repo.repo_root .. '/lua/one.lua')
       mock_runtime_attach(function() end)
 
-      local bufnr = commands.greview({
-        base = repo.base,
-        target = repo.target,
-        mode = 'merge-base',
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-
-      local two_line = find_buffer_line(bufnr, '+line 2 changed')
-      assert.is_not_nil(two_line)
-      vim.api.nvim_win_set_cursor(0, { two_line, 0 })
-
-      local opened = commands.greview_split({ bufnr = bufnr })
-      assert.is_not_nil(opened)
-      table.insert(test_buffers, opened.left_buf)
-      table.insert(test_buffers, opened.right_buf)
+      local diff_buf =
+        commands.greview_command(('++layout=split %s...%s'):format(repo.base, repo.target))
+      track_workspace(diff_buf)
 
       assert.are.same(
-        diffspec.rev_to_rev(repo.base_sha, repo.target, 'lua/two.lua'),
-        vim.api.nvim_buf_get_var(opened.right_buf, 'diffs_spec')
+        diffspec.rev_to_rev(repo.base_sha, repo.target, 'lua/one.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
       )
     end)
 
-    it('reports unsupported selected review files without opening a split pair', function()
+    it('reports unsupported selected review files without opening a workspace', function()
       local repo = create_mode_only_review_repo()
       local notifications = capture_notifications()
       mock_runtime_attach(function() end)
@@ -3390,7 +3072,7 @@ describe('commands', function()
       assert.is_true(
         notifications[#notifications].message:find('mode-only changes', 1, true) ~= nil
       )
-      assert.is_false(has_buf_var(bufnr, 'diffs_review_split_buf'))
+      assert.is_nil(commands._test.greview_workspace_state(bufnr))
     end)
 
     it('keeps no-hunk review file records in quickfix with an empty active loclist', function()

--- a/spec/rails_spec.lua
+++ b/spec/rails_spec.lua
@@ -39,6 +39,23 @@ describe('diffs.rails', function()
     assert.is_nil(info)
   end)
 
+  it('does not render trailing spaces for empty context lines', function()
+    local annotated, info = rails.annotate({
+      'diff --git a/file.txt b/file.txt',
+      '@@ -1,2 +1,2 @@',
+      ' line',
+      ' ',
+    })
+
+    assert.are.same({
+      width = 1,
+      prefix_width = 10,
+    }, info)
+    assert.are.equal('  2 2 ┃', annotated[4])
+    assert.is_nil(annotated[4]:match('%s$'))
+    assert.are.equal(' ', rails.strip(annotated[4], info.prefix_width))
+  end)
+
   it('returns byte ranges for old and new rail number columns', function()
     assert.are.same({
       old_start = 2,


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

## Solution

The solution replaces Greview split-pair/follow mode with a dedicated two-surface workspace; keeps quickfix as the review file index and loclist as the active-file hunk index; and refreshes the generated diff and target view from save, reload, qf/loclist jumps, and generated hunk actions.
