### PR TITLE
fix(config): deprecate neojj table config

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -194,6 +194,9 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              See |diffs.nvim-neojj|. >lua
                                  integrations = { neojj = true }
 <
+                             Passing a table is deprecated; use `true`
+                             instead. During the deprecation window, table
+                             presence still enables the integration.
 
             {gitsigns}       (boolean|table, default: false)
                              Enable gitsigns.nvim popup integration for
@@ -958,6 +961,12 @@ Enable neojj (https://github.com/NicholasZolton/neojj) support: >lua
 
 Expanding a diff in a neojj buffer (e.g., TAB on a file in the status view)
 applies treesitter syntax highlighting and intra-line diffs to the hunk lines.
+
+Configuration: ~
+                                                       *diffs.nvim.NeojjConfig*
+    Use `neojj = false` to disable. Passing a table is deprecated; use
+    `neojj = true` instead. During the deprecation window, table presence still
+    enables the integration.
 
 ------------------------------------------------------------------------------
 GITSIGNS                                                 *diffs.nvim-gitsigns*

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -44,7 +44,7 @@ local M = {}
 
 ---@class diffs.NeogitConfig deprecated: use integrations.neogit = true
 
----@class diffs.NeojjConfig
+---@class diffs.NeojjConfig deprecated: use integrations.neojj = true
 
 ---@class diffs.GitsignsConfig
 
@@ -74,7 +74,7 @@ local M = {}
 ---@class diffs.IntegrationsConfig
 ---@field fugitive diffs.FugitiveConfig|false
 ---@field neogit boolean|diffs.NeogitConfig
----@field neojj diffs.NeojjConfig|false
+---@field neojj boolean
 ---@field gitsigns diffs.GitsignsConfig|false
 ---@field committia diffs.CommittiaConfig|false
 ---@field telescope diffs.TelescopeConfig|false
@@ -193,6 +193,20 @@ local function migrate_neogit(integrations)
   integrations.neogit = true
 end
 
+---@param integrations table
+local function migrate_neojj(integrations)
+  if type(integrations.neojj) ~= 'table' then
+    return
+  end
+  vim.deprecate(
+    'vim.g.diffs.integrations.neojj = { ... }',
+    'vim.g.diffs.integrations.neojj = true',
+    '0.4.0',
+    'diffs.nvim'
+  )
+  integrations.neojj = true
+end
+
 ---@param opts table
 local function deprecate_highlights(opts)
   if opts.highlights and opts.highlights.gutter ~= nil then
@@ -237,9 +251,7 @@ function M.normalize_integrations(opts)
 
   migrate_neogit(intg)
 
-  if intg.neojj == true then
-    intg.neojj = {}
-  end
+  migrate_neojj(intg)
 
   if intg.gitsigns == true then
     intg.gitsigns = {}

--- a/lua/diffs/runtime/init.lua
+++ b/lua/diffs/runtime/init.lua
@@ -145,7 +145,7 @@ function M.get_fugitive_config()
   return config.integrations.fugitive
 end
 
----@return diffs.NeojjConfig|false
+---@return boolean
 function M.get_neojj_config()
   init()
   return config.integrations.neojj

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -30,7 +30,7 @@ describe('plugin bootstrap', function()
       'vim.notify = function(message, level)',
       '_G.diffs_notifications[#_G.diffs_notifications + 1] = { message = message, level = level }',
       'end',
-      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {} } }",
+      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {}, neojj = {} } }",
       ('vim.opt.runtimepath:prepend(%s)'):format(vim.inspect(vim.fn.getcwd())),
     }
 
@@ -55,21 +55,25 @@ describe('plugin bootstrap', function()
       "print('runtime_view_prefix=' .. tostring(runtime_config.view.prefix))",
       "print('runtime_fugitive_horizontal=' .. tostring(runtime_config.integrations.fugitive.horizontal))",
       "print('runtime_neogit=' .. tostring(runtime_config.integrations.neogit))",
+      "print('runtime_neojj=' .. tostring(runtime_config.integrations.neojj))",
       "print('runtime_gutter=' .. tostring(runtime_config.highlights.gutter))",
       'local has_fugitive = false',
       'local has_neogit = false',
+      'local has_neojj = false',
       "for _, autocmd in ipairs(vim.api.nvim_get_autocmds({ event = 'FileType' })) do",
       "if autocmd.pattern == 'fugitive' then has_fugitive = true end",
       "if autocmd.pattern == 'NeogitStatus' then has_neogit = true end",
+      "if autocmd.pattern == 'NeojjStatus' then has_neojj = true end",
       'end',
       "print('has_fugitive_autocmd=' .. tostring(has_fugitive))",
       "print('has_neogit_autocmd=' .. tostring(has_neogit))",
+      "print('has_neojj_autocmd=' .. tostring(has_neojj))",
     }
 
     local output = run_child(init_lines, after_lines)
 
     assert.matches('loaded=1', output, 1, true)
-    assert.matches('startup_deprecations=4', output, 1, true)
+    assert.matches('startup_deprecations=5', output, 1, true)
     assert.matches(
       'vim.g.diffs.hide_prefix is deprecated, use vim.g.diffs.view.prefix instead. | Feature will be removed in diffs.nvim 0.4.0',
       output,
@@ -89,17 +93,25 @@ describe('plugin bootstrap', function()
       true
     )
     assert.matches(
+      'vim.g.diffs.integrations.neojj = { ... } is deprecated, use vim.g.diffs.integrations.neojj = true instead. | Feature will be removed in diffs.nvim 0.4.0',
+      output,
+      1,
+      true
+    )
+    assert.matches(
       'vim.g.diffs.highlights.gutter is deprecated. | Feature will be removed in diffs.nvim 0.4.0',
       output,
       1,
       true
     )
-    assert.matches('after_attach_deprecations=4', output, 1, true)
+    assert.matches('after_attach_deprecations=5', output, 1, true)
     assert.matches('runtime_view_prefix=false', output, 1, true)
     assert.matches('runtime_fugitive_horizontal=nil', output, 1, true)
     assert.matches('runtime_neogit=true', output, 1, true)
+    assert.matches('runtime_neojj=true', output, 1, true)
     assert.matches('runtime_gutter=false', output, 1, true)
     assert.matches('has_fugitive_autocmd=true', output, 1, true)
     assert.matches('has_neogit_autocmd=true', output, 1, true)
+    assert.matches('has_neojj_autocmd=true', output, 1, true)
   end)
 end)

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -209,6 +209,52 @@ describe('diffs.runtime', function()
         notifications[2].message:find("in function 'normalize_integrations'", 1, true)
       )
     end)
+
+    it('keeps integrations.neojj = true as the supported enable path', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local opts = config.new({ integrations = { neojj = true } })
+      vim.notify = saved_notify
+
+      assert.is_true(opts.integrations.neojj)
+      assert.are.equal(0, #notifications)
+    end)
+
+    it('warns and maps deprecated integrations.neojj table form to true', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, opts = pcall(config.new, {
+        integrations = {
+          neojj = {},
+        },
+      })
+      vim.notify = saved_notify
+
+      assert.is_true(ok)
+      assert.is_true(opts.integrations.neojj)
+      assert.are.equal(2, #notifications)
+      assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+      assert.are.equal(
+        'vim.g.diffs.integrations.neojj = { ... } is deprecated, use vim.g.diffs.integrations.neojj = true instead.\n'
+          .. 'Feature will be removed in diffs.nvim 0.4.0',
+        notifications[1].message
+      )
+      assert.are.equal(vim.log.levels.WARN, notifications[2].level)
+      assert.is_true(notifications[2].message:find('stack traceback:\n\t', 1, true) == 1)
+      assert.is_not_nil(notifications[2].message:find('lua/diffs/config.lua:', 1, true))
+      assert.is_not_nil(notifications[2].message:find("in function 'migrate_neojj'", 1, true))
+      assert.is_not_nil(
+        notifications[2].message:find("in function 'normalize_integrations'", 1, true)
+      )
+    end)
   end)
 
   describe('attach', function()


### PR DESCRIPTION
## Summary
- deprecate `vim.g.diffs.integrations.neojj = { ... }` in favor of `vim.g.diffs.integrations.neojj = true`
- normalize deprecated neojj table config to the supported boolean shape during plugin bootstrap
- document the neojj table deprecation in place and keep other integration table forms scoped to their own future decisions
- extend runtime and plugin bootstrap regression coverage for the warning text, backtrace notification, normalized config, and neojj filetype autocmd

## Behavior
- `integrations.neojj = true` remains the supported enable path and emits no deprecation notifications
- `integrations.neojj = {}` emits the standard `vim.deprecate()` warning and still enables neojj during the deprecation window
- runtime config sees `integrations.neojj == true` for both old and new forms

## Shim
- `/tmp/diffs.nvim/neojj-boolean-config-shim`
- one-line validation:

```sh
cd /tmp/diffs.nvim/neojj-boolean-config-shim && nvim --headless --clean -u init-old.lua +'lua report()' +qa && printf '\n' && nvim --headless --clean -u init-new.lua +'lua report()' +qa
```

Expected highlights:

```text
vim.g.diffs.integrations.neojj = { ... } is deprecated, use vim.g.diffs.integrations.neojj = true instead.
runtime_neojj=true
has_neojj_autocmd=true
notifications=0
```

## Verification
- `busted spec/runtime_spec.lua spec/plugin_spec.lua spec/neojj_integration_spec.lua`
- shim command above
- `stylua --check lua/diffs/config.lua lua/diffs/runtime/init.lua spec/runtime_spec.lua spec/plugin_spec.lua`
- `vimdoc-language-server check doc/`
- `git diff --check`
- `just lint`
- `just test`
- `stylua --check .`
- `nix fmt -- --ci`
