### PR TITLE
fix(config): normalize config during plugin bootstrap

### DIFF
--- a/lua/diffs/runtime/init.lua
+++ b/lua/diffs/runtime/init.lua
@@ -24,6 +24,7 @@ local cache = cache_mod.new({
 })
 
 local initialized = false
+local configured = false
 local hl_retry_pending = false
 
 ---@diagnostic disable-next-line: missing-fields
@@ -57,7 +58,9 @@ local function init()
   end
   initialized = true
 
-  config = config_mod.new(vim.g.diffs or {})
+  if not configured then
+    config = config_mod.new(vim.g.diffs or {})
+  end
   log.set_enabled(config.debug)
 
   fast_hl_opts = {
@@ -97,6 +100,15 @@ local function init()
       diff_windows_mod.forget(diff_windows, tonumber(args.match))
     end,
   })
+end
+
+---@param user_config diffs.Config
+function M.configure(user_config)
+  if initialized then
+    return
+  end
+  config = user_config
+  configured = true
 end
 
 ---@param bufnr? integer

--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -1,12 +1,15 @@
 if vim.g.loaded_diffs then
   return
 end
+
+local config = require('diffs.config')
+local user_config = config.new(vim.deepcopy(vim.g.diffs or {}))
+local runtime = require('diffs.runtime')
+
+runtime.configure(user_config)
 vim.g.loaded_diffs = 1
 
 require('diffs.commands').setup()
-local config = require('diffs.config')
-local runtime = require('diffs.runtime')
-local user_config = vim.g.diffs or {}
 
 local integrations = user_config.integrations or {}
 

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -1,0 +1,93 @@
+require('spec.helpers')
+
+describe('plugin bootstrap', function()
+  local function run_child(init_lines, after_lines)
+    local tmpdir = vim.fn.tempname()
+    assert.are.equal(1, vim.fn.mkdir(tmpdir, 'p'))
+    local init_file = tmpdir .. '/init.lua'
+    local after_file = tmpdir .. '/after.lua'
+    vim.fn.writefile(init_lines, init_file)
+    vim.fn.writefile(after_lines, after_file)
+
+    local output = vim.fn.system({
+      vim.v.progpath,
+      '--headless',
+      '--clean',
+      '-u',
+      init_file,
+      '+luafile ' .. after_file,
+      '+qa',
+    })
+    local shell_error = vim.v.shell_error
+    vim.fn.delete(tmpdir, 'rf')
+    assert.are.equal(0, shell_error, output)
+    return output
+  end
+
+  it('emits config deprecations during plugin startup and not first attach', function()
+    local init_lines = {
+      '_G.diffs_notifications = {}',
+      'vim.notify = function(message, level)',
+      '_G.diffs_notifications[#_G.diffs_notifications + 1] = { message = message, level = level }',
+      'end',
+      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, integrations = { fugitive = { horizontal = 'dd', vertical = false } } }",
+      ('vim.opt.runtimepath:prepend(%s)'):format(vim.inspect(vim.fn.getcwd())),
+    }
+
+    local after_lines = {
+      'local function deprecations()',
+      'local result = {}',
+      'for _, item in ipairs(_G.diffs_notifications or {}) do',
+      "if item.message:find('Feature will be removed', 1, true) then",
+      "result[#result + 1] = item.message:gsub('\\n', ' | ')",
+      'end',
+      'end',
+      'return result',
+      'end',
+      "print('loaded=' .. tostring(vim.g.loaded_diffs))",
+      'local startup = deprecations()',
+      "print('startup_deprecations=' .. #startup)",
+      'for _, message in ipairs(startup) do print(message) end',
+      "local runtime = require('diffs.runtime')",
+      'runtime.attach(0)',
+      "print('after_attach_deprecations=' .. #deprecations())",
+      'local runtime_config = runtime._test.get_config()',
+      "print('runtime_view_prefix=' .. tostring(runtime_config.view.prefix))",
+      "print('runtime_fugitive_horizontal=' .. tostring(runtime_config.integrations.fugitive.horizontal))",
+      "print('runtime_gutter=' .. tostring(runtime_config.highlights.gutter))",
+      'local has_fugitive = false',
+      "for _, autocmd in ipairs(vim.api.nvim_get_autocmds({ event = 'FileType' })) do",
+      "if autocmd.pattern == 'fugitive' then has_fugitive = true end",
+      'end',
+      "print('has_fugitive_autocmd=' .. tostring(has_fugitive))",
+    }
+
+    local output = run_child(init_lines, after_lines)
+
+    assert.matches('loaded=1', output, 1, true)
+    assert.matches('startup_deprecations=3', output, 1, true)
+    assert.matches(
+      'vim.g.diffs.hide_prefix is deprecated, use vim.g.diffs.view.prefix instead. | Feature will be removed in diffs.nvim 0.4.0',
+      output,
+      1,
+      true
+    )
+    assert.matches(
+      'vim.g.diffs.integrations.fugitive.{horizontal,vertical} is deprecated. | Feature will be removed in diffs.nvim 0.4.0',
+      output,
+      1,
+      true
+    )
+    assert.matches(
+      'vim.g.diffs.highlights.gutter is deprecated. | Feature will be removed in diffs.nvim 0.4.0',
+      output,
+      1,
+      true
+    )
+    assert.matches('after_attach_deprecations=3', output, 1, true)
+    assert.matches('runtime_view_prefix=false', output, 1, true)
+    assert.matches('runtime_fugitive_horizontal=nil', output, 1, true)
+    assert.matches('runtime_gutter=false', output, 1, true)
+    assert.matches('has_fugitive_autocmd=true', output, 1, true)
+  end)
+end)


### PR DESCRIPTION
## Summary
- normalize `vim.g.diffs` during plugin bootstrap so config deprecations fire when the plugin consumes config
- pass the normalized bootstrap config into runtime so first attach/getter does not re-read a different config snapshot
- use the normalized config for integration setup and `FileType` autocmd registration
- add an isolated child-Neovim bootstrap regression test

## Behavior
- deprecated config now warns during plugin startup, before the first runtime attach
- repeated runtime attach keeps the same deprecation count because runtime consumes the bootstrap config
- `vim.g.diffs` is not assigned back to a default-expanded config table

## Shim
- `/tmp/diffs.nvim/config-deprecation-bootstrap-shim`
- one-line validation:

```sh
cd /tmp/diffs.nvim/config-deprecation-bootstrap-shim && nvim --headless --clean -u init.lua +'lua report()' +qa
```

Expected highlights:

```text
loaded=1
startup_deprecations=3
after_attach_deprecations=3
runtime_view_prefix=false
runtime_fugitive_horizontal=nil
runtime_gutter=false
has_fugitive_autocmd=true
```

## Verification
- `busted spec/plugin_spec.lua spec/runtime_spec.lua`
- shim command above
- `stylua --check plugin/diffs.lua lua/diffs/runtime/init.lua spec/plugin_spec.lua`
- `stylua --check .`
- `nix fmt -- --ci`
- `just lint`
- `just test`
- `git diff --check`
