### PR TITLE
fix(config): deprecate gitsigns table config

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -204,6 +204,9 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              See |diffs.nvim-gitsigns|. >lua
                                  integrations = { gitsigns = true }
 <
+                             Passing a table is deprecated; use `true`
+                             instead. During the deprecation window, table
+                             presence still enables the integration.
 
             {committia}      (boolean|table, default: false)
                              Enable committia.vim integration. When active,
@@ -975,6 +978,12 @@ Enable gitsigns.nvim (https://github.com/lewis6991/gitsigns.nvim) popup
 integration for blame hunk previews: >lua
     vim.g.diffs = { integrations = { gitsigns = true } }
 <
+
+Configuration: ~
+                                                   *diffs.nvim.GitsignsConfig*
+    Use `gitsigns = false` to disable. Passing a table is deprecated; use
+    `gitsigns = true` instead. During the deprecation window, table presence
+    still enables the integration.
 
 `:Gitsigns blame_line full=true` popups receive treesitter syntax, line
 backgrounds, and intra-line diffs.

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -46,7 +46,7 @@ local M = {}
 
 ---@class diffs.NeojjConfig deprecated: use integrations.neojj = true
 
----@class diffs.GitsignsConfig
+---@class diffs.GitsignsConfig deprecated: use integrations.gitsigns = true
 
 ---@class diffs.CommittiaConfig
 
@@ -75,7 +75,7 @@ local M = {}
 ---@field fugitive diffs.FugitiveConfig|false
 ---@field neogit boolean|diffs.NeogitConfig
 ---@field neojj boolean
----@field gitsigns diffs.GitsignsConfig|false
+---@field gitsigns boolean
 ---@field committia diffs.CommittiaConfig|false
 ---@field telescope diffs.TelescopeConfig|false
 
@@ -206,6 +206,20 @@ local function migrate_neojj(integrations)
   integrations.neojj = true
 end
 
+---@param integrations table
+local function migrate_gitsigns(integrations)
+  if type(integrations.gitsigns) ~= 'table' then
+    return
+  end
+  vim.deprecate(
+    'vim.g.diffs.integrations.gitsigns = { ... }',
+    'vim.g.diffs.integrations.gitsigns = true',
+    '0.4.0',
+    'diffs.nvim'
+  )
+  integrations.gitsigns = true
+end
+
 ---@param opts table
 local function deprecate_highlights(opts)
   if opts.highlights and opts.highlights.gutter ~= nil then
@@ -265,9 +279,7 @@ function M.normalize_integrations(opts)
 
   migrate_neojj(intg)
 
-  if intg.gitsigns == true then
-    intg.gitsigns = {}
-  end
+  migrate_gitsigns(intg)
 
   if intg.committia == true then
     intg.committia = {}

--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -14,7 +14,7 @@ require('diffs.commands').setup()
 local integrations = user_config.integrations or {}
 
 local gs_cfg = integrations.gitsigns
-if gs_cfg == true or type(gs_cfg) == 'table' then
+if gs_cfg == true then
   if not require('diffs.gitsigns').setup() then
     vim.api.nvim_create_autocmd('User', {
       pattern = 'GitAttach',

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -30,7 +30,7 @@ describe('plugin bootstrap', function()
       'vim.notify = function(message, level)',
       '_G.diffs_notifications[#_G.diffs_notifications + 1] = { message = message, level = level }',
       'end',
-      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, conflict = { priority = 250 }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {}, neojj = {} } }",
+      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, conflict = { priority = 250 }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {}, neojj = {}, gitsigns = {} } }",
       ('vim.opt.runtimepath:prepend(%s)'):format(vim.inspect(vim.fn.getcwd())),
     }
 
@@ -56,6 +56,7 @@ describe('plugin bootstrap', function()
       "print('runtime_fugitive_horizontal=' .. tostring(runtime_config.integrations.fugitive.horizontal))",
       "print('runtime_neogit=' .. tostring(runtime_config.integrations.neogit))",
       "print('runtime_neojj=' .. tostring(runtime_config.integrations.neojj))",
+      "print('runtime_gitsigns=' .. tostring(runtime_config.integrations.gitsigns))",
       "print('runtime_gutter=' .. tostring(runtime_config.highlights.gutter))",
       "print('runtime_conflict_priority=' .. tostring(runtime_config.conflict.priority))",
       'local has_fugitive = false',
@@ -74,7 +75,7 @@ describe('plugin bootstrap', function()
     local output = run_child(init_lines, after_lines)
 
     assert.matches('loaded=1', output, 1, true)
-    assert.matches('startup_deprecations=6', output, 1, true)
+    assert.matches('startup_deprecations=7', output, 1, true)
     assert.matches(
       'vim.g.diffs.hide_prefix is deprecated, use vim.g.diffs.view.prefix instead. | Feature will be removed in diffs.nvim 0.4.0',
       output,
@@ -100,6 +101,12 @@ describe('plugin bootstrap', function()
       true
     )
     assert.matches(
+      'vim.g.diffs.integrations.gitsigns = { ... } is deprecated, use vim.g.diffs.integrations.gitsigns = true instead. | Feature will be removed in diffs.nvim 0.4.0',
+      output,
+      1,
+      true
+    )
+    assert.matches(
       'vim.g.diffs.highlights.gutter is deprecated. | Feature will be removed in diffs.nvim 0.4.0',
       output,
       1,
@@ -111,11 +118,12 @@ describe('plugin bootstrap', function()
       1,
       true
     )
-    assert.matches('after_attach_deprecations=6', output, 1, true)
+    assert.matches('after_attach_deprecations=7', output, 1, true)
     assert.matches('runtime_view_prefix=false', output, 1, true)
     assert.matches('runtime_fugitive_horizontal=nil', output, 1, true)
     assert.matches('runtime_neogit=true', output, 1, true)
     assert.matches('runtime_neojj=true', output, 1, true)
+    assert.matches('runtime_gitsigns=true', output, 1, true)
     assert.matches('runtime_gutter=false', output, 1, true)
     assert.matches('runtime_conflict_priority=nil', output, 1, true)
     assert.matches('has_fugitive_autocmd=true', output, 1, true)

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -327,6 +327,52 @@ describe('diffs.runtime', function()
         notifications[2].message:find("in function 'normalize_integrations'", 1, true)
       )
     end)
+
+    it('keeps integrations.gitsigns = true as the supported enable path', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local opts = config.new({ integrations = { gitsigns = true } })
+      vim.notify = saved_notify
+
+      assert.is_true(opts.integrations.gitsigns)
+      assert.are.equal(0, #notifications)
+    end)
+
+    it('warns and maps deprecated integrations.gitsigns table form to true', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, opts = pcall(config.new, {
+        integrations = {
+          gitsigns = {},
+        },
+      })
+      vim.notify = saved_notify
+
+      assert.is_true(ok)
+      assert.is_true(opts.integrations.gitsigns)
+      assert.are.equal(2, #notifications)
+      assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+      assert.are.equal(
+        'vim.g.diffs.integrations.gitsigns = { ... } is deprecated, use vim.g.diffs.integrations.gitsigns = true instead.\n'
+          .. 'Feature will be removed in diffs.nvim 0.4.0',
+        notifications[1].message
+      )
+      assert.are.equal(vim.log.levels.WARN, notifications[2].level)
+      assert.is_true(notifications[2].message:find('stack traceback:\n\t', 1, true) == 1)
+      assert.is_not_nil(notifications[2].message:find('lua/diffs/config.lua:', 1, true))
+      assert.is_not_nil(notifications[2].message:find("in function 'migrate_gitsigns'", 1, true))
+      assert.is_not_nil(
+        notifications[2].message:find("in function 'normalize_integrations'", 1, true)
+      )
+    end)
   end)
 
   describe('attach', function()


### PR DESCRIPTION
Summary:
- deprecate `vim.g.diffs.integrations.gitsigns = { ... }` and normalize it to `true`
- make plugin bootstrap read the normalized boolean gitsigns config
- update vimdoc, bootstrap coverage, runtime config tests, and manual shims

Verification:
- `direnv exec /home/barrett/dev/diffs.nvim busted spec/runtime_spec.lua spec/plugin_spec.lua spec/gitsigns_spec.lua`
- `direnv exec /home/barrett/dev/diffs.nvim nvim --headless --clean -u /tmp/diffs.nvim/gitsigns-boolean-config-shim/init-old.lua +qa`
- `direnv exec /home/barrett/dev/diffs.nvim nvim --headless --clean -u /tmp/diffs.nvim/gitsigns-boolean-config-shim/init-new.lua +qa`
- `direnv exec /home/barrett/dev/diffs.nvim nix develop .#ci -c just ci`