### PR TITLE
fix(config): deprecate fugitive keymap options

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -168,18 +168,11 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              Fields: ~
 
             {fugitive}       (boolean|table, default: false)
-                             Enable vim-fugitive integration. Pass `true`
-                             for defaults, or a table with sub-options
-                             (see |diffs.nvim.FugitiveConfig|). When active,
-                             the `fugitive` filetype is registered and
+                             Enable vim-fugitive integration. When active,
+                             the `fugitive` filetype is registered and fixed
                              status buffer keymaps are set. >lua
                                  vim.g.diffs = {
                                    integrations = { fugitive = true },
-                                 }
-                                 vim.g.diffs = {
-                                   integrations = {
-                                     fugitive = { horizontal = 'dd' },
-                                   },
                                  }
 <
 
@@ -920,24 +913,22 @@ Configuration: ~
 >lua
     vim.g.diffs = {
       integrations = {
-        fugitive = {
-          horizontal = 'du',  -- keymap for horizontal split, false to disable
-          vertical = 'dU',    -- keymap for vertical split, false to disable
-        },
+        fugitive = true,
       },
     }
 <
-    Passing a table enables fugitive integration. Use `fugitive = false`
-    to disable. There is no `enabled` field; table presence is sufficient.
+    Use `fugitive = false` to disable. Passing a table also enables the
+    integration. There is no `enabled` field; table presence is sufficient.
+    Status keymaps are fixed at `du` and `dU`.
 
     Fields: ~
-        {horizontal}         (string|false, default: 'du')
-                             Keymap for unified diff in horizontal split.
-                             Set to `false` to disable.
+        {horizontal}         (string|false, deprecated)
+                             Remove this key; the horizontal Fugitive status
+                             keymap is fixed at `du`.
 
-        {vertical}           (string|false, default: 'dU')
-                             Keymap for unified diff in vertical split.
-                             Set to `false` to disable.
+        {vertical}           (string|false, deprecated)
+                             Remove this key; the vertical Fugitive status
+                             keymap is fixed at `dU`.
 
 ------------------------------------------------------------------------------
 NEOGIT                                                     *diffs.nvim-neogit*

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -39,8 +39,8 @@ local M = {}
 ---@field priorities diffs.PrioritiesConfig
 
 ---@class diffs.FugitiveConfig
----@field horizontal string|false
----@field vertical string|false
+---@field horizontal? string|false deprecated: remove; status keymaps are fixed
+---@field vertical? string|false deprecated: remove; status keymaps are fixed
 
 ---@class diffs.NeogitConfig
 
@@ -158,6 +158,27 @@ local function migrate_view(opts)
   opts.hide_prefix = nil
 end
 
+---@param fugitive diffs.FugitiveConfig
+local function deprecate_fugitive_keymaps(fugitive)
+  if fugitive.horizontal == nil and fugitive.vertical == nil then
+    return
+  end
+  vim.validate('integrations.fugitive.horizontal', fugitive.horizontal, function(v)
+    return v == nil or v == false or type(v) == 'string'
+  end, 'string or false')
+  vim.validate('integrations.fugitive.vertical', fugitive.vertical, function(v)
+    return v == nil or v == false or type(v) == 'string'
+  end, 'string or false')
+  vim.deprecate(
+    'vim.g.diffs.integrations.fugitive.{horizontal,vertical}',
+    nil,
+    '0.4.0',
+    'diffs.nvim'
+  )
+  fugitive.horizontal = nil
+  fugitive.vertical = nil
+end
+
 ---@param opts table
 local function deprecate_highlights(opts)
   if opts.highlights and opts.highlights.gutter ~= nil then
@@ -194,11 +215,10 @@ end
 ---@param opts table
 function M.normalize_integrations(opts)
   local intg = opts.integrations or {}
-  local fugitive_defaults = { horizontal = 'du', vertical = 'dU' }
   if intg.fugitive == true then
-    intg.fugitive = vim.deepcopy(fugitive_defaults)
+    intg.fugitive = {}
   elseif type(intg.fugitive) == 'table' then
-    intg.fugitive = vim.tbl_extend('keep', intg.fugitive, fugitive_defaults)
+    deprecate_fugitive_keymaps(intg.fugitive)
   end
 
   if intg.neogit == true then
@@ -314,17 +334,6 @@ function M.validate(opts)
         true
       )
     end
-  end
-
-  if type(opts.integrations.fugitive) == 'table' then
-    ---@type diffs.FugitiveConfig
-    local fug = opts.integrations.fugitive
-    vim.validate('integrations.fugitive.horizontal', fug.horizontal, function(v)
-      return v == nil or v == false or type(v) == 'string'
-    end, 'string or false')
-    vim.validate('integrations.fugitive.vertical', fug.vertical, function(v)
-      return v == nil or v == false or type(v) == 'string'
-    end, 'string or false')
   end
 
   if opts.conflict then

--- a/lua/diffs/fugitive.lua
+++ b/lua/diffs/fugitive.lua
@@ -254,18 +254,17 @@ function M.diff_file_under_cursor(vertical)
 end
 
 ---@param bufnr integer
----@param config { horizontal: string|false, vertical: string|false }
-function M.setup_keymaps(bufnr, config)
+function M.setup_keymaps(bufnr)
   keymaps.set_buffer_keymaps(buffer_keymaps, bufnr, {
     {
-      config.horizontal,
+      'du',
       function()
         M.diff_file_under_cursor(false)
       end,
       { desc = 'Unified diff (horizontal)' },
     },
     {
-      config.vertical,
+      'dU',
       function()
         M.diff_file_under_cursor(true)
       end,

--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -40,8 +40,8 @@ vim.api.nvim_create_autocmd('FileType', {
 
     if args.match == 'fugitive' then
       local fugitive_config = runtime.get_fugitive_config()
-      if fugitive_config and (fugitive_config.horizontal or fugitive_config.vertical) then
-        require('diffs.fugitive').setup_keymaps(args.buf, fugitive_config)
+      if fugitive_config then
+        require('diffs.fugitive').setup_keymaps(args.buf)
       end
     end
   end,

--- a/spec/fugitive_spec.lua
+++ b/spec/fugitive_spec.lua
@@ -369,11 +369,20 @@ describe('fugitive', function()
   end)
 
   describe('setup_keymaps', function()
+    it('installs fixed horizontal and vertical maps', function()
+      local buf = create_buffer()
+
+      fugitive.setup_keymaps(buf)
+
+      assert.are.equal('Unified diff (horizontal)', helpers.get_keymap(buf, 'du').desc)
+      assert.are.equal('Unified diff (vertical)', helpers.get_keymap(buf, 'dU').desc)
+    end)
+
     it('preserves pre-existing horizontal map and installs vertical map', function()
       local buf = create_buffer()
       vim.keymap.set('n', 'du', '<Nop>', { buffer = buf, desc = 'user horizontal' })
 
-      fugitive.setup_keymaps(buf, { horizontal = 'du', vertical = 'dU' })
+      fugitive.setup_keymaps(buf)
 
       assert.are.equal('user horizontal', helpers.get_keymap(buf, 'du').desc)
       assert.are.equal('Unified diff (vertical)', helpers.get_keymap(buf, 'dU').desc)
@@ -383,40 +392,10 @@ describe('fugitive', function()
       local buf = create_buffer()
       vim.keymap.set('n', 'dU', '<Nop>', { buffer = buf, desc = 'user vertical' })
 
-      fugitive.setup_keymaps(buf, { horizontal = 'du', vertical = 'dU' })
+      fugitive.setup_keymaps(buf)
 
       assert.are.equal('Unified diff (horizontal)', helpers.get_keymap(buf, 'du').desc)
       assert.are.equal('user vertical', helpers.get_keymap(buf, 'dU').desc)
-    end)
-
-    it('does not install disabled or empty maps', function()
-      local buf = create_buffer()
-
-      fugitive.setup_keymaps(buf, { horizontal = false, vertical = '' })
-
-      assert.is_false(helpers.has_keymap(buf, 'du'))
-      assert.is_false(helpers.has_keymap(buf, 'dU'))
-    end)
-
-    it('clears owned maps when disabled later', function()
-      local buf = create_buffer()
-
-      fugitive.setup_keymaps(buf, { horizontal = 'du', vertical = 'dU' })
-      fugitive.setup_keymaps(buf, { horizontal = false, vertical = false })
-
-      assert.is_false(helpers.has_keymap(buf, 'du'))
-      assert.is_false(helpers.has_keymap(buf, 'dU'))
-    end)
-
-    it('does not delete maps replaced after diffs.nvim installed them', function()
-      local buf = create_buffer()
-
-      fugitive.setup_keymaps(buf, { horizontal = 'du', vertical = 'dU' })
-      vim.keymap.set('n', 'du', '<Nop>', { buffer = buf, desc = 'user replacement' })
-      fugitive.setup_keymaps(buf, { horizontal = false, vertical = false })
-
-      assert.are.equal('user replacement', helpers.get_keymap(buf, 'du').desc)
-      assert.is_false(helpers.has_keymap(buf, 'dU'))
     end)
   end)
 end)

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -130,6 +130,39 @@ describe('diffs.runtime', function()
         notifications[1].message
       )
     end)
+
+    it('normalizes integrations.fugitive = true to enabled table without keymap config', function()
+      local opts = config.new({ integrations = { fugitive = true } })
+
+      assert.are.same({}, opts.integrations.fugitive)
+    end)
+
+    it('warns and drops deprecated fugitive keymap config', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, opts = pcall(config.new, {
+        integrations = {
+          fugitive = {
+            horizontal = 'dd',
+            vertical = false,
+          },
+        },
+      })
+      vim.notify = saved_notify
+
+      assert.is_true(ok)
+      assert.are.same({}, opts.integrations.fugitive)
+      assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+      assert.are.equal(
+        'vim.g.diffs.integrations.fugitive.{horizontal,vertical} is deprecated.\n'
+          .. 'Feature will be removed in diffs.nvim 0.4.0',
+        notifications[1].message
+      )
+    end)
   end)
 
   describe('attach', function()
@@ -421,7 +454,7 @@ describe('diffs.runtime', function()
     end)
 
     it('includes fugitive when integrations.fugitive is a table', function()
-      local fts = compute({ integrations = { fugitive = { horizontal = 'dd' } } })
+      local fts = compute({ integrations = { fugitive = {} } })
       assert.is_true(vim.tbl_contains(fts, 'fugitive'))
     end)
 


### PR DESCRIPTION
## Summary
- deprecate `integrations.fugitive.horizontal` and `.vertical`
- make Fugitive status keymaps fixed at `du` / `dU` whenever the integration is enabled
- drop deprecated keymap subkeys from normalized config
- remove runtime keymap configurability and update vimdoc/tests

## Deprecation Notice
```text
vim.g.diffs.integrations.fugitive.{horizontal,vertical} is deprecated.
Feature will be removed in diffs.nvim 0.4.0
```

Behavior:
- `integrations.fugitive = true` normalizes to an enabled table with no keymap config
- `integrations.fugitive = { horizontal = ..., vertical = ... }` warns, drops those keys, and installs fixed `du` / `dU`
- `integrations.fugitive = false` remains the disable path

## Shim
- `/tmp/diffs.nvim/fugitive-keymaps-migration-shim`
- old/new comparison: `cd /tmp/diffs.nvim/fugitive-keymaps-migration-shim && nvim --headless --clean -u init-old.lua +'lua dump_fugitive_maps()' +qa && printf '\n' && nvim --headless --clean -u init-new.lua +'lua dump_fugitive_maps()' +qa`

## Verification
- `busted spec/runtime_spec.lua spec/fugitive_spec.lua`
- `stylua --check lua/diffs/config.lua lua/diffs/fugitive.lua plugin/diffs.lua spec/runtime_spec.lua spec/fugitive_spec.lua`
- `vimdoc-language-server check doc/`
- `stylua --check .`
- `just lint`
- `nix fmt -- --ci`
- `just test`
- `git diff --check`

Note: `biome format .` could not run locally because `biome` is not on the current direnv PATH.
