### PR TITLE
fix(config): deprecate highlights.gutter

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -24,7 +24,6 @@ Features: ~
 - Vim syntax fallback for languages without a treesitter parser
 - Blended diff background colors that preserve syntax visibility
 - Optional diff prefix (`+`/`-`/` `) concealment
-- Gutter (line number) highlighting
 - |:Gdiff| unified diff against any revision
 - |:Greview| full-repo review diff with qflist/loclist navigation
 - Email quoting/patch syntax support (`> diff ...`)
@@ -99,7 +98,6 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
       extra_filetypes = {},
       highlights = {
         background = true,
-        gutter = true,
         blend_alpha = 0.6,
         warn_max_lines = true,
         context = {
@@ -244,9 +242,10 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              using `DiffsAdd`/`DiffsDelete` groups (derived
                              from `DiffAdd`/`DiffDelete` backgrounds).
 
-        {gutter}             (boolean, default: true)
-                             Highlight line numbers with matching colors.
-                             Only visible if line numbers are enabled.
+        {gutter}             (boolean, deprecated)
+                             Remove this key; it colored buffer line numbers
+                             rather than actual diff lines, so it did not
+                             model meaningful diff state.
 
         {blend_alpha}        (number, default: 0.6)
                              Alpha value for diff line background intensity.

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -27,7 +27,7 @@ local notify = require('diffs.log').notify
 
 ---@class diffs.Highlights
 ---@field background boolean
----@field gutter boolean
+---@field gutter? boolean deprecated: remove from config; no replacement
 ---@field blend_alpha? number
 ---@field overrides? table<string, table>
 ---@field warn_max_lines boolean
@@ -99,7 +99,6 @@ local DEFAULTS = {
   extra_filetypes = {},
   highlights = {
     background = true,
-    gutter = true,
     warn_max_lines = true,
     context = {
       enabled = true,
@@ -144,6 +143,13 @@ local DEFAULTS = {
 }
 
 local integration_keys = { 'fugitive', 'neogit', 'neojj', 'gitsigns', 'committia', 'telescope' }
+
+---@param opts table
+local function deprecate_highlights(opts)
+  if opts.highlights and opts.highlights.gutter ~= nil then
+    vim.deprecate('vim.g.diffs.highlights.gutter', nil, '0.4.0', 'diffs.nvim')
+  end
+end
 
 ---@param opts table
 ---@return string[]
@@ -444,6 +450,7 @@ end
 function M.new(opts)
   opts = opts or {}
   M.normalize_integrations(opts)
+  deprecate_highlights(opts)
   M.validate(opts)
   return vim.tbl_deep_extend('force', DEFAULTS, opts)
 end

--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -823,12 +823,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
         })
       end
 
-      if
-        hunk.rail_width
-        and is_diff_line
-        and opts.highlights.background
-        and opts.highlights.gutter
-      then
+      if hunk.rail_width and is_diff_line and opts.highlights.background then
         pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
           virt_text = { { generated_change_bar, bar_hl } },
           virt_text_pos = 'overlay',

--- a/minimal_init.lua
+++ b/minimal_init.lua
@@ -52,7 +52,6 @@ require('lazy').setup({
         },
         hide_prefix = false,
         highlights = {
-          gutter = true,
           intra = { enabled = true },
           overrides = {
             DiffsAdd = { bg = '#ff0000' },

--- a/spec/highlight_spec.lua
+++ b/spec/highlight_spec.lua
@@ -637,7 +637,6 @@ describe('highlight', function()
           hide_prefix = true,
           highlights = {
             background = true,
-            gutter = true,
             treesitter = { enabled = false },
           },
         })
@@ -686,7 +685,6 @@ describe('highlight', function()
           hide_prefix = true,
           highlights = {
             background = true,
-            gutter = true,
             treesitter = { enabled = false },
           },
         })
@@ -761,7 +759,6 @@ describe('highlight', function()
           hide_prefix = true,
           highlights = {
             background = true,
-            gutter = true,
             treesitter = { enabled = false },
           },
         })

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -28,7 +28,6 @@ describe('diffs.runtime', function()
         hide_prefix = false,
         highlights = {
           background = true,
-          gutter = true,
           treesitter = {
             enabled = true,
             max_lines = 1000,
@@ -51,6 +50,30 @@ describe('diffs.runtime', function()
       assert.has_no.errors(function()
         runtime.attach()
       end)
+    end)
+
+    it('leaves deprecated highlights.gutter unset by default', function()
+      local opts = config.new()
+      assert.is_nil(opts.highlights.gutter)
+    end)
+
+    it('warns when deprecated highlights.gutter is set', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, err = pcall(config.new, { highlights = { gutter = false } })
+      vim.notify = saved_notify
+
+      assert.is_true(ok, err)
+      assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+      assert.are.equal(
+        'vim.g.diffs.highlights.gutter is deprecated.\n'
+          .. 'Feature will be removed in diffs.nvim 0.4.0',
+        notifications[1].message
+      )
     end)
   end)
 


### PR DESCRIPTION
Summary
- Deprecate explicit `vim.g.diffs.highlights.gutter` config with the agreed `0.4.0` removal warning.
- Drop gutter from the default/public vimdoc config and add the one-sentence rationale for removing it.
- Keep generated rail change bars independent from the deprecated buffer-line-number option.

Verification
- `direnv exec /home/barrett/dev/diffs.nvim nix fmt -- --ci`
- `direnv exec /home/barrett/dev/diffs.nvim stylua --check .`
- `direnv exec /home/barrett/dev/diffs.nvim just lint`
- `direnv exec /home/barrett/dev/diffs.nvim just test`
- `/tmp/diffs.nvim/gutter-deprecation-shim`: `nvim --headless --clean --cmd "set rtp^=/tmp/diffs.nvim/gutter-deprecation" -u init.lua sample.diff +"lua vim.schedule(function() vim.cmd("qa") end)"`

Note: `just format` and `just ci` were not used as final aggregate commands because `biome` is not present on the current direnv PATH; the available formatter/lint/test components above passed.

Part of #313.