### PR TITLE
fix(commands): tighten layout command parsing

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -2141,14 +2141,16 @@ function M.setup()
     M.gdiff(opts.args ~= '' and opts.args or nil, false)
   end, {
     nargs = '*',
+    bar = true,
     complete = complete_gdiff_command,
-    desc = 'Show unified diff against a Fugitive object',
+    desc = 'Show current-file diff against a Fugitive object',
   })
 
   vim.api.nvim_create_user_command('Gvdiff', function(opts)
     M.gdiff(opts.args ~= '' and opts.args or nil, true)
   end, {
     nargs = '*',
+    bar = true,
     complete = complete_gdiff_split_command,
     desc = 'Show unified diff against a Fugitive object in vertical split',
   })
@@ -2157,6 +2159,7 @@ function M.setup()
     M.gdiff(opts.args ~= '' and opts.args or nil, false)
   end, {
     nargs = '*',
+    bar = true,
     complete = complete_gdiff_split_command,
     desc = 'Show unified diff against a Fugitive object in horizontal split',
   })
@@ -2165,6 +2168,7 @@ function M.setup()
     M.greview_command(opts.args ~= '' and opts.args or nil)
   end, {
     nargs = '*',
+    bar = true,
     complete = complete_greview_command,
     desc = 'Review the repo against the default branch or a git review spec',
   })

--- a/lua/diffs/gdiff.lua
+++ b/lua/diffs/gdiff.lua
@@ -93,16 +93,21 @@ function M.parse(args, context)
   local tokens = split_args(args)
   local novertical = false
   local layout = 'unified'
+  local has_layout = false
 
   while tokens[1] and tokens[1]:match('^%+%+') do
     if tokens[1] == '++novertical' then
       novertical = true
       table.remove(tokens, 1)
     elseif tokens[1]:match('^%+%+layout=') then
+      if has_layout then
+        return nil, 'repeated ++layout option'
+      end
       local value = tokens[1]:match('^%+%+layout=(.+)$')
       if value ~= 'unified' and value ~= 'split' then
         return nil, 'unsupported layout ' .. tostring(value)
       end
+      has_layout = true
       layout = value
       table.remove(tokens, 1)
     else

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -175,12 +175,17 @@ end
 function M.parse_command_args(args)
   local tokens = split_args(args)
   local layout = 'unified'
+  local has_layout = false
 
   while tokens[1] and tokens[1]:match('^%+%+layout=') do
+    if has_layout then
+      return nil, 'repeated ++layout option'
+    end
     local value = tokens[1]:match('^%+%+layout=(.+)$')
     if value ~= 'unified' and value ~= 'split' then
       return nil, 'unsupported layout ' .. tostring(value)
     end
+    has_layout = true
     layout = value
     table.remove(tokens, 1)
   end

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -407,6 +407,9 @@ describe('commands', function()
       assert.is_not_nil(cmds.Gdiff)
       assert.is_not_nil(cmds.Gvdiff)
       assert.is_not_nil(cmds.Ghdiff)
+      assert.is_true(cmds.Gdiff.bar)
+      assert.is_true(cmds.Gvdiff.bar)
+      assert.is_true(cmds.Ghdiff.bar)
     end)
   end)
 
@@ -2089,6 +2092,7 @@ describe('commands', function()
       commands.setup()
       local cmds = vim.api.nvim_get_commands({})
       assert.is_not_nil(cmds.Greview)
+      assert.is_true(cmds.Greview.bar)
     end)
   end)
 
@@ -2135,6 +2139,14 @@ describe('commands', function()
 
       assert.is_nil(parsed)
       assert.are.equal('unsupported layout tiled', err)
+    end)
+
+    it('rejects repeated Greview command layout options', function()
+      local parsed, err =
+        commands._test.parse_greview_command('++layout=split ++layout=unified origin/main')
+
+      assert.is_nil(parsed)
+      assert.are.equal('repeated ++layout option', err)
     end)
 
     it('treats non-layout plus-prefixed Greview args as review specs', function()

--- a/spec/gdiff_spec.lua
+++ b/spec/gdiff_spec.lua
@@ -84,6 +84,13 @@ describe('diffs.gdiff', function()
     assert.are.equal('unified', result.layout)
   end)
 
+  it('rejects repeated layout options', function()
+    local result, err = gdiff.parse('++layout=split ++layout=unified HEAD', { path = path })
+
+    assert.is_nil(result)
+    assert.are.equal('repeated ++layout option', err)
+  end)
+
   it('rejects unsupported layouts', function()
     local result, err = gdiff.parse('++layout=tiled HEAD', { path = path })
 


### PR DESCRIPTION
## Summary

- reject repeated `++layout=` for `:Gdiff` and `:Greview` instead of silently taking the last value
- set `bar = true` on `:Gdiff`, `:Gvdiff`, `:Ghdiff`, and `:Greview` so `|` remains an Ex command separator
- adjust the `:Gdiff` command description so it is not unified-only

## Tests

- `direnv exec /home/barrett/dev/diffs.nvim busted spec/gdiff_spec.lua spec/commands_spec.lua`
- `direnv exec /home/barrett/dev/diffs.nvim just lint`
- `direnv exec /home/barrett/dev/diffs.nvim just test`