### PR TITLE
fix(config): deprecate telescope table config

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -223,6 +223,9 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              See |diffs.nvim-telescope|. >lua
                                  integrations = { telescope = true }
 <
+                             Passing a table is deprecated; use `true`
+                             instead. During the deprecation window, table
+                             presence still normalizes to `true`.
 
         {extra_filetypes}    (table, default: {})
                              Additional filetypes to attach to, beyond the
@@ -1001,6 +1004,9 @@ Enable telescope.nvim (https://github.com/nvim-telescope/telescope.nvim)
 preview highlighting: >lua
     vim.g.diffs = { integrations = { telescope = true } }
 <
+
+Passing a table is deprecated; use `true` instead. During the deprecation
+window, table presence still normalizes to `true`.
 
 Telescope does not set `filetype=diff` on preview buffers — it calls
 `vim.treesitter.start(bufnr, "diff")` directly, so diffs.nvim's `FileType`

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -50,7 +50,7 @@ local M = {}
 
 ---@class diffs.CommittiaConfig deprecated: use integrations.committia = true
 
----@class diffs.TelescopeConfig
+---@class diffs.TelescopeConfig deprecated: use integrations.telescope = true
 
 ---@class diffs.ConflictKeymaps
 ---@field ours string|false
@@ -77,7 +77,7 @@ local M = {}
 ---@field neojj boolean
 ---@field gitsigns boolean
 ---@field committia boolean
----@field telescope diffs.TelescopeConfig|false
+---@field telescope boolean
 
 ---@class diffs.Config
 ---@field debug boolean|string
@@ -234,6 +234,20 @@ local function migrate_committia(integrations)
   integrations.committia = true
 end
 
+---@param integrations table
+local function migrate_telescope(integrations)
+  if type(integrations.telescope) ~= 'table' then
+    return
+  end
+  vim.deprecate(
+    'vim.g.diffs.integrations.telescope = { ... }',
+    'vim.g.diffs.integrations.telescope = true',
+    '0.4.0',
+    'diffs.nvim'
+  )
+  integrations.telescope = true
+end
+
 ---@param opts table
 local function deprecate_highlights(opts)
   if opts.highlights and opts.highlights.gutter ~= nil then
@@ -297,9 +311,7 @@ function M.normalize_integrations(opts)
 
   migrate_committia(intg)
 
-  if intg.telescope == true then
-    intg.telescope = {}
-  end
+  migrate_telescope(intg)
 
   opts.integrations = intg
 end

--- a/lua/diffs/runtime/init.lua
+++ b/lua/diffs/runtime/init.lua
@@ -157,7 +157,7 @@ function M.get_committia_config()
   return config.integrations.committia
 end
 
----@return diffs.TelescopeConfig|false
+---@return boolean
 function M.get_telescope_config()
   init()
   return config.integrations.telescope

--- a/lua/diffs/telescope.lua
+++ b/lua/diffs/telescope.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+function M.setup()
+  local runtime = require('diffs.runtime')
+  local group = vim.api.nvim_create_augroup('diffs_telescope', { clear = true })
+  return vim.api.nvim_create_autocmd('User', {
+    group = group,
+    pattern = 'TelescopePreviewerLoaded',
+    callback = function()
+      runtime.attach(vim.api.nvim_get_current_buf())
+    end,
+  })
+end
+
+return M

--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -27,13 +27,8 @@ if gs_cfg == true then
 end
 
 local tel_cfg = integrations.telescope
-if tel_cfg == true or type(tel_cfg) == 'table' then
-  vim.api.nvim_create_autocmd('User', {
-    pattern = 'TelescopePreviewerLoaded',
-    callback = function()
-      runtime.attach(vim.api.nvim_get_current_buf())
-    end,
-  })
+if tel_cfg == true then
+  require('diffs.telescope').setup()
 end
 
 vim.api.nvim_create_autocmd('FileType', {

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -30,7 +30,7 @@ describe('plugin bootstrap', function()
       'vim.notify = function(message, level)',
       '_G.diffs_notifications[#_G.diffs_notifications + 1] = { message = message, level = level }',
       'end',
-      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, conflict = { priority = 250 }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {}, neojj = {}, gitsigns = {}, committia = {} } }",
+      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, conflict = { priority = 250 }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {}, neojj = {}, gitsigns = {}, committia = {}, telescope = {} } }",
       ('vim.opt.runtimepath:prepend(%s)'):format(vim.inspect(vim.fn.getcwd())),
     }
 
@@ -58,25 +58,31 @@ describe('plugin bootstrap', function()
       "print('runtime_neojj=' .. tostring(runtime_config.integrations.neojj))",
       "print('runtime_gitsigns=' .. tostring(runtime_config.integrations.gitsigns))",
       "print('runtime_committia=' .. tostring(runtime_config.integrations.committia))",
+      "print('runtime_telescope=' .. tostring(runtime_config.integrations.telescope))",
       "print('runtime_gutter=' .. tostring(runtime_config.highlights.gutter))",
       "print('runtime_conflict_priority=' .. tostring(runtime_config.conflict.priority))",
       'local has_fugitive = false',
       'local has_neogit = false',
       'local has_neojj = false',
+      'local has_telescope = false',
       "for _, autocmd in ipairs(vim.api.nvim_get_autocmds({ event = 'FileType' })) do",
       "if autocmd.pattern == 'fugitive' then has_fugitive = true end",
       "if autocmd.pattern == 'NeogitStatus' then has_neogit = true end",
       "if autocmd.pattern == 'NeojjStatus' then has_neojj = true end",
       'end',
+      "for _, autocmd in ipairs(vim.api.nvim_get_autocmds({ event = 'User' })) do",
+      "if autocmd.pattern == 'TelescopePreviewerLoaded' then has_telescope = true end",
+      'end',
       "print('has_fugitive_autocmd=' .. tostring(has_fugitive))",
       "print('has_neogit_autocmd=' .. tostring(has_neogit))",
       "print('has_neojj_autocmd=' .. tostring(has_neojj))",
+      "print('has_telescope_autocmd=' .. tostring(has_telescope))",
     }
 
     local output = run_child(init_lines, after_lines)
 
     assert.matches('loaded=1', output, 1, true)
-    assert.matches('startup_deprecations=8', output, 1, true)
+    assert.matches('startup_deprecations=9', output, 1, true)
     assert.matches(
       'vim.g.diffs.hide_prefix is deprecated, use vim.g.diffs.view.prefix instead. | Feature will be removed in diffs.nvim 0.4.0',
       output,
@@ -114,6 +120,12 @@ describe('plugin bootstrap', function()
       true
     )
     assert.matches(
+      'vim.g.diffs.integrations.telescope = { ... } is deprecated, use vim.g.diffs.integrations.telescope = true instead. | Feature will be removed in diffs.nvim 0.4.0',
+      output,
+      1,
+      true
+    )
+    assert.matches(
       'vim.g.diffs.highlights.gutter is deprecated. | Feature will be removed in diffs.nvim 0.4.0',
       output,
       1,
@@ -125,17 +137,19 @@ describe('plugin bootstrap', function()
       1,
       true
     )
-    assert.matches('after_attach_deprecations=8', output, 1, true)
+    assert.matches('after_attach_deprecations=9', output, 1, true)
     assert.matches('runtime_view_prefix=false', output, 1, true)
     assert.matches('runtime_fugitive_horizontal=nil', output, 1, true)
     assert.matches('runtime_neogit=true', output, 1, true)
     assert.matches('runtime_neojj=true', output, 1, true)
     assert.matches('runtime_gitsigns=true', output, 1, true)
     assert.matches('runtime_committia=true', output, 1, true)
+    assert.matches('runtime_telescope=true', output, 1, true)
     assert.matches('runtime_gutter=false', output, 1, true)
     assert.matches('runtime_conflict_priority=nil', output, 1, true)
     assert.matches('has_fugitive_autocmd=true', output, 1, true)
     assert.matches('has_neogit_autocmd=true', output, 1, true)
     assert.matches('has_neojj_autocmd=true', output, 1, true)
+    assert.matches('has_telescope_autocmd=true', output, 1, true)
   end)
 end)

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -419,6 +419,52 @@ describe('diffs.runtime', function()
         notifications[2].message:find("in function 'normalize_integrations'", 1, true)
       )
     end)
+
+    it('keeps integrations.telescope = true as the supported enable path', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local opts = config.new({ integrations = { telescope = true } })
+      vim.notify = saved_notify
+
+      assert.is_true(opts.integrations.telescope)
+      assert.are.equal(0, #notifications)
+    end)
+
+    it('warns and maps deprecated non-empty integrations.telescope table form to true', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, opts = pcall(config.new, {
+        integrations = {
+          telescope = { enabled = false },
+        },
+      })
+      vim.notify = saved_notify
+
+      assert.is_true(ok)
+      assert.is_true(opts.integrations.telescope)
+      assert.are.equal(2, #notifications)
+      assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+      assert.are.equal(
+        'vim.g.diffs.integrations.telescope = { ... } is deprecated, use vim.g.diffs.integrations.telescope = true instead.\n'
+          .. 'Feature will be removed in diffs.nvim 0.4.0',
+        notifications[1].message
+      )
+      assert.are.equal(vim.log.levels.WARN, notifications[2].level)
+      assert.is_true(notifications[2].message:find('stack traceback:\n\t', 1, true) == 1)
+      assert.is_not_nil(notifications[2].message:find('lua/diffs/config.lua:', 1, true))
+      assert.is_not_nil(notifications[2].message:find("in function 'migrate_telescope'", 1, true))
+      assert.is_not_nil(
+        notifications[2].message:find("in function 'normalize_integrations'", 1, true)
+      )
+    end)
   end)
 
   describe('attach', function()

--- a/spec/telescope_spec.lua
+++ b/spec/telescope_spec.lua
@@ -1,0 +1,42 @@
+local helpers = require('spec.helpers')
+local runtime = require('diffs.runtime')
+local telescope = require('diffs.telescope')
+
+describe('diffs.telescope', function()
+  local saved_attach
+
+  before_each(function()
+    saved_attach = runtime.attach
+    pcall(vim.api.nvim_del_augroup_by_name, 'diffs_telescope')
+  end)
+
+  after_each(function()
+    runtime.attach = saved_attach
+    pcall(vim.api.nvim_del_augroup_by_name, 'diffs_telescope')
+  end)
+
+  it('attaches the current Telescope preview buffer when the preview event fires', function()
+    local bufnr = helpers.create_buffer({
+      'diff --git a/file.lua b/file.lua',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+    })
+    local previous = vim.api.nvim_get_current_buf()
+    local attached_bufnr
+
+    runtime.attach = function(target)
+      attached_bufnr = target
+    end
+
+    telescope.setup()
+    vim.api.nvim_set_current_buf(bufnr)
+    vim.api.nvim_exec_autocmds('User', { pattern = 'TelescopePreviewerLoaded' })
+    if vim.api.nvim_buf_is_valid(previous) then
+      vim.api.nvim_set_current_buf(previous)
+    end
+    helpers.delete_buffer(bufnr)
+
+    assert.are.equal(bufnr, attached_bufnr)
+  end)
+end)


### PR DESCRIPTION
Summary:
- deprecate `vim.g.diffs.integrations.telescope = { ... }` and normalize it to `true`
- move Telescope preview autocmd ownership into a small testable module
- update vimdoc, bootstrap coverage, runtime config tests, and Telescope preview event tests

Verification:
- `direnv exec /home/barrett/dev/diffs.nvim busted spec/runtime_spec.lua spec/plugin_spec.lua spec/telescope_spec.lua`
- `direnv exec /home/barrett/dev/diffs.nvim nvim --headless --clean -u /tmp/diffs.nvim/telescope-boolean-config-shim/init-old.lua +DiffsTelescopeShimReport +qa`
- `direnv exec /home/barrett/dev/diffs.nvim nvim --headless --clean -u /tmp/diffs.nvim/telescope-boolean-config-shim/init-new.lua +DiffsTelescopeShimReport +qa`
- `direnv exec /home/barrett/dev/diffs.nvim nix develop .#ci -c just ci`