### PR TITLE
fix(config): remove legacy integration keys

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -207,12 +207,6 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                                  integrations = { telescope = true }
 <
 
-                             Legacy top-level keys (`vim.g.diffs.fugitive`,
-                             etc.) still work but emit a deprecation
-                             warning. If both `integrations` and top-level
-                             keys are present, `integrations` wins and
-                             the stale keys are ignored with a warning.
-
         {extra_filetypes}    (table, default: {})
                              Additional filetypes to attach to, beyond the
                              built-in `git`, `gitcommit`, and any enabled

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-local notify = require('diffs.log').notify
-
 ---@class diffs.TreesitterConfig
 ---@field enabled boolean
 ---@field max_lines integer
@@ -84,12 +82,6 @@ local notify = require('diffs.log').notify
 ---@field extra_filetypes string[]
 ---@field highlights diffs.Highlights
 ---@field integrations diffs.IntegrationsConfig
----@field fugitive? diffs.FugitiveConfig|false deprecated: use integrations.fugitive
----@field neogit? diffs.NeogitConfig|false deprecated: use integrations.neogit
----@field neojj? diffs.NeojjConfig|false deprecated: use integrations.neojj
----@field gitsigns? diffs.GitsignsConfig|false deprecated: use integrations.gitsigns
----@field committia? diffs.CommittiaConfig|false deprecated: use integrations.committia
----@field telescope? diffs.TelescopeConfig|false deprecated: use integrations.telescope
 ---@field conflict diffs.ConflictConfig
 
 ---@type diffs.Config
@@ -156,27 +148,15 @@ end
 function M.compute_filetypes(opts)
   local fts = { 'git', 'gitcommit' }
   local intg = opts.integrations or {}
-  local fug = intg.fugitive
-  if fug == nil then
-    fug = opts.fugitive
-  end
-  if fug == true or type(fug) == 'table' then
+  if intg.fugitive == true or type(intg.fugitive) == 'table' then
     table.insert(fts, 'fugitive')
   end
-  local neo = intg.neogit
-  if neo == nil then
-    neo = opts.neogit
-  end
-  if neo == true or type(neo) == 'table' then
+  if intg.neogit == true or type(intg.neogit) == 'table' then
     table.insert(fts, 'NeogitStatus')
     table.insert(fts, 'NeogitCommitView')
     table.insert(fts, 'NeogitDiffView')
   end
-  local njj = intg.neojj
-  if njj == nil then
-    njj = opts.neojj
-  end
-  if njj == true or type(njj) == 'table' then
+  if intg.neojj == true or type(intg.neojj) == 'table' then
     table.insert(fts, 'NeojjStatus')
     table.insert(fts, 'NeojjCommitView')
     table.insert(fts, 'NeojjDiffView')
@@ -190,47 +170,7 @@ function M.compute_filetypes(opts)
 end
 
 ---@param opts table
-function M.migrate_integrations(opts)
-  if opts.integrations then
-    local stale = {}
-    for _, key in ipairs(integration_keys) do
-      if opts[key] ~= nil then
-        stale[#stale + 1] = key
-        opts[key] = nil
-      end
-    end
-    if #stale > 0 then
-      local old = 'vim.g.diffs.{' .. table.concat(stale, ', ') .. '}'
-      local new = 'vim.g.diffs.integrations.{' .. table.concat(stale, ', ') .. '}'
-      notify('ignoring ' .. old .. '; move to ' .. new .. ' or remove', vim.log.levels.WARN)
-    end
-    return
-  end
-  local has_legacy = false
-  for _, key in ipairs(integration_keys) do
-    if opts[key] ~= nil then
-      has_legacy = true
-      break
-    end
-  end
-  if not has_legacy then
-    return
-  end
-  vim.deprecate('vim.g.diffs.<integration>', 'vim.g.diffs.integrations.*', '0.3.2', 'diffs.nvim')
-  local legacy = {}
-  for _, key in ipairs(integration_keys) do
-    if opts[key] ~= nil then
-      legacy[key] = opts[key]
-      opts[key] = nil
-    end
-  end
-  opts.integrations = legacy
-end
-
----@param opts table
 function M.normalize_integrations(opts)
-  M.migrate_integrations(opts)
-
   local intg = opts.integrations or {}
   local fugitive_defaults = { horizontal = 'du', vertical = 'dU' }
   if intg.fugitive == true then

--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -6,18 +6,11 @@ vim.g.loaded_diffs = 1
 require('diffs.commands').setup()
 local config = require('diffs.config')
 local runtime = require('diffs.runtime')
+local user_config = vim.g.diffs or {}
 
-local function get_raw_integration(key)
-  local user = vim.g.diffs or {}
-  local intg = user.integrations or {}
-  local v = intg[key]
-  if v ~= nil then
-    return v
-  end
-  return user[key]
-end
+local integrations = user_config.integrations or {}
 
-local gs_cfg = get_raw_integration('gitsigns')
+local gs_cfg = integrations.gitsigns
 if gs_cfg == true or type(gs_cfg) == 'table' then
   if not require('diffs.gitsigns').setup() then
     vim.api.nvim_create_autocmd('User', {
@@ -30,7 +23,7 @@ if gs_cfg == true or type(gs_cfg) == 'table' then
   end
 end
 
-local tel_cfg = get_raw_integration('telescope')
+local tel_cfg = integrations.telescope
 if tel_cfg == true or type(tel_cfg) == 'table' then
   vim.api.nvim_create_autocmd('User', {
     pattern = 'TelescopePreviewerLoaded',
@@ -41,7 +34,7 @@ if tel_cfg == true or type(tel_cfg) == 'table' then
 end
 
 vim.api.nvim_create_autocmd('FileType', {
-  pattern = config.compute_filetypes(vim.g.diffs or {}),
+  pattern = config.compute_filetypes(user_config),
   callback = function(args)
     runtime.attach(args.buf)
 

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -417,21 +417,6 @@ describe('diffs.runtime', function()
       assert.is_true(vim.tbl_contains(fts, 'NeogitStatus'))
       assert.is_true(vim.tbl_contains(fts, 'diff'))
     end)
-
-    it('falls back to legacy top-level fugitive key', function()
-      local fts = compute({ fugitive = true })
-      assert.is_true(vim.tbl_contains(fts, 'fugitive'))
-    end)
-
-    it('falls back to legacy top-level neogit key', function()
-      local fts = compute({ neogit = true })
-      assert.is_true(vim.tbl_contains(fts, 'NeogitStatus'))
-    end)
-
-    it('prefers integrations key over legacy top-level key', function()
-      local fts = compute({ integrations = { fugitive = false }, fugitive = true })
-      assert.is_false(vim.tbl_contains(fts, 'fugitive'))
-    end)
   end)
 
   describe('diff mode', function()


### PR DESCRIPTION
## Summary
- remove support for legacy top-level integration keys (`vim.g.diffs.fugitive`, `neogit`, `neojj`, `gitsigns`, `committia`, `telescope`)
- remove startup-time raw integration fallbacks
- remove docs and tests that referenced the removed keys

## Shim
- `/tmp/diffs.nvim/legacy-integrations-removal-shim`
- supported config smoke: `cd /tmp/diffs.nvim/legacy-integrations-removal-shim && nvim --clean -u init-new.lua +'lua print("new integrations config loaded")' +qa`

## Verification
- `busted spec/runtime_spec.lua`
- `stylua --check lua/diffs/config.lua plugin/diffs.lua spec/runtime_spec.lua`
- `stylua --check .`
- `just lint`
- `vimdoc-language-server check doc/`
- `nix fmt -- --ci`
- `just test`
- `git diff --check`

Note: `biome format .` could not run locally because `biome` is not on the current direnv PATH.
