### PR TITLE
fix(config): migrate hide_prefix to view.prefix

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -86,7 +86,9 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
 >lua
     vim.g.diffs = {
       debug = false,
-      hide_prefix = false,
+      view = {
+        prefix = true,
+      },
       integrations = {
         fugitive = false,
         neogit = false,
@@ -140,12 +142,22 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              Enable debug logging to ` :messages` with
                              `[diffs]` prefix.
 
-        {hide_prefix}        (boolean, default: false)
-                             Hide diff prefixes (`+`/`-`/` `) using virtual
-                             text overlay. Makes code appear without the
-                             leading diff character. When `highlights.background`
-                             is also enabled, the overlay inherits the line's
-                             background color.
+        {view}               (table, default: see below)
+                             Diff view display options.
+                             See |diffs.nvim.ViewConfig| for fields.
+
+                                                    *diffs.nvim.ViewConfig*
+    View table fields: ~
+        {prefix}             (boolean, default: true)
+                             Show diff prefixes (`+`/`-`/` `). Set to
+                             `false` to hide them with virtual text overlay.
+                             When `highlights.background` is also enabled,
+                             the overlay inherits the line's background color.
+
+        {hide_prefix}        (boolean, deprecated)
+                             Use `view.prefix` instead. The value is inverted:
+                             `hide_prefix = true` maps to
+                             `view.prefix = false`.
 
         {integrations}       (table, default: all false)
                              Integration toggles. Each key accepts `true`,
@@ -1176,7 +1188,7 @@ Summary / commit detail views: ~
    - Background extmarks (`DiffsAdd`/`DiffsDelete`) at priority 200
    - Character-level diff extmarks (`DiffsAddText`/`DiffsDeleteText`) at
      priority 201 overlay changed characters with an intense background
-   - Conceal extmarks hide diff prefixes when `hide_prefix` is enabled
+   - Conceal extmarks hide diff prefixes when `view.prefix` is disabled
    - All priorities are configurable via |diffs.nvim.PrioritiesConfig|
 4. A decoration provider re-highlights visible hunks on each redraw
 

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -23,6 +23,9 @@ local M = {}
 ---@field line_bg integer
 ---@field char_bg integer
 
+---@class diffs.ViewConfig
+---@field prefix boolean
+
 ---@class diffs.Highlights
 ---@field background boolean
 ---@field gutter? boolean deprecated: remove from config; no replacement
@@ -78,7 +81,8 @@ local M = {}
 
 ---@class diffs.Config
 ---@field debug boolean|string
----@field hide_prefix boolean
+---@field hide_prefix? boolean deprecated: use view.prefix
+---@field view diffs.ViewConfig
 ---@field extra_filetypes string[]
 ---@field highlights diffs.Highlights
 ---@field integrations diffs.IntegrationsConfig
@@ -87,7 +91,9 @@ local M = {}
 ---@type diffs.Config
 local DEFAULTS = {
   debug = false,
-  hide_prefix = false,
+  view = {
+    prefix = true,
+  },
   extra_filetypes = {},
   highlights = {
     background = true,
@@ -135,6 +141,22 @@ local DEFAULTS = {
 }
 
 local integration_keys = { 'fugitive', 'neogit', 'neojj', 'gitsigns', 'committia', 'telescope' }
+
+---@param opts table
+local function migrate_view(opts)
+  if opts.hide_prefix == nil then
+    return
+  end
+  vim.validate('hide_prefix', opts.hide_prefix, 'boolean')
+  vim.deprecate('vim.g.diffs.hide_prefix', 'vim.g.diffs.view.prefix', '0.4.0', 'diffs.nvim')
+  if opts.view == nil then
+    opts.view = {}
+  end
+  if type(opts.view) == 'table' and opts.view.prefix == nil then
+    opts.view.prefix = not opts.hide_prefix
+  end
+  opts.hide_prefix = nil
+end
 
 ---@param opts table
 local function deprecate_highlights(opts)
@@ -207,7 +229,10 @@ function M.validate(opts)
   vim.validate('debug', opts.debug, function(v)
     return v == nil or type(v) == 'boolean' or type(v) == 'string'
   end, 'boolean or string (file path)')
-  vim.validate('hide_prefix', opts.hide_prefix, 'boolean', true)
+  vim.validate('view', opts.view, 'table', true)
+  if opts.view then
+    vim.validate('view.prefix', opts.view.prefix, 'boolean', true)
+  end
   vim.validate('integrations', opts.integrations, 'table', true)
   local integration_validator = function(v)
     return v == nil or v == false or type(v) == 'table'
@@ -389,6 +414,7 @@ end
 ---@return diffs.Config
 function M.new(opts)
   opts = opts or {}
+  migrate_view(opts)
   M.normalize_integrations(opts)
   deprecate_highlights(opts)
   M.validate(opts)

--- a/lua/diffs/runtime/cache.lua
+++ b/lua/diffs/runtime/cache.lua
@@ -319,7 +319,7 @@ function Cache:run_deferred_syntax(bufnr, tick, changedtick, job_id, deferred_sy
   local config = self.get_config()
   local t1 = config.debug and vim.uv.hrtime() or nil
   local syntax_opts = {
-    hide_prefix = config.hide_prefix,
+    hide_prefix = not config.view.prefix,
     highlights = config.highlights,
     syntax_only = true,
   }

--- a/lua/diffs/runtime/init.lua
+++ b/lua/diffs/runtime/init.lua
@@ -61,7 +61,7 @@ local function init()
   log.set_enabled(config.debug)
 
   fast_hl_opts = {
-    hide_prefix = config.hide_prefix,
+    hide_prefix = not config.view.prefix,
     highlights = vim.tbl_deep_extend('force', config.highlights, {
       treesitter = { enabled = false },
     }),
@@ -160,7 +160,7 @@ end
 ---@return diffs.HunkOpts
 function M.get_highlight_opts()
   init()
-  return { hide_prefix = config.hide_prefix, highlights = config.highlights }
+  return { hide_prefix = not config.view.prefix, highlights = config.highlights }
 end
 
 M._test = {

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -25,7 +25,9 @@ describe('diffs.runtime', function()
     it('accepts full config', function()
       vim.g.diffs = {
         debug = true,
-        hide_prefix = false,
+        view = {
+          prefix = true,
+        },
         highlights = {
           background = true,
           treesitter = {
@@ -45,11 +47,64 @@ describe('diffs.runtime', function()
 
     it('accepts partial config', function()
       vim.g.diffs = {
-        hide_prefix = true,
+        view = {
+          prefix = false,
+        },
       }
       assert.has_no.errors(function()
         runtime.attach()
       end)
+    end)
+
+    it('defaults view.prefix to true', function()
+      local opts = config.new()
+      assert.is_true(opts.view.prefix)
+      assert.is_nil(opts.hide_prefix)
+    end)
+
+    it('warns and maps deprecated hide_prefix = true to view.prefix = false', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, opts = pcall(config.new, { hide_prefix = true })
+      vim.notify = saved_notify
+
+      assert.is_true(ok)
+      assert.is_false(opts.view.prefix)
+      assert.is_nil(opts.hide_prefix)
+      assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+      assert.are.equal(
+        'vim.g.diffs.hide_prefix is deprecated, use vim.g.diffs.view.prefix instead.\n'
+          .. 'Feature will be removed in diffs.nvim 0.4.0',
+        notifications[1].message
+      )
+    end)
+
+    it('warns and maps deprecated hide_prefix = false to view.prefix = true', function()
+      local saved_deprecate = vim.deprecate
+      vim.deprecate = function() end
+
+      local ok, opts = pcall(config.new, { hide_prefix = false })
+      vim.deprecate = saved_deprecate
+
+      assert.is_true(ok)
+      assert.is_true(opts.view.prefix)
+      assert.is_nil(opts.hide_prefix)
+    end)
+
+    it('keeps view.prefix when deprecated hide_prefix is also set', function()
+      local saved_deprecate = vim.deprecate
+      vim.deprecate = function() end
+
+      local ok, opts = pcall(config.new, { hide_prefix = true, view = { prefix = true } })
+      vim.deprecate = saved_deprecate
+
+      assert.is_true(ok)
+      assert.is_true(opts.view.prefix)
+      assert.is_nil(opts.hide_prefix)
     end)
 
     it('leaves deprecated highlights.gutter unset by default', function()


### PR DESCRIPTION
## Summary
- add `vim.g.diffs.view.prefix` as the public config for showing diff prefixes
- migrate deprecated `vim.g.diffs.hide_prefix` to the inverted `view.prefix` value
- keep `view.prefix` authoritative when both old and new keys are set
- update vimdoc and runtime highlight wiring to use the new config shape

## Deprecation Notice
```text
vim.g.diffs.hide_prefix is deprecated, use vim.g.diffs.view.prefix instead.
Feature will be removed in diffs.nvim 0.4.0
```

Mapping:
- `hide_prefix = true` -> `view.prefix = false`
- `hide_prefix = false` -> `view.prefix = true`

## Shim
- `/tmp/diffs.nvim/view-prefix-migration-shim`
- old/new comparison: `cd /tmp/diffs.nvim/view-prefix-migration-shim && nvim --headless --clean -u init-old.lua +'lua print("old hide_prefix=" .. tostring(require("diffs.runtime").get_highlight_opts().hide_prefix))' +qa && printf '\n' && nvim --headless --clean -u init-new.lua +'lua print("new hide_prefix=" .. tostring(require("diffs.runtime").get_highlight_opts().hide_prefix))' +qa`

## Verification
- `busted spec/runtime_spec.lua`
- `stylua --check lua/diffs/config.lua lua/diffs/runtime/init.lua lua/diffs/runtime/cache.lua spec/runtime_spec.lua`
- `vimdoc-language-server check doc/`
- `stylua --check .`
- `just lint`
- `nix fmt -- --ci`
- `just test`
- `git diff --check`

Note: `biome format .` could not run locally because `biome` is not on the current direnv PATH.
