### PR TITLE
fix(config): deprecate committia table config

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -214,6 +214,9 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              syntax and intra-line diffs. >lua
                                  integrations = { committia = true }
 <
+                             Passing a table is deprecated; use `true`
+                             instead. During the deprecation window, table
+                             presence still normalizes to `true`.
 
             {telescope}      (boolean|table, default: false)
                              Enable telescope.nvim preview highlighting.

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -48,7 +48,7 @@ local M = {}
 
 ---@class diffs.GitsignsConfig deprecated: use integrations.gitsigns = true
 
----@class diffs.CommittiaConfig
+---@class diffs.CommittiaConfig deprecated: use integrations.committia = true
 
 ---@class diffs.TelescopeConfig
 
@@ -76,7 +76,7 @@ local M = {}
 ---@field neogit boolean|diffs.NeogitConfig
 ---@field neojj boolean
 ---@field gitsigns boolean
----@field committia diffs.CommittiaConfig|false
+---@field committia boolean
 ---@field telescope diffs.TelescopeConfig|false
 
 ---@class diffs.Config
@@ -220,6 +220,20 @@ local function migrate_gitsigns(integrations)
   integrations.gitsigns = true
 end
 
+---@param integrations table
+local function migrate_committia(integrations)
+  if type(integrations.committia) ~= 'table' then
+    return
+  end
+  vim.deprecate(
+    'vim.g.diffs.integrations.committia = { ... }',
+    'vim.g.diffs.integrations.committia = true',
+    '0.4.0',
+    'diffs.nvim'
+  )
+  integrations.committia = true
+end
+
 ---@param opts table
 local function deprecate_highlights(opts)
   if opts.highlights and opts.highlights.gutter ~= nil then
@@ -281,9 +295,7 @@ function M.normalize_integrations(opts)
 
   migrate_gitsigns(intg)
 
-  if intg.committia == true then
-    intg.committia = {}
-  end
+  migrate_committia(intg)
 
   if intg.telescope == true then
     intg.telescope = {}

--- a/lua/diffs/runtime/init.lua
+++ b/lua/diffs/runtime/init.lua
@@ -151,7 +151,7 @@ function M.get_neojj_config()
   return config.integrations.neojj
 end
 
----@return diffs.CommittiaConfig|false
+---@return boolean
 function M.get_committia_config()
   init()
   return config.integrations.committia

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -30,7 +30,7 @@ describe('plugin bootstrap', function()
       'vim.notify = function(message, level)',
       '_G.diffs_notifications[#_G.diffs_notifications + 1] = { message = message, level = level }',
       'end',
-      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, conflict = { priority = 250 }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {}, neojj = {}, gitsigns = {} } }",
+      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, conflict = { priority = 250 }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {}, neojj = {}, gitsigns = {}, committia = {} } }",
       ('vim.opt.runtimepath:prepend(%s)'):format(vim.inspect(vim.fn.getcwd())),
     }
 
@@ -57,6 +57,7 @@ describe('plugin bootstrap', function()
       "print('runtime_neogit=' .. tostring(runtime_config.integrations.neogit))",
       "print('runtime_neojj=' .. tostring(runtime_config.integrations.neojj))",
       "print('runtime_gitsigns=' .. tostring(runtime_config.integrations.gitsigns))",
+      "print('runtime_committia=' .. tostring(runtime_config.integrations.committia))",
       "print('runtime_gutter=' .. tostring(runtime_config.highlights.gutter))",
       "print('runtime_conflict_priority=' .. tostring(runtime_config.conflict.priority))",
       'local has_fugitive = false',
@@ -75,7 +76,7 @@ describe('plugin bootstrap', function()
     local output = run_child(init_lines, after_lines)
 
     assert.matches('loaded=1', output, 1, true)
-    assert.matches('startup_deprecations=7', output, 1, true)
+    assert.matches('startup_deprecations=8', output, 1, true)
     assert.matches(
       'vim.g.diffs.hide_prefix is deprecated, use vim.g.diffs.view.prefix instead. | Feature will be removed in diffs.nvim 0.4.0',
       output,
@@ -107,6 +108,12 @@ describe('plugin bootstrap', function()
       true
     )
     assert.matches(
+      'vim.g.diffs.integrations.committia = { ... } is deprecated, use vim.g.diffs.integrations.committia = true instead. | Feature will be removed in diffs.nvim 0.4.0',
+      output,
+      1,
+      true
+    )
+    assert.matches(
       'vim.g.diffs.highlights.gutter is deprecated. | Feature will be removed in diffs.nvim 0.4.0',
       output,
       1,
@@ -118,12 +125,13 @@ describe('plugin bootstrap', function()
       1,
       true
     )
-    assert.matches('after_attach_deprecations=7', output, 1, true)
+    assert.matches('after_attach_deprecations=8', output, 1, true)
     assert.matches('runtime_view_prefix=false', output, 1, true)
     assert.matches('runtime_fugitive_horizontal=nil', output, 1, true)
     assert.matches('runtime_neogit=true', output, 1, true)
     assert.matches('runtime_neojj=true', output, 1, true)
     assert.matches('runtime_gitsigns=true', output, 1, true)
+    assert.matches('runtime_committia=true', output, 1, true)
     assert.matches('runtime_gutter=false', output, 1, true)
     assert.matches('runtime_conflict_priority=nil', output, 1, true)
     assert.matches('has_fugitive_autocmd=true', output, 1, true)

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -373,6 +373,52 @@ describe('diffs.runtime', function()
         notifications[2].message:find("in function 'normalize_integrations'", 1, true)
       )
     end)
+
+    it('keeps integrations.committia = true as the supported enable path', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local opts = config.new({ integrations = { committia = true } })
+      vim.notify = saved_notify
+
+      assert.is_true(opts.integrations.committia)
+      assert.are.equal(0, #notifications)
+    end)
+
+    it('warns and maps deprecated integrations.committia table form to true', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, opts = pcall(config.new, {
+        integrations = {
+          committia = {},
+        },
+      })
+      vim.notify = saved_notify
+
+      assert.is_true(ok)
+      assert.is_true(opts.integrations.committia)
+      assert.are.equal(2, #notifications)
+      assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+      assert.are.equal(
+        'vim.g.diffs.integrations.committia = { ... } is deprecated, use vim.g.diffs.integrations.committia = true instead.\n'
+          .. 'Feature will be removed in diffs.nvim 0.4.0',
+        notifications[1].message
+      )
+      assert.are.equal(vim.log.levels.WARN, notifications[2].level)
+      assert.is_true(notifications[2].message:find('stack traceback:\n\t', 1, true) == 1)
+      assert.is_not_nil(notifications[2].message:find('lua/diffs/config.lua:', 1, true))
+      assert.is_not_nil(notifications[2].message:find("in function 'migrate_committia'", 1, true))
+      assert.is_not_nil(
+        notifications[2].message:find("in function 'normalize_integrations'", 1, true)
+      )
+    end)
   end)
 
   describe('attach', function()


### PR DESCRIPTION
Summary:
- deprecate `vim.g.diffs.integrations.committia = { ... }` and normalize it to `true`
- update the committia runtime getter annotation for the boolean shape
- update vimdoc, bootstrap coverage, runtime config tests, and manual shims

Verification:
- `direnv exec /home/barrett/dev/diffs.nvim busted spec/runtime_spec.lua spec/plugin_spec.lua`
- `direnv exec /home/barrett/dev/diffs.nvim nvim --headless --clean -u /tmp/diffs.nvim/committia-boolean-config-shim/init-old.lua +qa`
- `direnv exec /home/barrett/dev/diffs.nvim nvim --headless --clean -u /tmp/diffs.nvim/committia-boolean-config-shim/init-new.lua +qa`
- `direnv exec /home/barrett/dev/diffs.nvim nix develop .#ci -c just ci`