### PR TITLE
fix(highlight): remove gutter highlight groups

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -1271,14 +1271,6 @@ Fugitive unified diff highlights: ~
     DiffsDelete         Background for `-` lines. Derived by blending
                         `DiffDelete` background with `Normal` at 40% alpha.
 
-                                                                  *DiffsAddNr*
-    DiffsAddNr          Line number for `+` lines. Foreground from
-                        `DiffsAddText`, background from `DiffsAdd`.
-
-                                                               *DiffsDeleteNr*
-    DiffsDeleteNr       Line number for `-` lines. Foreground from
-                        `DiffsDeleteText`, background from `DiffsDelete`.
-
                                                                  *DiffsRail*
     DiffsRail           Generated old/new line-number rail and separator.
                         Foreground follows the plain diff rail text; does not
@@ -1303,13 +1295,13 @@ Fugitive unified diff highlights: ~
 
                                                                  *DiffsAddBar*
     DiffsAddBar         Change bar for `+` lines in diffs.nvim-owned views.
-                        Background uses the same color as `DiffsAddNr`
-                        foreground.
+                        Foreground follows added diff text; background follows
+                        the changed-line background.
 
                                                               *DiffsDeleteBar*
     DiffsDeleteBar      Change bar for `-` lines in diffs.nvim-owned views.
-                        Background uses the same color as `DiffsDeleteNr`
-                        foreground.
+                        Foreground follows deleted diff text; background
+                        follows the changed-line background.
 
                                                                 *DiffsAddText*
     DiffsAddText        Character-level background for changed characters

--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -718,7 +718,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
     local has_del = prefix:find('-', 1, true) ~= nil
     local is_diff_line = has_add or has_del
     local line_hl = is_diff_line and (has_add and 'DiffsAdd' or 'DiffsDelete') or nil
-    local number_hl = is_diff_line and (has_add and 'DiffsAddNr' or 'DiffsDeleteNr') or nil
+    local prefix_hl = is_diff_line and (has_add and '@diff.plus' or '@diff.minus') or nil
     local bar_hl = is_diff_line and (has_add and 'DiffsAddBar' or 'DiffsDeleteBar') or nil
 
     local is_marker = false
@@ -818,7 +818,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
       elseif opts.highlights.background and is_diff_line then
         pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
           end_col = 1,
-          hl_group = number_hl,
+          hl_group = prefix_hl,
           priority = p.syntax,
         })
       end
@@ -840,12 +840,6 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
           hl_eol = true,
           priority = p.line_bg,
         })
-        if opts.highlights.gutter then
-          pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
-            number_hl_group = number_hl,
-            priority = p.line_bg,
-          })
-        end
       end
 
       if is_marker and line_len > pw then

--- a/lua/diffs/runtime/highlight_groups.lua
+++ b/lua/diffs/runtime/highlight_groups.lua
@@ -74,8 +74,6 @@ function M.apply(config, is_default)
   vim.api.nvim_set_hl(0, 'DiffsClear', clear_hl)
   vim.api.nvim_set_hl(0, 'DiffsAdd', { default = dflt, bg = blended_add })
   vim.api.nvim_set_hl(0, 'DiffsDelete', { default = dflt, bg = blended_del })
-  vim.api.nvim_set_hl(0, 'DiffsAddNr', { default = dflt, fg = add_fg, bg = blended_add })
-  vim.api.nvim_set_hl(0, 'DiffsDeleteNr', { default = dflt, fg = del_fg, bg = blended_del })
   vim.api.nvim_set_hl(0, 'DiffsRail', rail_hl)
   vim.api.nvim_set_hl(
     0,
@@ -103,12 +101,7 @@ function M.apply(config, is_default)
     add_bg,
     add_fg
   )
-  log.dbg(
-    'DiffsAdd.bg=#%06x DiffsAddText.bg=#%06x DiffsAddNr.fg=#%06x',
-    blended_add,
-    blended_add_text,
-    add_fg
-  )
+  log.dbg('DiffsAdd.bg=#%06x DiffsAddText.bg=#%06x', blended_add, blended_add_text)
   log.dbg('DiffsDelete.bg=#%06x DiffsDeleteText.bg=#%06x', blended_del, blended_del_text)
 
   local diff_change = resolve_hl('DiffChange')

--- a/spec/context_spec.lua
+++ b/spec/context_spec.lua
@@ -310,7 +310,6 @@ describe('context', function()
         hide_prefix = false,
         highlights = {
           background = false,
-          gutter = false,
           context = { enabled = true, lines = 25 },
           treesitter = { enabled = true, max_lines = 500 },
           vim = { enabled = false, max_lines = 200 },

--- a/spec/email_quote_spec.lua
+++ b/spec/email_quote_spec.lua
@@ -172,7 +172,6 @@ describe('email-quoted diffs', function()
         hide_prefix = false,
         highlights = {
           background = true,
-          gutter = false,
           context = { enabled = false, lines = 0 },
           treesitter = {
             enabled = true,

--- a/spec/highlight_spec.lua
+++ b/spec/highlight_spec.lua
@@ -42,7 +42,6 @@ describe('highlight', function()
         hide_prefix = false,
         highlights = {
           background = false,
-          gutter = false,
           context = { enabled = false, lines = 0 },
           treesitter = {
             enabled = true,
@@ -334,39 +333,6 @@ describe('highlight', function()
       delete_buffer(bufnr)
     end)
 
-    it('applies number_hl_group when gutter enabled', function()
-      local bufnr = create_buffer({
-        '@@ -1,1 +1,2 @@',
-        ' local x = 1',
-        '+local y = 2',
-      })
-
-      local hunk = {
-        filename = 'test.lua',
-        lang = 'lua',
-        start_line = 1,
-        lines = { ' local x = 1', '+local y = 2' },
-      }
-
-      highlight.highlight_hunk(
-        bufnr,
-        ns,
-        hunk,
-        default_opts({ highlights = { background = true, gutter = true } })
-      )
-
-      local extmarks = get_extmarks(bufnr)
-      local has_number_hl = false
-      for _, mark in ipairs(extmarks) do
-        if mark[4] and mark[4].number_hl_group then
-          has_number_hl = true
-          break
-        end
-      end
-      assert.is_true(has_number_hl)
-      delete_buffer(bufnr)
-    end)
-
     it('line bg uses hl_group with hl_eol not line_hl_group', function()
       local bufnr = create_buffer({
         '@@ -1,1 +1,2 @@',
@@ -571,7 +537,7 @@ describe('highlight', function()
       delete_buffer(bufnr)
     end)
 
-    it('applies DiffsAddNr prefix extmark on + line for pw=1', function()
+    it('applies diff syntax prefix extmarks on changed lines for pw=1', function()
       local bufnr = create_buffer({
         '@@ -1,2 +1,2 @@',
         '-old',
@@ -599,16 +565,16 @@ describe('highlight', function()
       for _, mark in ipairs(extmarks) do
         local d = mark[4]
         if d and d.end_col == 1 and mark[3] == 0 then
-          if d.hl_group == 'DiffsAddNr' and mark[2] == 2 then
+          if d.hl_group == '@diff.plus' and mark[2] == 2 then
             add_prefix = true
           end
-          if d.hl_group == 'DiffsDeleteNr' and mark[2] == 1 then
+          if d.hl_group == '@diff.minus' and mark[2] == 1 then
             del_prefix = true
           end
         end
       end
-      assert.is_true(add_prefix, 'DiffsAddNr on + prefix')
-      assert.is_true(del_prefix, 'DiffsDeleteNr on - prefix')
+      assert.is_true(add_prefix, '@diff.plus on + prefix')
+      assert.is_true(del_prefix, '@diff.minus on - prefix')
       delete_buffer(bufnr)
     end)
 
@@ -838,7 +804,7 @@ describe('highlight', function()
       for _, mark in ipairs(extmarks) do
         local d = mark[4]
         if d and mark[2] == 1 and mark[3] == 0 and d.end_col == 1 then
-          if d.hl_group == 'DiffsAddNr' or d.hl_group == 'DiffsDeleteNr' then
+          if d.hl_group == '@diff.plus' or d.hl_group == '@diff.minus' then
             ctx_prefix = true
           end
         end
@@ -1109,41 +1075,6 @@ describe('highlight', function()
         end
       end
       assert.is_true(found)
-      delete_buffer(bufnr)
-    end)
-
-    it('number_hl_group does not bleed to adjacent lines', function()
-      local bufnr = create_buffer({
-        '@@ -1,3 +1,3 @@',
-        ' local a = 0',
-        '-local x = 1',
-        '+local y = 2',
-        ' local b = 3',
-      })
-
-      local hunk = {
-        filename = 'test.lua',
-        lang = 'lua',
-        start_line = 1,
-        lines = { ' local a = 0', '-local x = 1', '+local y = 2', ' local b = 3' },
-      }
-
-      highlight.highlight_hunk(
-        bufnr,
-        ns,
-        hunk,
-        default_opts({ highlights = { background = true, gutter = true } })
-      )
-
-      local extmarks = get_extmarks(bufnr)
-      for _, mark in ipairs(extmarks) do
-        local d = mark[4]
-        if d and d.number_hl_group then
-          local start_row = mark[2]
-          local end_row = d.end_row or start_row
-          assert.are.equal(start_row, end_row)
-        end
-      end
       delete_buffer(bufnr)
     end)
 
@@ -1549,20 +1480,16 @@ describe('highlight', function()
         bufnr,
         ns,
         hunk,
-        default_opts({ highlights = { background = true, gutter = true } })
+        default_opts({ highlights = { background = true } })
       )
 
       local extmarks = get_extmarks(bufnr)
       local line_bgs = {}
-      local gutter_hls = {}
       local marker_text = {}
       for _, mark in ipairs(extmarks) do
         local d = mark[4]
         if d and (d.hl_group == 'DiffsAdd' or d.hl_group == 'DiffsDelete') then
           line_bgs[mark[2]] = d.hl_group
-        end
-        if d and d.number_hl_group then
-          gutter_hls[mark[2]] = d.number_hl_group
         end
         if d and d.hl_group == 'DiffsConflictMarker' then
           marker_text[mark[2]] = true
@@ -1577,15 +1504,6 @@ describe('highlight', function()
       assert.are.equal('DiffsAdd', line_bgs[6])
       assert.are.equal('DiffsAdd', line_bgs[7])
       assert.is_nil(line_bgs[8])
-
-      assert.is_nil(gutter_hls[1])
-      assert.are.equal('DiffsAddNr', gutter_hls[2])
-      assert.are.equal('DiffsAddNr', gutter_hls[3])
-      assert.are.equal('DiffsAddNr', gutter_hls[4])
-      assert.are.equal('DiffsAddNr', gutter_hls[5])
-      assert.are.equal('DiffsAddNr', gutter_hls[6])
-      assert.are.equal('DiffsAddNr', gutter_hls[7])
-      assert.is_nil(gutter_hls[8])
 
       assert.is_true(marker_text[2] ~= nil)
       assert.is_nil(marker_text[3])
@@ -1656,8 +1574,6 @@ describe('highlight', function()
     it('two-pass rendering produces no duplicate extmarks', function()
       vim.api.nvim_set_hl(0, 'DiffsAddText', { bg = 0x00FF00 })
       vim.api.nvim_set_hl(0, 'DiffsDeleteText', { bg = 0xFF0000 })
-      vim.api.nvim_set_hl(0, 'DiffsAddNr', { fg = 0x80c080, bg = 0x2e4a3a })
-      vim.api.nvim_set_hl(0, 'DiffsDeleteNr', { fg = 0xc08080, bg = 0x4a2e3a })
 
       local bufnr = create_buffer({
         '@@ -1,2 +1,2 @@',
@@ -1676,7 +1592,6 @@ describe('highlight', function()
         highlights = {
           treesitter = { enabled = false },
           background = true,
-          gutter = true,
           intra = { enabled = true, algorithm = 'default', max_lines = 500 },
         },
       })
@@ -1685,7 +1600,6 @@ describe('highlight', function()
         highlights = {
           treesitter = { enabled = true },
           background = true,
-          gutter = true,
           intra = { enabled = true, algorithm = 'default', max_lines = 500 },
         },
       })
@@ -1697,7 +1611,6 @@ describe('highlight', function()
       local extmarks = get_extmarks(bufnr)
       for row = 1, 2 do
         local line_hl_count = 0
-        local number_hl_count = 0
         local intra_count = 0
         for _, mark in ipairs(extmarks) do
           if mark[2] == row then
@@ -1705,16 +1618,12 @@ describe('highlight', function()
             if d.hl_group and d.hl_eol then
               line_hl_count = line_hl_count + 1
             end
-            if d.number_hl_group then
-              number_hl_count = number_hl_count + 1
-            end
             if d.hl_group == 'DiffsAddText' or d.hl_group == 'DiffsDeleteText' then
               intra_count = intra_count + 1
             end
           end
         end
         assert.are.equal(1, line_hl_count, 'row ' .. row .. ' has duplicate line bg')
-        assert.are.equal(1, number_hl_count, 'row ' .. row .. ' has duplicate number_hl_group')
         assert.is_true(intra_count <= 1, 'row ' .. row .. ' has duplicate intra extmarks')
       end
       delete_buffer(bufnr)
@@ -1799,7 +1708,6 @@ describe('highlight', function()
         hide_prefix = false,
         highlights = {
           background = false,
-          gutter = false,
           context = { enabled = false, lines = 0 },
           treesitter = { enabled = true, max_lines = 500 },
           vim = { enabled = false, max_lines = 200 },
@@ -2384,7 +2292,6 @@ describe('highlight', function()
         hide_prefix = false,
         highlights = {
           background = false,
-          gutter = false,
           context = { enabled = false, lines = 0 },
           treesitter = { enabled = true, max_lines = 500 },
           vim = { enabled = false, max_lines = 200 },

--- a/spec/integration_spec.lua
+++ b/spec/integration_spec.lua
@@ -38,7 +38,6 @@ local function highlight_opts_with_background()
     hide_prefix = false,
     highlights = {
       background = true,
-      gutter = false,
       context = { enabled = false, lines = 0 },
       treesitter = { enabled = true, max_lines = 500 },
       vim = { enabled = false, max_lines = 200 },


### PR DESCRIPTION
Summary
- Remove the remaining generated-diff `number_hl_group` path owned by the deprecated `highlights.gutter` option.
- Delete stale `DiffsAddNr` / `DiffsDeleteNr` highlight groups instead of repurposing gutter-era names for prefix cells.
- Keep generated rail, conflict number-column, and change-bar highlight groups because they are separate features.

Verification
- `direnv exec /home/barrett/dev/diffs.nvim nix fmt -- --ci`
- `direnv exec /home/barrett/dev/diffs.nvim stylua --check .`
- `direnv exec /home/barrett/dev/diffs.nvim vimdoc-language-server check doc/`
- `direnv exec /home/barrett/dev/diffs.nvim just lint`
- `direnv exec /home/barrett/dev/diffs.nvim just test`
- `/tmp/diffs.nvim/gutter-removal-greview-shim`: `cd /tmp/diffs.nvim/gutter-removal-greview-shim && nvim --clean --cmd 'set rtp^=/tmp/diffs.nvim/gutter-deprecation' -u init.lua +'Greview HEAD'`

Follow-up to #323. Part of #313.