### PR TITLE
fix(config): deprecate fugitive table config

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -175,6 +175,11 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                                    integrations = { fugitive = true },
                                  }
 <
+                             Passing a table is deprecated; use `true`
+                             instead. During the deprecation window, table
+                             presence still enables the integration. Table
+                             fields do not configure the fixed `du`/`dU`
+                             status keymaps.
 
             {neogit}         (boolean|table, default: false)
                              Enable Neogit integration. When active,
@@ -932,11 +937,12 @@ Configuration: ~
       },
     }
 <
-    Use `fugitive = false` to disable. Passing a table also enables the
-    integration. There is no `enabled` field; table presence is sufficient.
-    Status keymaps are fixed at `du` and `dU`.
+    Use `fugitive = false` to disable. Passing a table is deprecated; use
+    `fugitive = true` instead. During the deprecation window, table presence
+    still enables the integration. There is no table `enabled` field. Status
+    keymaps are fixed at `du` and `dU`.
 
-    Fields: ~
+    Deprecated table fields: ~
         {horizontal}         (string|false, deprecated)
                              Remove this key; the horizontal Fugitive status
                              keymap is fixed at `du`.

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -38,7 +38,7 @@ local M = {}
 ---@field intra diffs.IntraConfig
 ---@field priorities diffs.PrioritiesConfig
 
----@class diffs.FugitiveConfig
+---@class diffs.FugitiveConfig deprecated: use integrations.fugitive = true
 ---@field horizontal? string|false deprecated: remove; status keymaps are fixed
 ---@field vertical? string|false deprecated: remove; status keymaps are fixed
 
@@ -72,7 +72,7 @@ local M = {}
 ---@field keymaps diffs.ConflictKeymaps|false
 
 ---@class diffs.IntegrationsConfig
----@field fugitive diffs.FugitiveConfig|false
+---@field fugitive boolean
 ---@field neogit boolean|diffs.NeogitConfig
 ---@field neojj boolean
 ---@field gitsigns boolean
@@ -176,6 +176,22 @@ local function deprecate_fugitive_keymaps(fugitive)
   )
   fugitive.horizontal = nil
   fugitive.vertical = nil
+end
+
+---@param integrations table
+local function migrate_fugitive(integrations)
+  local fugitive = integrations.fugitive
+  if type(fugitive) ~= 'table' then
+    return
+  end
+  deprecate_fugitive_keymaps(fugitive)
+  vim.deprecate(
+    'vim.g.diffs.integrations.fugitive = { ... }',
+    'vim.g.diffs.integrations.fugitive = true',
+    '0.4.0',
+    'diffs.nvim'
+  )
+  integrations.fugitive = true
 end
 
 ---@param integrations table
@@ -297,11 +313,7 @@ end
 ---@param opts table
 function M.normalize_integrations(opts)
   local intg = opts.integrations or {}
-  if intg.fugitive == true then
-    intg.fugitive = {}
-  elseif type(intg.fugitive) == 'table' then
-    deprecate_fugitive_keymaps(intg.fugitive)
-  end
+  migrate_fugitive(intg)
 
   migrate_neogit(intg)
 

--- a/lua/diffs/runtime/init.lua
+++ b/lua/diffs/runtime/init.lua
@@ -139,7 +139,7 @@ function M.detach_diff()
   diff_windows_mod.detach(diff_windows)
 end
 
----@return diffs.FugitiveConfig|false
+---@return boolean
 function M.get_fugitive_config()
   init()
   return config.integrations.fugitive

--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -38,7 +38,7 @@ vim.api.nvim_create_autocmd('FileType', {
 
     if args.match == 'fugitive' then
       local fugitive_config = runtime.get_fugitive_config()
-      if fugitive_config then
+      if fugitive_config == true then
         require('diffs.fugitive').setup_keymaps(args.buf)
       end
     end

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -53,7 +53,7 @@ describe('plugin bootstrap', function()
       "print('after_attach_deprecations=' .. #deprecations())",
       'local runtime_config = runtime._test.get_config()',
       "print('runtime_view_prefix=' .. tostring(runtime_config.view.prefix))",
-      "print('runtime_fugitive_horizontal=' .. tostring(runtime_config.integrations.fugitive.horizontal))",
+      "print('runtime_fugitive=' .. tostring(runtime_config.integrations.fugitive))",
       "print('runtime_neogit=' .. tostring(runtime_config.integrations.neogit))",
       "print('runtime_neojj=' .. tostring(runtime_config.integrations.neojj))",
       "print('runtime_gitsigns=' .. tostring(runtime_config.integrations.gitsigns))",
@@ -82,7 +82,7 @@ describe('plugin bootstrap', function()
     local output = run_child(init_lines, after_lines)
 
     assert.matches('loaded=1', output, 1, true)
-    assert.matches('startup_deprecations=9', output, 1, true)
+    assert.matches('startup_deprecations=10', output, 1, true)
     assert.matches(
       'vim.g.diffs.hide_prefix is deprecated, use vim.g.diffs.view.prefix instead. | Feature will be removed in diffs.nvim 0.4.0',
       output,
@@ -91,6 +91,12 @@ describe('plugin bootstrap', function()
     )
     assert.matches(
       'vim.g.diffs.integrations.fugitive.{horizontal,vertical} is deprecated. | Feature will be removed in diffs.nvim 0.4.0',
+      output,
+      1,
+      true
+    )
+    assert.matches(
+      'vim.g.diffs.integrations.fugitive = { ... } is deprecated, use vim.g.diffs.integrations.fugitive = true instead. | Feature will be removed in diffs.nvim 0.4.0',
       output,
       1,
       true
@@ -137,9 +143,9 @@ describe('plugin bootstrap', function()
       1,
       true
     )
-    assert.matches('after_attach_deprecations=9', output, 1, true)
+    assert.matches('after_attach_deprecations=10', output, 1, true)
     assert.matches('runtime_view_prefix=false', output, 1, true)
-    assert.matches('runtime_fugitive_horizontal=nil', output, 1, true)
+    assert.matches('runtime_fugitive=true', output, 1, true)
     assert.matches('runtime_neogit=true', output, 1, true)
     assert.matches('runtime_neojj=true', output, 1, true)
     assert.matches('runtime_gitsigns=true', output, 1, true)

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -203,13 +203,53 @@ describe('diffs.runtime', function()
       assert.are.equal(0, #notifications)
     end)
 
-    it('normalizes integrations.fugitive = true to enabled table without keymap config', function()
-      local opts = config.new({ integrations = { fugitive = true } })
+    it('keeps integrations.fugitive = true as the supported enable path', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
 
-      assert.are.same({}, opts.integrations.fugitive)
+      local opts = config.new({ integrations = { fugitive = true } })
+      vim.notify = saved_notify
+
+      assert.is_true(opts.integrations.fugitive)
+      assert.are.equal(0, #notifications)
     end)
 
-    it('warns and drops deprecated fugitive keymap config', function()
+    it('warns and maps deprecated integrations.fugitive table form to true', function()
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+
+      local ok, opts = pcall(config.new, {
+        integrations = {
+          fugitive = {},
+        },
+      })
+      vim.notify = saved_notify
+
+      assert.is_true(ok)
+      assert.is_true(opts.integrations.fugitive)
+      assert.are.equal(2, #notifications)
+      assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+      assert.are.equal(
+        'vim.g.diffs.integrations.fugitive = { ... } is deprecated, use vim.g.diffs.integrations.fugitive = true instead.\n'
+          .. 'Feature will be removed in diffs.nvim 0.4.0',
+        notifications[1].message
+      )
+      assert.are.equal(vim.log.levels.WARN, notifications[2].level)
+      assert.is_true(notifications[2].message:find('stack traceback:\n\t', 1, true) == 1)
+      assert.is_not_nil(notifications[2].message:find('lua/diffs/config.lua:', 1, true))
+      assert.is_not_nil(notifications[2].message:find("in function 'migrate_fugitive'", 1, true))
+      assert.is_not_nil(
+        notifications[2].message:find("in function 'normalize_integrations'", 1, true)
+      )
+    end)
+
+    it('warns and maps deprecated fugitive keymap config to true', function()
       local saved_notify = vim.notify
       local notifications = {}
       vim.notify = function(message, level)
@@ -227,12 +267,18 @@ describe('diffs.runtime', function()
       vim.notify = saved_notify
 
       assert.is_true(ok)
-      assert.are.same({}, opts.integrations.fugitive)
+      assert.is_true(opts.integrations.fugitive)
       assert.are.equal(vim.log.levels.WARN, notifications[1].level)
       assert.are.equal(
         'vim.g.diffs.integrations.fugitive.{horizontal,vertical} is deprecated.\n'
           .. 'Feature will be removed in diffs.nvim 0.4.0',
         notifications[1].message
+      )
+      assert.are.equal(vim.log.levels.WARN, notifications[2].level)
+      assert.is_true(notifications[2].message:find('stack traceback:\n\t', 1, true) == 1)
+      assert.is_not_nil(notifications[2].message:find('lua/diffs/config.lua:', 1, true))
+      assert.is_not_nil(
+        notifications[2].message:find("in function 'deprecate_fugitive_keymaps'", 1, true)
       )
     end)
 
@@ -755,7 +801,7 @@ describe('diffs.runtime', function()
       assert.is_true(vim.tbl_contains(fts, 'fugitive'))
     end)
 
-    it('includes fugitive when integrations.fugitive is a table', function()
+    it('includes fugitive during deprecated table-form window', function()
       local fts = compute({ integrations = { fugitive = {} } })
       assert.is_true(vim.tbl_contains(fts, 'fugitive'))
     end)


### PR DESCRIPTION
Summary:
- deprecate `vim.g.diffs.integrations.fugitive = { ... }` and normalize it to `true`
- preserve the existing `horizontal`/`vertical` deprecation path and fixed `du`/`dU` maps
- update vimdoc, bootstrap coverage, runtime config tests, and manual shims

Verification:
- `direnv exec /home/barrett/dev/diffs.nvim busted spec/runtime_spec.lua spec/plugin_spec.lua spec/fugitive_spec.lua`
- `direnv exec /home/barrett/dev/diffs.nvim nvim --headless --clean -u /tmp/diffs.nvim/fugitive-boolean-config-shim/init-old.lua +qa`
- `direnv exec /home/barrett/dev/diffs.nvim nvim --headless --clean -u /tmp/diffs.nvim/fugitive-boolean-config-shim/init-new.lua +qa`
- `direnv exec /home/barrett/dev/diffs.nvim nvim --headless --clean -u /tmp/diffs.nvim/fugitive-boolean-config-shim/init-false.lua +qa`
- `direnv exec /home/barrett/dev/diffs.nvim nix develop .#ci -c just ci`