### PR TITLE
fix(config): deprecate conflict priority

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -1024,7 +1024,6 @@ Configuration: ~
         disable_diagnostics = true,
         show_virtual_text = true,
         show_actions = false,
-        priority = 200,
         keymaps = false,
       },
     }
@@ -1085,10 +1084,10 @@ Configuration: ~
                              `DiffsConflictActions` highlight group. Only
                              configured keymaps appear.
 
-        {priority}           (integer, default: 200)
-                             Extmark priority for conflict region
-                             backgrounds and markers. Adjust if other
-                             plugins use the same priority range.
+        {priority}           (integer, deprecated)
+                             Remove this key. Conflict extmark ordering is
+                             fixed internally; during the deprecation window,
+                             custom values are ignored.
 
         {keymaps}            (table|false, default: false)
                              Opt-in buffer-local keymaps for conflict

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -68,7 +68,7 @@ local M = {}
 ---@field show_virtual_text boolean
 ---@field format_virtual_text? fun(side: string, keymap: string|false): string?
 ---@field show_actions boolean
----@field priority integer
+---@field priority? integer deprecated: remove from config; conflict priority is fixed internally
 ---@field keymaps diffs.ConflictKeymaps|false
 
 ---@class diffs.IntegrationsConfig
@@ -135,7 +135,6 @@ local DEFAULTS = {
     disable_diagnostics = true,
     show_virtual_text = true,
     show_actions = false,
-    priority = 200,
     keymaps = false,
   },
 }
@@ -212,6 +211,19 @@ local function deprecate_highlights(opts)
   if opts.highlights and opts.highlights.gutter ~= nil then
     vim.deprecate('vim.g.diffs.highlights.gutter', nil, '0.4.0', 'diffs.nvim')
   end
+end
+
+---@param opts table
+local function deprecate_conflict(opts)
+  if type(opts.conflict) ~= 'table' or opts.conflict.priority == nil then
+    return
+  end
+  vim.validate('conflict.priority', opts.conflict.priority, 'number')
+  if opts.conflict.priority < 0 then
+    error('diffs: conflict.priority must be >= 0')
+  end
+  vim.deprecate('vim.g.diffs.conflict.priority', nil, '0.4.0', 'diffs.nvim')
+  opts.conflict.priority = nil
 end
 
 ---@param opts table
@@ -371,7 +383,6 @@ function M.validate(opts)
       true
     )
     vim.validate('conflict.show_actions', opts.conflict.show_actions, 'boolean', true)
-    vim.validate('conflict.priority', opts.conflict.priority, 'number', true)
     vim.validate('conflict.keymaps', opts.conflict.keymaps, function(v)
       return v == nil or v == false or type(v) == 'table'
     end, 'table or false')
@@ -438,9 +449,6 @@ function M.validate(opts)
       end
     end
   end
-  if opts.conflict and opts.conflict.priority and opts.conflict.priority < 0 then
-    error('diffs: conflict.priority must be >= 0')
-  end
 end
 
 ---@param opts? table
@@ -450,6 +458,7 @@ function M.new(opts)
   migrate_view(opts)
   M.normalize_integrations(opts)
   deprecate_highlights(opts)
+  deprecate_conflict(opts)
   M.validate(opts)
   return vim.tbl_deep_extend('force', DEFAULTS, opts)
 end

--- a/lua/diffs/conflict.lua
+++ b/lua/diffs/conflict.lua
@@ -16,6 +16,7 @@ local keymaps = require('diffs.keymaps')
 local notify = require('diffs.log').notify
 
 local ns = vim.api.nvim_create_namespace('diffs-conflict')
+local CONFLICT_PRIORITY = 200
 
 ---@type table<integer, true>
 local attached_buffers = {}
@@ -121,7 +122,7 @@ local function apply_highlights(bufnr, regions, config)
       end_row = region.marker_ours + 1,
       hl_group = 'DiffsConflictMarker',
       hl_eol = true,
-      priority = config.priority,
+      priority = CONFLICT_PRIORITY,
     })
 
     if config.show_virtual_text then
@@ -163,11 +164,11 @@ local function apply_highlights(bufnr, regions, config)
         end_row = line + 1,
         hl_group = 'DiffsConflictOurs',
         hl_eol = true,
-        priority = config.priority,
+        priority = CONFLICT_PRIORITY,
       })
       pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, {
         number_hl_group = 'DiffsConflictOursNr',
-        priority = config.priority,
+        priority = CONFLICT_PRIORITY,
       })
     end
 
@@ -176,7 +177,7 @@ local function apply_highlights(bufnr, regions, config)
         end_row = region.marker_base + 1,
         hl_group = 'DiffsConflictMarker',
         hl_eol = true,
-        priority = config.priority,
+        priority = CONFLICT_PRIORITY,
       })
 
       for line = region.base_start, region.base_end - 1 do
@@ -184,11 +185,11 @@ local function apply_highlights(bufnr, regions, config)
           end_row = line + 1,
           hl_group = 'DiffsConflictBase',
           hl_eol = true,
-          priority = config.priority,
+          priority = CONFLICT_PRIORITY,
         })
         pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, {
           number_hl_group = 'DiffsConflictBaseNr',
-          priority = config.priority,
+          priority = CONFLICT_PRIORITY,
         })
       end
     end
@@ -197,7 +198,7 @@ local function apply_highlights(bufnr, regions, config)
       end_row = region.marker_sep + 1,
       hl_group = 'DiffsConflictMarker',
       hl_eol = true,
-      priority = config.priority,
+      priority = CONFLICT_PRIORITY,
     })
 
     for line = region.theirs_start, region.theirs_end - 1 do
@@ -205,11 +206,11 @@ local function apply_highlights(bufnr, regions, config)
         end_row = line + 1,
         hl_group = 'DiffsConflictTheirs',
         hl_eol = true,
-        priority = config.priority,
+        priority = CONFLICT_PRIORITY,
       })
       pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, {
         number_hl_group = 'DiffsConflictTheirsNr',
-        priority = config.priority,
+        priority = CONFLICT_PRIORITY,
       })
     end
 
@@ -217,7 +218,7 @@ local function apply_highlights(bufnr, regions, config)
       end_row = region.marker_theirs + 1,
       hl_group = 'DiffsConflictMarker',
       hl_eol = true,
-      priority = config.priority,
+      priority = CONFLICT_PRIORITY,
     })
 
     if config.show_virtual_text then

--- a/spec/conflict_spec.lua
+++ b/spec/conflict_spec.lua
@@ -205,6 +205,30 @@ describe('conflict', function()
       helpers.delete_buffer(bufnr)
     end)
 
+    it('uses fixed extmark priority for conflict regions', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+
+      conflict.attach(bufnr, default_config({ priority = 999 }))
+
+      local checked = 0
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        local details = mark[4]
+        if details and (details.hl_group or details.number_hl_group) then
+          assert.are.equal(200, details.priority)
+          checked = checked + 1
+        end
+      end
+      assert.is_true(checked > 0)
+
+      helpers.delete_buffer(bufnr)
+    end)
+
     it('applies virtual text when enabled', function()
       local bufnr = create_file_buffer({
         '<<<<<<< HEAD',

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -30,7 +30,7 @@ describe('plugin bootstrap', function()
       'vim.notify = function(message, level)',
       '_G.diffs_notifications[#_G.diffs_notifications + 1] = { message = message, level = level }',
       'end',
-      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {}, neojj = {} } }",
+      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, conflict = { priority = 250 }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {}, neojj = {} } }",
       ('vim.opt.runtimepath:prepend(%s)'):format(vim.inspect(vim.fn.getcwd())),
     }
 
@@ -57,6 +57,7 @@ describe('plugin bootstrap', function()
       "print('runtime_neogit=' .. tostring(runtime_config.integrations.neogit))",
       "print('runtime_neojj=' .. tostring(runtime_config.integrations.neojj))",
       "print('runtime_gutter=' .. tostring(runtime_config.highlights.gutter))",
+      "print('runtime_conflict_priority=' .. tostring(runtime_config.conflict.priority))",
       'local has_fugitive = false',
       'local has_neogit = false',
       'local has_neojj = false',
@@ -73,7 +74,7 @@ describe('plugin bootstrap', function()
     local output = run_child(init_lines, after_lines)
 
     assert.matches('loaded=1', output, 1, true)
-    assert.matches('startup_deprecations=5', output, 1, true)
+    assert.matches('startup_deprecations=6', output, 1, true)
     assert.matches(
       'vim.g.diffs.hide_prefix is deprecated, use vim.g.diffs.view.prefix instead. | Feature will be removed in diffs.nvim 0.4.0',
       output,
@@ -104,12 +105,19 @@ describe('plugin bootstrap', function()
       1,
       true
     )
-    assert.matches('after_attach_deprecations=5', output, 1, true)
+    assert.matches(
+      'vim.g.diffs.conflict.priority is deprecated. | Feature will be removed in diffs.nvim 0.4.0',
+      output,
+      1,
+      true
+    )
+    assert.matches('after_attach_deprecations=6', output, 1, true)
     assert.matches('runtime_view_prefix=false', output, 1, true)
     assert.matches('runtime_fugitive_horizontal=nil', output, 1, true)
     assert.matches('runtime_neogit=true', output, 1, true)
     assert.matches('runtime_neojj=true', output, 1, true)
     assert.matches('runtime_gutter=false', output, 1, true)
+    assert.matches('runtime_conflict_priority=nil', output, 1, true)
     assert.matches('has_fugitive_autocmd=true', output, 1, true)
     assert.matches('has_neogit_autocmd=true', output, 1, true)
     assert.matches('has_neojj_autocmd=true', output, 1, true)

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -131,6 +131,78 @@ describe('diffs.runtime', function()
       )
     end)
 
+    it('warns and drops deprecated conflict.priority', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, opts = pcall(config.new, { conflict = { priority = 250 } })
+      vim.notify = saved_notify
+
+      assert.is_true(ok)
+      assert.is_nil(opts.conflict.priority)
+      assert.are.equal(2, #notifications)
+      assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+      assert.are.equal(
+        'vim.g.diffs.conflict.priority is deprecated.\n'
+          .. 'Feature will be removed in diffs.nvim 0.4.0',
+        notifications[1].message
+      )
+      assert.are.equal(vim.log.levels.WARN, notifications[2].level)
+      assert.is_true(notifications[2].message:find('stack traceback:\n\t', 1, true) == 1)
+      assert.is_not_nil(notifications[2].message:find('lua/diffs/config.lua:', 1, true))
+      assert.is_not_nil(notifications[2].message:find("in function 'deprecate_conflict'", 1, true))
+    end)
+
+    it('keeps supported conflict config without priority quiet', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, opts = pcall(config.new, { conflict = { show_virtual_text = false } })
+      vim.notify = saved_notify
+
+      assert.is_true(ok)
+      assert.is_false(opts.conflict.show_virtual_text)
+      assert.is_nil(opts.conflict.priority)
+      assert.are.equal(0, #notifications)
+    end)
+
+    it('validates deprecated conflict.priority before warning', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, err = pcall(config.new, { conflict = { priority = -1 } })
+      vim.notify = saved_notify
+
+      assert.is_false(ok)
+      assert.matches('diffs: conflict.priority must be >= 0', err, 1, true)
+      assert.are.equal(0, #notifications)
+    end)
+
+    it('type-checks deprecated conflict.priority before warning', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, err = pcall(config.new, { conflict = { priority = 'bad' } })
+      vim.notify = saved_notify
+
+      assert.is_false(ok)
+      assert.matches('conflict.priority', err, 1, true)
+      assert.matches('number', err, 1, true)
+      assert.are.equal(0, #notifications)
+    end)
+
     it('normalizes integrations.fugitive = true to enabled table without keymap config', function()
       local opts = config.new({ integrations = { fugitive = true } })
 


### PR DESCRIPTION
Summary:
- deprecate `vim.g.diffs.conflict.priority`, validate old values, and drop the key from stored runtime config
- use fixed internal priority `200` for conflict extmarks
- update vimdoc, bootstrap coverage, runtime config tests, and conflict extmark tests

Verification:
- `direnv exec /home/barrett/dev/diffs.nvim busted spec/runtime_spec.lua spec/plugin_spec.lua spec/conflict_spec.lua`
- `direnv exec /home/barrett/dev/diffs.nvim nvim --headless --clean -u /tmp/diffs.nvim/conflict-priority-config-shim/init-old.lua +qa`
- `direnv exec /home/barrett/dev/diffs.nvim nvim --headless --clean -u /tmp/diffs.nvim/conflict-priority-config-shim/init-new.lua +qa`
- `direnv exec /home/barrett/dev/diffs.nvim nix develop .#ci -c just ci`