### PR TITLE
fix(config): deprecate highlight priority config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ highlighting driven by treesitter.
 - Inline merge conflict detection, highlighting, and resolution
 - Email quoting/patch syntax support (`> diff ...`)
 - Vim syntax fallback
-- Configurable highlighting blend & priorities
+- Configurable highlighting blend
 
 ## Requirements
 

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -119,12 +119,6 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
           algorithm = 'default',
           max_lines = 500,
         },
-        priorities = {
-          clear = 198,
-          syntax = 199,
-          line_bg = 200,
-          char_bg = 201,
-        },
         overrides = {},
       },
       conflict = {
@@ -296,8 +290,9 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              Character-level (intra-line) diff highlighting.
                              See |diffs.nvim.IntraConfig| for fields.
 
-        {priorities}         (table, default: see below)
-                             Extmark priority values.
+        {priorities}         (table, deprecated)
+                             Remove this key. Custom priority values are
+                             ignored and layering is fixed internally.
                              See |diffs.nvim.PrioritiesConfig| for fields.
 
         {overrides}          (table, default: {})
@@ -326,26 +321,27 @@ Configuration is done via `vim.g.diffs`. Set this before the plugin loads:
                              hunks in the same file.
 
                                                  *diffs.nvim.PrioritiesConfig*
-    Priorities config fields: ~
-        {clear}              (integer, default: 198)
-                             Priority for `DiffsClear` extmarks that reset
-                             underlying diff foreground colors. Must be
-                             below {syntax}.
+    Priorities config fields (deprecated): ~
+        This table remains documented for the 0.4.0 migration window only.
+        Custom values are validated for compatibility, then ignored and
+        removed; diffs.nvim uses the fixed internal layering below.
 
-        {syntax}             (integer, default: 199)
-                             Priority for treesitter and vim syntax extmarks.
-                             Must be below {line_bg} so that colorscheme
-                             backgrounds on syntax groups do not obscure
-                             line-level diff backgrounds.
+        {clear}              (integer, default: 198, deprecated)
+                             Fixed priority for `DiffsClear` extmarks that
+                             reset underlying diff foreground colors.
 
-        {line_bg}            (integer, default: 200)
-                             Priority for `DiffsAdd`/`DiffsDelete` line
-                             background extmarks. Must be below {char_bg}.
+        {syntax}             (integer, default: 199, deprecated)
+                             Fixed priority for treesitter and vim syntax
+                             extmarks.
 
-        {char_bg}            (integer, default: 201)
-                             Priority for `DiffsAddText`/`DiffsDeleteText`
-                             character-level background extmarks. Highest
-                             priority so changed characters stand out.
+        {line_bg}            (integer, default: 200, deprecated)
+                             Fixed priority for `DiffsAdd`/`DiffsDelete`
+                             line background extmarks.
+
+        {char_bg}            (integer, default: 201, deprecated)
+                             Fixed priority for
+                             `DiffsAddText`/`DiffsDeleteText`
+                             character-level background extmarks.
 
                                                  *diffs.nvim.TreesitterConfig*
     Treesitter config fields: ~
@@ -1221,7 +1217,8 @@ Summary / commit detail views: ~
    - Character-level diff extmarks (`DiffsAddText`/`DiffsDeleteText`) at
      priority 201 overlay changed characters with an intense background
    - Conceal extmarks hide diff prefixes when `view.prefix` is disabled
-   - All priorities are configurable via |diffs.nvim.PrioritiesConfig|
+   - Priority layering is fixed internally; deprecated custom priorities are
+     ignored
 4. A decoration provider re-highlights visible hunks on each redraw
 
 Diff mode views: ~

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -36,7 +36,7 @@ local M = {}
 ---@field treesitter diffs.TreesitterConfig
 ---@field vim diffs.VimConfig
 ---@field intra diffs.IntraConfig
----@field priorities diffs.PrioritiesConfig
+---@field priorities diffs.PrioritiesConfig deprecated: custom values are ignored; priorities are fixed internally
 
 ---@class diffs.FugitiveConfig deprecated: use integrations.fugitive = true
 ---@field horizontal? string|false deprecated: remove; status keymaps are fixed
@@ -140,6 +140,7 @@ local DEFAULTS = {
 }
 
 local integration_keys = { 'fugitive', 'neogit', 'neojj', 'gitsigns', 'committia', 'telescope' }
+local priority_keys = { 'clear', 'syntax', 'line_bg', 'char_bg' }
 
 ---@param opts table
 local function migrate_view(opts)
@@ -264,11 +265,37 @@ local function migrate_telescope(integrations)
   integrations.telescope = true
 end
 
+---@param highlights diffs.Highlights
+local function deprecate_highlight_priorities(highlights)
+  if highlights.priorities == nil then
+    return
+  end
+  local priorities = highlights.priorities
+  vim.validate('highlights.priorities', priorities, 'table')
+  for _, key in ipairs(priority_keys) do
+    vim.validate('highlights.priorities.' .. key, priorities[key], 'number', true)
+    if priorities[key] and priorities[key] < 0 then
+      error('diffs: highlights.priorities.' .. key .. ' must be >= 0')
+    end
+  end
+  vim.deprecate(
+    'vim.g.diffs.highlights.priorities.{clear,syntax,line_bg,char_bg}',
+    nil,
+    '0.4.0',
+    'diffs.nvim'
+  )
+  highlights.priorities = nil
+end
+
 ---@param opts table
 local function deprecate_highlights(opts)
-  if opts.highlights and opts.highlights.gutter ~= nil then
+  if type(opts.highlights) ~= 'table' then
+    return
+  end
+  if opts.highlights.gutter ~= nil then
     vim.deprecate('vim.g.diffs.highlights.gutter', nil, '0.4.0', 'diffs.nvim')
   end
+  deprecate_highlight_priorities(opts.highlights)
 end
 
 ---@param opts table
@@ -490,7 +517,7 @@ function M.validate(opts)
     error('diffs: highlights.blend_alpha must be >= 0 and <= 1')
   end
   if opts.highlights and opts.highlights.priorities then
-    for _, key in ipairs({ 'clear', 'syntax', 'line_bg', 'char_bg' }) do
+    for _, key in ipairs(priority_keys) do
       local v = opts.highlights.priorities[key]
       if v and v < 0 then
         error('diffs: highlights.priorities.' .. key .. ' must be >= 0')

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -30,7 +30,7 @@ describe('plugin bootstrap', function()
       'vim.notify = function(message, level)',
       '_G.diffs_notifications[#_G.diffs_notifications + 1] = { message = message, level = level }',
       'end',
-      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false }, conflict = { priority = 250 }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {}, neojj = {}, gitsigns = {}, committia = {}, telescope = {} } }",
+      "vim.g.diffs = { hide_prefix = true, highlights = { gutter = false, priorities = { clear = 10, syntax = 20, line_bg = 30, char_bg = 40 } }, conflict = { priority = 250 }, integrations = { fugitive = { horizontal = 'dd', vertical = false }, neogit = {}, neojj = {}, gitsigns = {}, committia = {}, telescope = {} } }",
       ('vim.opt.runtimepath:prepend(%s)'):format(vim.inspect(vim.fn.getcwd())),
     }
 
@@ -60,6 +60,10 @@ describe('plugin bootstrap', function()
       "print('runtime_committia=' .. tostring(runtime_config.integrations.committia))",
       "print('runtime_telescope=' .. tostring(runtime_config.integrations.telescope))",
       "print('runtime_gutter=' .. tostring(runtime_config.highlights.gutter))",
+      "print('runtime_priority_clear=' .. tostring(runtime_config.highlights.priorities.clear))",
+      "print('runtime_priority_syntax=' .. tostring(runtime_config.highlights.priorities.syntax))",
+      "print('runtime_priority_line_bg=' .. tostring(runtime_config.highlights.priorities.line_bg))",
+      "print('runtime_priority_char_bg=' .. tostring(runtime_config.highlights.priorities.char_bg))",
       "print('runtime_conflict_priority=' .. tostring(runtime_config.conflict.priority))",
       'local has_fugitive = false',
       'local has_neogit = false',
@@ -82,7 +86,7 @@ describe('plugin bootstrap', function()
     local output = run_child(init_lines, after_lines)
 
     assert.matches('loaded=1', output, 1, true)
-    assert.matches('startup_deprecations=10', output, 1, true)
+    assert.matches('startup_deprecations=11', output, 1, true)
     assert.matches(
       'vim.g.diffs.hide_prefix is deprecated, use vim.g.diffs.view.prefix instead. | Feature will be removed in diffs.nvim 0.4.0',
       output,
@@ -138,12 +142,18 @@ describe('plugin bootstrap', function()
       true
     )
     assert.matches(
+      'vim.g.diffs.highlights.priorities.{clear,syntax,line_bg,char_bg} is deprecated. | Feature will be removed in diffs.nvim 0.4.0',
+      output,
+      1,
+      true
+    )
+    assert.matches(
       'vim.g.diffs.conflict.priority is deprecated. | Feature will be removed in diffs.nvim 0.4.0',
       output,
       1,
       true
     )
-    assert.matches('after_attach_deprecations=10', output, 1, true)
+    assert.matches('after_attach_deprecations=11', output, 1, true)
     assert.matches('runtime_view_prefix=false', output, 1, true)
     assert.matches('runtime_fugitive=true', output, 1, true)
     assert.matches('runtime_neogit=true', output, 1, true)
@@ -152,6 +162,10 @@ describe('plugin bootstrap', function()
     assert.matches('runtime_committia=true', output, 1, true)
     assert.matches('runtime_telescope=true', output, 1, true)
     assert.matches('runtime_gutter=false', output, 1, true)
+    assert.matches('runtime_priority_clear=198', output, 1, true)
+    assert.matches('runtime_priority_syntax=199', output, 1, true)
+    assert.matches('runtime_priority_line_bg=200', output, 1, true)
+    assert.matches('runtime_priority_char_bg=201', output, 1, true)
     assert.matches('runtime_conflict_priority=nil', output, 1, true)
     assert.matches('has_fugitive_autocmd=true', output, 1, true)
     assert.matches('has_neogit_autocmd=true', output, 1, true)

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -4,6 +4,19 @@ local runtime = require('diffs.runtime')
 
 describe('diffs.runtime', function()
   describe('vim.g.diffs config', function()
+    local default_priorities = { clear = 198, syntax = 199, line_bg = 200, char_bg = 201 }
+
+    local function capture_notifications(fn)
+      local saved_notify = vim.notify
+      local notifications = {}
+      vim.notify = function(message, level)
+        notifications[#notifications + 1] = { message = message, level = level }
+      end
+      local ok, result = pcall(fn)
+      vim.notify = saved_notify
+      return ok, result, notifications
+    end
+
     after_each(function()
       vim.g.diffs = nil
     end)
@@ -129,6 +142,112 @@ describe('diffs.runtime', function()
           .. 'Feature will be removed in diffs.nvim 0.4.0',
         notifications[1].message
       )
+    end)
+
+    it('warns and drops deprecated highlights.priorities values', function()
+      local ok, opts, notifications = capture_notifications(function()
+        return config.new({
+          highlights = {
+            priorities = { clear = 10, syntax = 20, line_bg = 30, char_bg = 40 },
+          },
+        })
+      end)
+
+      assert.is_true(ok)
+      assert.are.same(default_priorities, opts.highlights.priorities)
+      assert.are.equal(2, #notifications)
+      assert.are.equal(vim.log.levels.WARN, notifications[1].level)
+      assert.are.equal(
+        'vim.g.diffs.highlights.priorities.{clear,syntax,line_bg,char_bg} is deprecated.\n'
+          .. 'Feature will be removed in diffs.nvim 0.4.0',
+        notifications[1].message
+      )
+      assert.are.equal(vim.log.levels.WARN, notifications[2].level)
+      assert.is_true(notifications[2].message:find('stack traceback:\n\t', 1, true) == 1)
+      assert.is_not_nil(notifications[2].message:find('lua/diffs/config.lua:', 1, true))
+      assert.is_not_nil(
+        notifications[2].message:find("in function 'deprecate_highlight_priorities'", 1, true)
+      )
+    end)
+
+    it('warns and drops an empty deprecated highlights.priorities table', function()
+      local saved_deprecate = vim.deprecate
+      local calls = {}
+      vim.deprecate = function(name, alternative, version, plugin)
+        calls[#calls + 1] = { name, alternative, version, plugin }
+      end
+
+      local ok, opts = pcall(config.new, {
+        highlights = {
+          priorities = {},
+        },
+      })
+      vim.deprecate = saved_deprecate
+
+      assert.is_true(ok)
+      assert.are.same(default_priorities, opts.highlights.priorities)
+      assert.are.equal(1, #calls)
+      assert.are.equal(
+        'vim.g.diffs.highlights.priorities.{clear,syntax,line_bg,char_bg}',
+        calls[1][1]
+      )
+      assert.is_nil(calls[1][2])
+      assert.are.equal('0.4.0', calls[1][3])
+      assert.are.equal('diffs.nvim', calls[1][4])
+    end)
+
+    it('keeps supported highlights config without priorities quiet', function()
+      local ok, opts, notifications = capture_notifications(function()
+        return config.new({ highlights = { background = false, blend_alpha = 0.4 } })
+      end)
+
+      assert.is_true(ok)
+      assert.is_false(opts.highlights.background)
+      assert.are.equal(0.4, opts.highlights.blend_alpha)
+      assert.are.same(default_priorities, opts.highlights.priorities)
+      assert.are.equal(0, #notifications)
+    end)
+
+    it('validates deprecated highlights.priorities before warning', function()
+      for _, key in ipairs({ 'clear', 'syntax', 'line_bg', 'char_bg' }) do
+        local ok, err, notifications = capture_notifications(function()
+          return config.new({
+            highlights = {
+              priorities = { [key] = -1 },
+            },
+          })
+        end)
+
+        assert.is_false(ok)
+        assert.matches('diffs: highlights.priorities.' .. key .. ' must be >= 0', err, 1, true)
+        assert.are.equal(0, #notifications)
+      end
+    end)
+
+    it('type-checks deprecated highlights.priorities before warning', function()
+      local ok, err, notifications = capture_notifications(function()
+        return config.new({ highlights = { priorities = false } })
+      end)
+
+      assert.is_false(ok)
+      assert.matches('highlights.priorities', err, 1, true)
+      assert.matches('table', err, 1, true)
+      assert.are.equal(0, #notifications)
+
+      for _, key in ipairs({ 'clear', 'syntax', 'line_bg', 'char_bg' }) do
+        ok, err, notifications = capture_notifications(function()
+          return config.new({
+            highlights = {
+              priorities = { [key] = 'bad' },
+            },
+          })
+        end)
+
+        assert.is_false(ok)
+        assert.matches('highlights.priorities.' .. key, err, 1, true)
+        assert.matches('number', err, 1, true)
+        assert.are.equal(0, #notifications)
+      end
     end)
 
     it('warns and drops deprecated conflict.priority', function()


### PR DESCRIPTION
## Summary
- deprecate `vim.g.diffs.highlights.priorities.{clear,syntax,line_bg,char_bg}` with no replacement
- validate deprecated values before warning, then drop them so runtime uses fixed internal priorities `198/199/200/201`
- update help/README wording so priority configurability is no longer advertised

## Warning
```text
vim.g.diffs.highlights.priorities.{clear,syntax,line_bg,char_bg} is deprecated.
Feature will be removed in diffs.nvim 0.4.0
```

## Validation
- `busted spec/runtime_spec.lua spec/plugin_spec.lua spec/highlight_spec.lua spec/gitsigns_spec.lua`
- `stylua --check lua spec plugin`
- `vimdoc-language-server check doc/`
- `git diff --check`
- shim smoke in `/tmp/diffs/gdiff-stack-shim-today` for old/new priority config
- `nix develop .#ci -c just ci`

Subagent audit found no additional config-deprecation PRs needed for this migration series after this one.