### PR TITLE
refactor(config): centralize integration metadata

### DIFF
--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local integration_metadata = require('diffs.integrations')
+
 ---@class diffs.TreesitterConfig
 ---@field enabled boolean
 ---@field max_lines integer
@@ -122,14 +124,7 @@ local DEFAULTS = {
       char_bg = 201,
     },
   },
-  integrations = {
-    fugitive = false,
-    neogit = false,
-    neojj = false,
-    gitsigns = false,
-    committia = false,
-    telescope = false,
-  },
+  integrations = integration_metadata.defaults(),
   conflict = {
     enabled = true,
     disable_diagnostics = true,
@@ -139,7 +134,6 @@ local DEFAULTS = {
   },
 }
 
-local integration_keys = { 'fugitive', 'neogit', 'neojj', 'gitsigns', 'committia', 'telescope' }
 local priority_keys = { 'clear', 'syntax', 'line_bg', 'char_bg' }
 
 ---@param opts table
@@ -314,27 +308,7 @@ end
 ---@param opts table
 ---@return string[]
 function M.compute_filetypes(opts)
-  local fts = { 'git', 'gitcommit' }
-  local intg = opts.integrations or {}
-  if intg.fugitive == true or type(intg.fugitive) == 'table' then
-    table.insert(fts, 'fugitive')
-  end
-  if intg.neogit == true or type(intg.neogit) == 'table' then
-    table.insert(fts, 'NeogitStatus')
-    table.insert(fts, 'NeogitCommitView')
-    table.insert(fts, 'NeogitDiffView')
-  end
-  if intg.neojj == true or type(intg.neojj) == 'table' then
-    table.insert(fts, 'NeojjStatus')
-    table.insert(fts, 'NeojjCommitView')
-    table.insert(fts, 'NeojjDiffView')
-  end
-  if type(opts.extra_filetypes) == 'table' then
-    for _, ft in ipairs(opts.extra_filetypes) do
-      table.insert(fts, ft)
-    end
-  end
-  return fts
+  return integration_metadata.filetypes(opts)
 end
 
 ---@param opts table
@@ -368,7 +342,7 @@ function M.validate(opts)
   local integration_validator = function(v)
     return v == nil or type(v) == 'boolean' or type(v) == 'table'
   end
-  for _, key in ipairs(integration_keys) do
+  for _, key in ipairs(integration_metadata.keys()) do
     vim.validate(
       'integrations.' .. key,
       opts.integrations[key],

--- a/lua/diffs/integrations.lua
+++ b/lua/diffs/integrations.lua
@@ -1,0 +1,79 @@
+local M = {}
+
+local keys = { 'fugitive', 'neogit', 'neojj', 'gitsigns', 'committia', 'telescope' }
+
+local metadata = {
+  fugitive = {
+    default = false,
+    filetypes = { 'fugitive' },
+  },
+  neogit = {
+    default = false,
+    filetypes = { 'NeogitStatus', 'NeogitCommitView', 'NeogitDiffView' },
+    filetype_pattern = '^Neogit',
+  },
+  neojj = {
+    default = false,
+    filetypes = { 'NeojjStatus', 'NeojjCommitView', 'NeojjDiffView' },
+    filetype_pattern = '^Neojj',
+  },
+  gitsigns = {
+    default = false,
+  },
+  committia = {
+    default = false,
+  },
+  telescope = {
+    default = false,
+  },
+}
+
+---@return string[]
+function M.keys()
+  return vim.deepcopy(keys)
+end
+
+---@return table<string, boolean>
+function M.defaults()
+  local result = {}
+  for _, key in ipairs(keys) do
+    result[key] = metadata[key].default
+  end
+  return result
+end
+
+---@param value any
+---@return boolean
+function M.is_enabled(value)
+  return value == true or type(value) == 'table'
+end
+
+---@param opts table
+---@return string[]
+function M.filetypes(opts)
+  local fts = { 'git', 'gitcommit' }
+  local intg = opts.integrations or {}
+  for _, key in ipairs(keys) do
+    if M.is_enabled(intg[key]) then
+      for _, filetype in ipairs(metadata[key].filetypes or {}) do
+        table.insert(fts, filetype)
+      end
+    end
+  end
+  if type(opts.extra_filetypes) == 'table' then
+    for _, ft in ipairs(opts.extra_filetypes) do
+      table.insert(fts, ft)
+    end
+  end
+  return fts
+end
+
+---@param key string
+---@param filetype string
+---@return boolean
+function M.matches_filetype(key, filetype)
+  local pattern = metadata[key] and metadata[key].filetype_pattern
+  return pattern ~= nil and filetype:match(pattern) ~= nil
+end
+
+return M

--- a/lua/diffs/runtime/attach.lua
+++ b/lua/diffs/runtime/attach.lua
@@ -1,3 +1,4 @@
+local integrations = require('diffs.integrations')
 local log = require('diffs.log')
 
 local M = {}
@@ -26,7 +27,10 @@ function M.attach(opts, bufnr)
 
   local config = opts.get_config()
   local neogit_augroup = nil
-  if config.integrations.neogit and vim.bo[bufnr].filetype:match('^Neogit') then
+  if
+    integrations.is_enabled(config.integrations.neogit)
+    and integrations.matches_filetype('neogit', vim.bo[bufnr].filetype)
+  then
     vim.b[bufnr].neogit_disable_hunk_highlight = true
     neogit_augroup = vim.api.nvim_create_augroup('diffs_neogit_' .. bufnr, { clear = true })
     vim.api.nvim_create_autocmd('User', {
@@ -41,7 +45,10 @@ function M.attach(opts, bufnr)
   end
 
   local neojj_augroup = nil
-  if config.integrations.neojj and vim.bo[bufnr].filetype:match('^Neojj') then
+  if
+    integrations.is_enabled(config.integrations.neojj)
+    and integrations.matches_filetype('neojj', vim.bo[bufnr].filetype)
+  then
     vim.b[bufnr].neojj_disable_hunk_highlight = true
     neojj_augroup = vim.api.nvim_create_augroup('diffs_neojj_' .. bufnr, { clear = true })
     vim.api.nvim_create_autocmd('User', {

--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -3,6 +3,7 @@ if vim.g.loaded_diffs then
 end
 
 local config = require('diffs.config')
+local integrations = require('diffs.integrations')
 local user_config = config.new(vim.deepcopy(vim.g.diffs or {}))
 local runtime = require('diffs.runtime')
 
@@ -11,10 +12,9 @@ vim.g.loaded_diffs = 1
 
 require('diffs.commands').setup()
 
-local integrations = user_config.integrations or {}
+local integration_config = user_config.integrations or {}
 
-local gs_cfg = integrations.gitsigns
-if gs_cfg == true then
+if integrations.is_enabled(integration_config.gitsigns) then
   if not require('diffs.gitsigns').setup() then
     vim.api.nvim_create_autocmd('User', {
       pattern = 'GitAttach',
@@ -26,8 +26,7 @@ if gs_cfg == true then
   end
 end
 
-local tel_cfg = integrations.telescope
-if tel_cfg == true then
+if integrations.is_enabled(integration_config.telescope) then
   require('diffs.telescope').setup()
 end
 


### PR DESCRIPTION
## Summary

- add a single internal metadata module for integration keys, defaults, and filetypes
- keep current v0.3.x table-form deprecation and normalization behavior unchanged
- use the shared metadata from config, plugin bootstrap, and runtime attach checks

Closes #341

## Verification

- `direnv exec /home/barrett/dev/diffs.nvim busted spec/config_spec.lua spec/runtime_spec.lua spec/plugin_spec.lua spec/neogit_integration_spec.lua spec/neojj_integration_spec.lua`
- `direnv exec /home/barrett/dev/diffs.nvim nix develop .#ci -c just ci`
