### PR TITLE
fix(config): deprecate neogit table config

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -160,10 +160,10 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              `view.prefix = false`.
 
         {integrations}       (table, default: all false)
-                             Integration toggles. Each key accepts `true`,
-                             `false`, or a table with sub-options. Passing
-                             `true` or a table enables the integration;
-                             `false` disables it. See |diffs.nvim-integrations|.
+                             Integration toggles. Each key accepts `true` or
+                             `false`; tables are accepted where documented for
+                             current or deprecated sub-options. See
+                             |diffs.nvim-integrations|.
                                                *diffs.nvim.IntegrationsConfig*
                              Fields: ~
 
@@ -183,6 +183,9 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              See |diffs.nvim-neogit|. >lua
                                  integrations = { neogit = true }
 <
+                             Passing a table is deprecated; use `true`
+                             instead. During the deprecation window, table
+                             presence still enables the integration.
 
             {neojj}          (boolean|table, default: false)
                              Enable neojj integration. When active,
@@ -939,6 +942,12 @@ Enable Neogit (https://github.com/NeogitOrg/neogit) support: >lua
 
 Expanding a diff in a Neogit buffer (e.g., TAB on a file in the status view)
 applies treesitter syntax highlighting and intra-line diffs to the hunk lines.
+
+Configuration: ~
+                                                     *diffs.nvim.NeogitConfig*
+    Use `neogit = false` to disable. Passing a table is deprecated; use
+    `neogit = true` instead. During the deprecation window, table presence still
+    enables the integration.
 
 ------------------------------------------------------------------------------
 NEOJJ                                                       *diffs.nvim-neojj*

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -42,7 +42,7 @@ local M = {}
 ---@field horizontal? string|false deprecated: remove; status keymaps are fixed
 ---@field vertical? string|false deprecated: remove; status keymaps are fixed
 
----@class diffs.NeogitConfig
+---@class diffs.NeogitConfig deprecated: use integrations.neogit = true
 
 ---@class diffs.NeojjConfig
 
@@ -73,7 +73,7 @@ local M = {}
 
 ---@class diffs.IntegrationsConfig
 ---@field fugitive diffs.FugitiveConfig|false
----@field neogit diffs.NeogitConfig|false
+---@field neogit boolean|diffs.NeogitConfig
 ---@field neojj diffs.NeojjConfig|false
 ---@field gitsigns diffs.GitsignsConfig|false
 ---@field committia diffs.CommittiaConfig|false
@@ -179,6 +179,20 @@ local function deprecate_fugitive_keymaps(fugitive)
   fugitive.vertical = nil
 end
 
+---@param integrations table
+local function migrate_neogit(integrations)
+  if type(integrations.neogit) ~= 'table' then
+    return
+  end
+  vim.deprecate(
+    'vim.g.diffs.integrations.neogit = { ... }',
+    'vim.g.diffs.integrations.neogit = true',
+    '0.4.0',
+    'diffs.nvim'
+  )
+  integrations.neogit = true
+end
+
 ---@param opts table
 local function deprecate_highlights(opts)
   if opts.highlights and opts.highlights.gutter ~= nil then
@@ -221,9 +235,7 @@ function M.normalize_integrations(opts)
     deprecate_fugitive_keymaps(intg.fugitive)
   end
 
-  if intg.neogit == true then
-    intg.neogit = {}
-  end
+  migrate_neogit(intg)
 
   if intg.neojj == true then
     intg.neojj = {}
@@ -255,14 +267,14 @@ function M.validate(opts)
   end
   vim.validate('integrations', opts.integrations, 'table', true)
   local integration_validator = function(v)
-    return v == nil or v == false or type(v) == 'table'
+    return v == nil or type(v) == 'boolean' or type(v) == 'table'
   end
   for _, key in ipairs(integration_keys) do
     vim.validate(
       'integrations.' .. key,
       opts.integrations[key],
       integration_validator,
-      'table or false'
+      'boolean or table'
     )
   end
   vim.validate('extra_filetypes', opts.extra_filetypes, 'table', true)

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -30,7 +30,7 @@ describe('plugin bootstrap', function()
       'vim.notify = function(message, level)',
       '_G.diffs_notifications[#_G.diffs_notifications + 1] = { message = message, level = level }',
       'end',
-      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, integrations = { fugitive = { horizontal = 'dd', vertical = false } } }",
+      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {} } }",
       ('vim.opt.runtimepath:prepend(%s)'):format(vim.inspect(vim.fn.getcwd())),
     }
 
@@ -54,18 +54,22 @@ describe('plugin bootstrap', function()
       'local runtime_config = runtime._test.get_config()',
       "print('runtime_view_prefix=' .. tostring(runtime_config.view.prefix))",
       "print('runtime_fugitive_horizontal=' .. tostring(runtime_config.integrations.fugitive.horizontal))",
+      "print('runtime_neogit=' .. tostring(runtime_config.integrations.neogit))",
       "print('runtime_gutter=' .. tostring(runtime_config.highlights.gutter))",
       'local has_fugitive = false',
+      'local has_neogit = false',
       "for _, autocmd in ipairs(vim.api.nvim_get_autocmds({ event = 'FileType' })) do",
       "if autocmd.pattern == 'fugitive' then has_fugitive = true end",
+      "if autocmd.pattern == 'NeogitStatus' then has_neogit = true end",
       'end',
       "print('has_fugitive_autocmd=' .. tostring(has_fugitive))",
+      "print('has_neogit_autocmd=' .. tostring(has_neogit))",
     }
 
     local output = run_child(init_lines, after_lines)
 
     assert.matches('loaded=1', output, 1, true)
-    assert.matches('startup_deprecations=3', output, 1, true)
+    assert.matches('startup_deprecations=4', output, 1, true)
     assert.matches(
       'vim.g.diffs.hide_prefix is deprecated, use vim.g.diffs.view.prefix instead. | Feature will be removed in diffs.nvim 0.4.0',
       output,
@@ -79,15 +83,23 @@ describe('plugin bootstrap', function()
       true
     )
     assert.matches(
+      'vim.g.diffs.integrations.neogit = { ... } is deprecated, use vim.g.diffs.integrations.neogit = true instead. | Feature will be removed in diffs.nvim 0.4.0',
+      output,
+      1,
+      true
+    )
+    assert.matches(
       'vim.g.diffs.highlights.gutter is deprecated. | Feature will be removed in diffs.nvim 0.4.0',
       output,
       1,
       true
     )
-    assert.matches('after_attach_deprecations=3', output, 1, true)
+    assert.matches('after_attach_deprecations=4', output, 1, true)
     assert.matches('runtime_view_prefix=false', output, 1, true)
     assert.matches('runtime_fugitive_horizontal=nil', output, 1, true)
+    assert.matches('runtime_neogit=true', output, 1, true)
     assert.matches('runtime_gutter=false', output, 1, true)
     assert.matches('has_fugitive_autocmd=true', output, 1, true)
+    assert.matches('has_neogit_autocmd=true', output, 1, true)
   end)
 end)

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -163,6 +163,52 @@ describe('diffs.runtime', function()
         notifications[1].message
       )
     end)
+
+    it('keeps integrations.neogit = true as the supported enable path', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local opts = config.new({ integrations = { neogit = true } })
+      vim.notify = saved_notify
+
+      assert.is_true(opts.integrations.neogit)
+      assert.are.equal(0, #notifications)
+    end)
+
+    it('warns and maps deprecated integrations.neogit table form to true', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, opts = pcall(config.new, {
+        integrations = {
+          neogit = {},
+        },
+      })
+      vim.notify = saved_notify
+
+      assert.is_true(ok)
+      assert.is_true(opts.integrations.neogit)
+      assert.are.equal(2, #notifications)
+      assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+      assert.are.equal(
+        'vim.g.diffs.integrations.neogit = { ... } is deprecated, use vim.g.diffs.integrations.neogit = true instead.\n'
+          .. 'Feature will be removed in diffs.nvim 0.4.0',
+        notifications[1].message
+      )
+      assert.are.equal(vim.log.levels.WARN, notifications[2].level)
+      assert.is_true(notifications[2].message:find('stack traceback:\n\t', 1, true) == 1)
+      assert.is_not_nil(notifications[2].message:find('lua/diffs/config.lua:', 1, true))
+      assert.is_not_nil(notifications[2].message:find("in function 'migrate_neogit'", 1, true))
+      assert.is_not_nil(
+        notifications[2].message:find("in function 'normalize_integrations'", 1, true)
+      )
+    end)
   end)
 
   describe('attach', function()


### PR DESCRIPTION
## Summary
- deprecate `vim.g.diffs.integrations.neogit = { ... }` in favor of `vim.g.diffs.integrations.neogit = true`
- normalize deprecated Neogit table config to the supported boolean shape during plugin bootstrap
- document the Neogit table deprecation in place and keep other integration table forms scoped to their own future decisions
- extend runtime and plugin bootstrap regression coverage for the warning text, backtrace notification, normalized config, and Neogit filetype autocmd

## Behavior
- `integrations.neogit = true` remains the supported enable path and emits no deprecation notifications
- `integrations.neogit = {}` emits the standard `vim.deprecate()` warning and still enables Neogit during the deprecation window
- runtime config sees `integrations.neogit == true` for both old and new forms

## Shim
- `/tmp/diffs.nvim/neogit-boolean-config-shim`
- one-line validation:

```sh
cd /tmp/diffs.nvim/neogit-boolean-config-shim && nvim --headless --clean -u init-old.lua +'lua report()' +qa && printf '\n' && nvim --headless --clean -u init-new.lua +'lua report()' +qa
```

Expected highlights:

```text
vim.g.diffs.integrations.neogit = { ... } is deprecated, use vim.g.diffs.integrations.neogit = true instead.
runtime_neogit=true
has_neogit_autocmd=true
notifications=0
```

## Verification
- `busted spec/runtime_spec.lua spec/plugin_spec.lua spec/neogit_integration_spec.lua`
- shim command above
- `stylua --check lua/diffs/config.lua spec/runtime_spec.lua spec/plugin_spec.lua`
- `vimdoc-language-server check doc/`
- `git diff --check`
- `just lint`
- `just test`
- `stylua --check .`
- `nix fmt -- --ci`
