### PR TITLE
refactor(highlight): centralize hunk options

### DIFF
--- a/lua/diffs/gitsigns.lua
+++ b/lua/diffs/gitsigns.lua
@@ -113,16 +113,7 @@ local function on_preview(preview_winid, preview_bufnr)
     local highlight = require('diffs.highlight')
     for _, hunk in ipairs(hunks) do
       highlight.highlight_hunk(preview_bufnr, ns, hunk, opts)
-      for j, line in ipairs(hunk.lines) do
-        local ch = line:sub(1, 1)
-        if ch == '+' or ch == '-' then
-          pcall(api.nvim_buf_set_extmark, preview_bufnr, ns, hunk.start_line + j - 1, 0, {
-            end_col = 1,
-            hl_group = ch == '+' and '@diff.plus' or '@diff.minus',
-            priority = opts.highlights.priorities.syntax,
-          })
-        end
-      end
+      highlight.highlight_hunk_prefixes(preview_bufnr, ns, hunk, opts)
     end
 
     dbg('gitsigns blame: highlighted %d hunks in popup buf %d', #hunks, preview_bufnr)

--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -152,6 +152,63 @@ end
 ---@field defer_vim_syntax? boolean
 ---@field syntax_only? boolean
 
+---@class diffs.HunkOptsOverride
+---@field highlights? table
+---@field defer_vim_syntax? boolean
+---@field syntax_only? boolean
+
+---@param config diffs.Config
+---@param overrides? diffs.HunkOptsOverride
+---@return diffs.HunkOpts
+function M.hunk_opts(config, overrides)
+  local opts = {
+    hide_prefix = not config.view.prefix,
+    highlights = config.highlights,
+  }
+  if not overrides then
+    return opts
+  end
+
+  for key, value in pairs(overrides) do
+    if key == 'highlights' then
+      opts.highlights = vim.tbl_deep_extend('force', config.highlights, value)
+    else
+      opts[key] = value
+    end
+  end
+
+  return opts
+end
+
+---@param bufnr integer
+---@param ns integer
+---@param hunk diffs.Hunk
+---@param opts diffs.HunkOpts
+---@return integer
+function M.highlight_hunk_prefixes(bufnr, ns, hunk, opts)
+  local p = opts.highlights.priorities
+  local pw = hunk.prefix_width or 1
+  local qw = hunk.quote_width or 0
+  local extmark_count = 0
+
+  for i, line in ipairs(hunk.lines) do
+    local buf_line = hunk.start_line + i - 1
+    for ci = 0, pw - 1 do
+      local ch = line:sub(ci + 1, ci + 1)
+      if ch == '+' or ch == '-' then
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, ci + qw, {
+          end_col = ci + qw + 1,
+          hl_group = ch == '+' and '@diff.plus' or '@diff.minus',
+          priority = p.syntax,
+        })
+        extmark_count = extmark_count + 1
+      end
+    end
+  end
+
+  return extmark_count
+end
+
 ---@class diffs.TSContext
 ---@field before string[]?
 ---@field after string[]?

--- a/lua/diffs/runtime/cache.lua
+++ b/lua/diffs/runtime/cache.lua
@@ -318,11 +318,9 @@ function Cache:run_deferred_syntax(bufnr, tick, changedtick, job_id, deferred_sy
   end
   local config = self.get_config()
   local t1 = config.debug and vim.uv.hrtime() or nil
-  local syntax_opts = {
-    hide_prefix = not config.view.prefix,
-    highlights = config.highlights,
+  local syntax_opts = highlight.hunk_opts(config, {
     syntax_only = true,
-  }
+  })
   for _, hunk in ipairs(hunks_to_hl) do
     highlight.highlight_hunk(bufnr, self.ns, hunk, syntax_opts)
   end

--- a/lua/diffs/runtime/init.lua
+++ b/lua/diffs/runtime/init.lua
@@ -8,6 +8,7 @@ local cache_mod = require('diffs.runtime.cache')
 local config_mod = require('diffs.config')
 local decorator = require('diffs.runtime.decorator')
 local diff_windows_mod = require('diffs.runtime.diff_windows')
+local highlight = require('diffs.highlight')
 local highlight_groups = require('diffs.runtime.highlight_groups')
 local log = require('diffs.log')
 
@@ -63,13 +64,12 @@ local function init()
   end
   log.set_enabled(config.debug)
 
-  fast_hl_opts = {
-    hide_prefix = not config.view.prefix,
-    highlights = vim.tbl_deep_extend('force', config.highlights, {
+  fast_hl_opts = highlight.hunk_opts(config, {
+    highlights = {
       treesitter = { enabled = false },
-    }),
+    },
     defer_vim_syntax = true,
-  }
+  })
 
   compute_highlight_groups(true)
 
@@ -172,7 +172,7 @@ end
 ---@return diffs.HunkOpts
 function M.get_highlight_opts()
   init()
-  return { hide_prefix = not config.view.prefix, highlights = config.highlights }
+  return highlight.hunk_opts(config)
 end
 
 M._test = {

--- a/spec/highlight_spec.lua
+++ b/spec/highlight_spec.lua
@@ -1,7 +1,37 @@
 require('spec.helpers')
+local config = require('diffs.config')
 local highlight = require('diffs.highlight')
 
 describe('highlight', function()
+  describe('hunk_opts', function()
+    it('builds full hunk options from normalized config', function()
+      local opts = highlight.hunk_opts(config.new({ view = { prefix = false } }))
+
+      assert.is_true(opts.hide_prefix)
+      assert.are.same(
+        { clear = 198, syntax = 199, line_bg = 200, char_bg = 201 },
+        opts.highlights.priorities
+      )
+      assert.is_true(opts.highlights.treesitter.enabled)
+      assert.is_true(opts.highlights.vim.enabled)
+    end)
+
+    it('applies highlight overrides without mutating config', function()
+      local cfg = config.new()
+      local opts = highlight.hunk_opts(cfg, {
+        highlights = {
+          treesitter = { enabled = false },
+        },
+        defer_vim_syntax = true,
+      })
+
+      assert.is_false(opts.highlights.treesitter.enabled)
+      assert.is_true(cfg.highlights.treesitter.enabled)
+      assert.is_true(opts.defer_vim_syntax)
+      assert.are.same(cfg.highlights.priorities, opts.highlights.priorities)
+    end)
+  end)
+
   describe('highlight_hunk', function()
     local ns
 
@@ -74,6 +104,42 @@ describe('highlight', function()
       end
       return opts
     end
+
+    it('applies prefix extmarks with syntax priority', function()
+      local bufnr = create_buffer({
+        '-local x = 1',
+        '+local x = 2',
+        ' return x',
+      })
+      local hunk = {
+        filename = 'test.lua',
+        start_line = 0,
+        prefix_width = 1,
+        quote_width = 0,
+        lines = {
+          '-local x = 1',
+          '+local x = 2',
+          ' return x',
+        },
+      }
+
+      local count = highlight.highlight_hunk_prefixes(bufnr, ns, hunk, default_opts())
+
+      assert.are.equal(2, count)
+      local prefixes = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        if mark[4] and mark[4].hl_group and mark[3] == 0 then
+          prefixes[mark[2]] = {
+            hl_group = mark[4].hl_group,
+            priority = mark[4].priority,
+          }
+        end
+      end
+      assert.are.same({ hl_group = '@diff.minus', priority = 199 }, prefixes[0])
+      assert.are.same({ hl_group = '@diff.plus', priority = 199 }, prefixes[1])
+      assert.is_nil(prefixes[2])
+      delete_buffer(bufnr)
+    end)
 
     it('applies DiffsClear extmarks to clear diff colors', function()
       local bufnr = create_buffer({


### PR DESCRIPTION
## Summary

- centralize runtime hunk highlight option construction behind `highlight.hunk_opts()`
- keep current v0.3.x config priority defaults and deprecation behavior unchanged
- move gitsigns popup prefix extmarks behind a highlight helper instead of reading priority fields directly

Closes #339
Closes #344

## Verification

- `direnv exec /home/barrett/dev/diffs.nvim busted spec/config_spec.lua spec/runtime_spec.lua spec/plugin_spec.lua spec/highlight_spec.lua spec/gitsigns_spec.lua`
- `direnv exec /home/barrett/dev/diffs.nvim nix develop .#ci -c just ci`
