### PR TITLE
refactor(generated): centralize buffer metadata

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -4,6 +4,7 @@ local actions = require('diffs.actions')
 local content = require('diffs.content')
 local diffspec = require('diffs.spec')
 local gdiff_parser = require('diffs.gdiff')
+local generated = require('diffs.generated')
 local git = require('diffs.git')
 local hunk_model = require('diffs.hunks')
 local lists = require('diffs.lists')
@@ -152,7 +153,7 @@ function M.setup_diff_buf(bufnr)
   if not get_buffer_keymap(bufnr, 'n', 'q') then
     vim.keymap.set('n', 'q', '<cmd>close<CR>', { buffer = bufnr })
   end
-  local has_hunks, parsed_hunks = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_hunks')
+  local has_hunks, parsed_hunks = generated.raw_hunks(bufnr)
   if not has_hunks then
     clear_hunk_keymaps(bufnr)
     return
@@ -264,27 +265,16 @@ local function gdiff_buffer_label(diff_spec)
 end
 
 ---@param bufnr integer
----@param name string
----@return any
-local function get_buf_var(bufnr, name)
-  local ok, value = pcall(vim.api.nvim_buf_get_var, bufnr, name)
-  if ok then
-    return value
-  end
-  return nil
-end
-
----@param bufnr integer
 ---@param diff_spec diffs.DiffSpec
 local function set_diff_spec_var(bufnr, diff_spec)
-  vim.api.nvim_buf_set_var(bufnr, 'diffs_spec', diffspec.new(diff_spec))
+  generated.set_spec(bufnr, diff_spec)
 end
 
 ---@param bufnr integer
 ---@param diff_lines string[]
 ---@param diff_spec diffs.DiffSpec
 local function set_diff_hunks_var(bufnr, diff_lines, diff_spec)
-  vim.api.nvim_buf_set_var(bufnr, 'diffs_hunks', hunk_model.parse(diff_lines, diff_spec))
+  generated.set_hunks_from_lines(bufnr, diff_lines, diff_spec)
 end
 
 ---@param bufnr integer
@@ -299,125 +289,19 @@ end
 
 ---@param bufnr integer
 local function clear_diff_hunks_var(bufnr)
-  pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_hunks')
+  generated.clear_hunks(bufnr)
 end
 
 ---@param bufnr integer
 ---@return diffs.DiffSpec?, string?
 local function get_diff_spec_var(bufnr)
-  local raw = get_buf_var(bufnr, 'diffs_spec')
-  if raw == nil then
-    return nil, nil
-  end
-
-  local ok, parsed = pcall(diffspec.new, raw)
-  if not ok then
-    return nil, tostring(parsed)
-  end
-
-  return parsed, nil
-end
-
----@class diffs.GeneratedBufferSource
----@field version integer
----@field kind "file"|"file_pair"|"section"|"review"|"review_file"|"unmerged"|"split_endpoint"
----@field repo_root string
----@field spec? diffs.DiffSpec
----@field edge? "staged"|"unstaged"
----@field path? string
----@field old_path? string
----@field section? "staged"|"unstaged"
----@field review? diffs.GreviewSpec
----@field review_display? string
----@field selected_key? string
----@field selected_file? string
----@field working_path? string
----@field side? "left"|"right"
----@field filetype? string
-
----@param source table
----@return diffs.GeneratedBufferSource?
-local function normalize_source(source)
-  if type(source) ~= 'table' then
-    error('expected table')
-  end
-  if source.version ~= 1 then
-    error('expected version 1')
-  end
-  if type(source.repo_root) ~= 'string' or source.repo_root == '' then
-    error('expected repo_root')
-  end
-
-  if source.kind == 'file' then
-    if source.spec == nil then
-      error('expected file spec')
-    end
-    source.spec = diffspec.new(source.spec)
-  elseif source.kind == 'split_endpoint' then
-    if source.spec == nil then
-      error('expected split endpoint spec')
-    end
-    source.spec = diffspec.new(source.spec)
-    if source.side ~= 'left' and source.side ~= 'right' then
-      error('expected split endpoint side')
-    end
-    if type(source.path) ~= 'string' or source.path == '' then
-      error('expected split endpoint path')
-    end
-  elseif source.kind == 'file_pair' then
-    if source.edge ~= 'staged' and source.edge ~= 'unstaged' then
-      error('expected file_pair edge')
-    end
-    if type(source.path) ~= 'string' or source.path == '' then
-      error('expected file_pair path')
-    end
-    if type(source.old_path) ~= 'string' or source.old_path == '' then
-      error('expected file_pair old_path')
-    end
-  elseif source.kind == 'section' then
-    if source.section ~= 'staged' and source.section ~= 'unstaged' then
-      error('expected section')
-    end
-  elseif source.kind == 'review' then
-    if type(source.review) ~= 'table' then
-      error('expected review spec')
-    end
-  elseif source.kind == 'review_file' then
-    if type(source.review) ~= 'table' then
-      error('expected review file spec')
-    end
-    if source.spec == nil then
-      error('expected review file diff spec')
-    end
-    source.spec = diffspec.new(source.spec)
-    if type(source.path) ~= 'string' or source.path == '' then
-      error('expected review file path')
-    end
-  elseif source.kind == 'unmerged' then
-    if type(source.path) ~= 'string' or source.path == '' then
-      error('expected unmerged path')
-    end
-  else
-    error('unknown source kind')
-  end
-
-  return source
+  return generated.spec(bufnr)
 end
 
 ---@param bufnr integer
 ---@return diffs.GeneratedBufferSource?, string?
 local function get_source_var(bufnr)
-  local raw = get_buf_var(bufnr, 'diffs_source')
-  if raw == nil then
-    return nil, nil
-  end
-
-  local ok, source = pcall(normalize_source, raw)
-  if not ok then
-    return nil, tostring(source)
-  end
-
-  return source, nil
+  return generated.source(bufnr)
 end
 
 ---@param bufnr integer
@@ -465,10 +349,10 @@ local function create_generated_diff_buffer(opts)
     set_diff_hunks_var(bufnr, opts.lines, opts.diff_spec)
   end
   if opts.repo_root then
-    vim.api.nvim_buf_set_var(bufnr, 'diffs_repo_root', opts.repo_root)
+    generated.set_repo_root(bufnr, opts.repo_root)
   end
   if opts.source then
-    vim.api.nvim_buf_set_var(bufnr, 'diffs_source', opts.source)
+    generated.set_source(bufnr, opts.source)
   end
   for name, value in pairs(opts.vars or {}) do
     if value ~= nil then
@@ -1067,8 +951,7 @@ end
 ---@param state diffs.GreviewWorkspaceState
 ---@return diffs.GdiffHunk[]
 local function greview_workspace_hunks(state)
-  local hunks = get_buf_var(state.diff_buf, 'diffs_hunks')
-  return type(hunks) == 'table' and hunks or {}
+  return generated.hunks(state.diff_buf)
 end
 
 ---@param state diffs.GreviewWorkspaceState
@@ -1151,9 +1034,7 @@ end
 ---@param diff_spec diffs.DiffSpec
 ---@return diffs.GeneratedBufferSource
 local function review_file_source(state, selected, diff_spec)
-  return {
-    version = 1,
-    kind = 'review_file',
+  return generated.review_file_source({
     repo_root = state.repo_root,
     review = state.review,
     review_display = state.display,
@@ -1161,7 +1042,7 @@ local function review_file_source(state, selected, diff_spec)
     selected_file = selected.file,
     path = selected.file,
     spec = diff_spec,
-  }
+  })
 end
 
 ---@param bufnr integer
@@ -1171,8 +1052,8 @@ end
 ---@param diff_lines string[]
 local function replace_review_file_buffer(bufnr, state, selected, diff_spec, diff_lines)
   set_diff_spec_var(bufnr, diff_spec)
-  vim.api.nvim_buf_set_var(bufnr, 'diffs_repo_root', state.repo_root)
-  vim.api.nvim_buf_set_var(bufnr, 'diffs_source', review_file_source(state, selected, diff_spec))
+  generated.set_repo_root(bufnr, state.repo_root)
+  generated.set_source(bufnr, review_file_source(state, selected, diff_spec))
   replace_generated_diff_buffer_lines(bufnr, diff_lines, diff_spec)
   lists.set_for_unified_buffer(bufnr, diff_lines, {
     title = 'review: ' .. (selected.key or selected.file),
@@ -1575,9 +1456,7 @@ open_greview_workspace = function(spec, opts)
     lines = diff_lines,
     repo_root = normalized.repo_root,
     diff_spec = diff_spec,
-    source = {
-      version = 1,
-      kind = 'review_file',
+    source = generated.review_file_source({
       repo_root = normalized.repo_root,
       review = review_spec,
       review_display = normalized.display,
@@ -1585,7 +1464,7 @@ open_greview_workspace = function(spec, opts)
       selected_file = first.file,
       path = first.file,
       spec = diff_spec,
-    },
+    }),
   })
 
   local diff_win = vim.api.nvim_get_current_win()
@@ -1759,12 +1638,7 @@ function M.gdiff(args, vertical)
     lines = diff_lines,
     repo_root = repo_root,
     diff_spec = diff_spec,
-    source = {
-      version = 1,
-      kind = 'file',
-      repo_root = repo_root,
-      spec = diff_spec,
-    },
+    source = generated.file_source(repo_root, diff_spec),
   })
   show_generated_diff_buffer(diff_buf, vertical)
   lists.set_for_unified_buffer(diff_buf, diff_lines, {
@@ -1868,29 +1742,12 @@ function M.gdiff_file(filepath, opts)
 
   local source
   if diff_spec then
-    source = {
-      version = 1,
-      kind = 'file',
-      repo_root = repo_root,
-      spec = diff_spec,
-    }
+    source = generated.file_source(repo_root, diff_spec)
   elseif opts.unmerged then
-    source = {
-      version = 1,
-      kind = 'unmerged',
-      repo_root = repo_root,
-      path = rel_path,
-      working_path = filepath,
-    }
+    source = generated.unmerged_source(repo_root, rel_path, filepath)
   else
-    source = {
-      version = 1,
-      kind = 'file_pair',
-      repo_root = repo_root,
-      edge = diff_label,
-      path = rel_path,
-      old_path = old_rel_path,
-    }
+    local edge = opts.staged and 'staged' or 'unstaged'
+    source = generated.file_pair_source(repo_root, edge, rel_path, old_rel_path)
   end
 
   local diff_buf = create_generated_diff_buffer({
@@ -1962,12 +1819,7 @@ function M.gdiff_section(repo_root, opts)
     name = 'diffs://' .. diff_label .. ':all',
     lines = result,
     repo_root = repo_root,
-    source = {
-      version = 1,
-      kind = 'section',
-      repo_root = repo_root,
-      section = diff_label,
-    },
+    source = generated.section_source(repo_root, diff_label),
   })
   show_generated_diff_buffer(diff_buf, opts.vertical)
   lists.set_for_unified_buffer(diff_buf, result, {
@@ -1991,7 +1843,7 @@ function M.read_buffer(bufnr)
     return
   end
 
-  local repo_root = source and source.repo_root or get_buf_var(bufnr, 'diffs_repo_root')
+  local repo_root = source and source.repo_root or generated.repo_root(bufnr)
   if not repo_root then
     notify('cannot reload diffs:// buffer without diffs_repo_root', vim.log.levels.WARN)
     return

--- a/lua/diffs/generated.lua
+++ b/lua/diffs/generated.lua
@@ -1,0 +1,291 @@
+local M = {}
+
+local diffspec = require('diffs.spec')
+local hunk_model = require('diffs.hunks')
+
+---@param bufnr integer
+---@param name string
+---@return any
+function M.get_var(bufnr, name)
+  local ok, value = pcall(vim.api.nvim_buf_get_var, bufnr, name)
+  if ok then
+    return value
+  end
+  return nil
+end
+
+---@param bufnr integer
+---@return string?
+function M.repo_root(bufnr)
+  return M.get_var(bufnr, 'diffs_repo_root')
+end
+
+---@param bufnr integer
+---@param repo_root string
+function M.set_repo_root(bufnr, repo_root)
+  vim.api.nvim_buf_set_var(bufnr, 'diffs_repo_root', repo_root)
+end
+
+---@param bufnr integer
+---@param diff_spec diffs.DiffSpec
+function M.set_spec(bufnr, diff_spec)
+  vim.api.nvim_buf_set_var(bufnr, 'diffs_spec', diffspec.new(diff_spec))
+end
+
+---@param bufnr integer
+---@return diffs.DiffSpec?, string?
+function M.spec(bufnr)
+  local raw = M.get_var(bufnr, 'diffs_spec')
+  if raw == nil then
+    return nil, nil
+  end
+
+  local ok, parsed = pcall(diffspec.new, raw)
+  if not ok then
+    return nil, tostring(parsed)
+  end
+
+  return parsed, nil
+end
+
+---@param bufnr integer
+---@return boolean, any
+function M.raw_hunks(bufnr)
+  return pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_hunks')
+end
+
+---@param bufnr integer
+---@return diffs.GdiffHunk[]
+function M.hunks(bufnr)
+  local ok, parsed = M.raw_hunks(bufnr)
+  if ok and type(parsed) == 'table' then
+    return parsed
+  end
+  return {}
+end
+
+---@param bufnr integer
+---@param hunks diffs.GdiffHunk[]
+function M.set_hunks(bufnr, hunks)
+  vim.api.nvim_buf_set_var(bufnr, 'diffs_hunks', hunks)
+end
+
+---@param bufnr integer
+---@param diff_lines string[]
+---@param diff_spec diffs.DiffSpec
+function M.set_hunks_from_lines(bufnr, diff_lines, diff_spec)
+  M.set_hunks(bufnr, hunk_model.parse(diff_lines, diff_spec))
+end
+
+---@param bufnr integer
+function M.clear_hunks(bufnr)
+  pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_hunks')
+end
+
+---@class diffs.GeneratedBufferSource
+---@field version integer
+---@field kind "file"|"file_pair"|"section"|"review"|"review_file"|"unmerged"|"split_endpoint"
+---@field repo_root string
+---@field spec? diffs.DiffSpec
+---@field edge? "staged"|"unstaged"
+---@field path? string
+---@field old_path? string
+---@field section? "staged"|"unstaged"
+---@field review? diffs.GreviewSpec
+---@field review_display? string
+---@field selected_key? string
+---@field selected_file? string
+---@field working_path? string
+---@field side? "left"|"right"
+---@field filetype? string
+---@field quickfix? boolean
+
+---@param source table
+---@return diffs.GeneratedBufferSource?
+function M.normalize_source(source)
+  if type(source) ~= 'table' then
+    error('expected table')
+  end
+  if source.version ~= 1 then
+    error('expected version 1')
+  end
+  if type(source.repo_root) ~= 'string' or source.repo_root == '' then
+    error('expected repo_root')
+  end
+
+  if source.kind == 'file' then
+    if source.spec == nil then
+      error('expected file spec')
+    end
+    source.spec = diffspec.new(source.spec)
+  elseif source.kind == 'split_endpoint' then
+    if source.spec == nil then
+      error('expected split endpoint spec')
+    end
+    source.spec = diffspec.new(source.spec)
+    if source.side ~= 'left' and source.side ~= 'right' then
+      error('expected split endpoint side')
+    end
+    if type(source.path) ~= 'string' or source.path == '' then
+      error('expected split endpoint path')
+    end
+  elseif source.kind == 'file_pair' then
+    if source.edge ~= 'staged' and source.edge ~= 'unstaged' then
+      error('expected file_pair edge')
+    end
+    if type(source.path) ~= 'string' or source.path == '' then
+      error('expected file_pair path')
+    end
+    if type(source.old_path) ~= 'string' or source.old_path == '' then
+      error('expected file_pair old_path')
+    end
+  elseif source.kind == 'section' then
+    if source.section ~= 'staged' and source.section ~= 'unstaged' then
+      error('expected section')
+    end
+  elseif source.kind == 'review' then
+    if type(source.review) ~= 'table' then
+      error('expected review spec')
+    end
+  elseif source.kind == 'review_file' then
+    if type(source.review) ~= 'table' then
+      error('expected review file spec')
+    end
+    if source.spec == nil then
+      error('expected review file diff spec')
+    end
+    source.spec = diffspec.new(source.spec)
+    if type(source.path) ~= 'string' or source.path == '' then
+      error('expected review file path')
+    end
+  elseif source.kind == 'unmerged' then
+    if type(source.path) ~= 'string' or source.path == '' then
+      error('expected unmerged path')
+    end
+  else
+    error('unknown source kind')
+  end
+
+  return source
+end
+
+---@param bufnr integer
+---@return diffs.GeneratedBufferSource?, string?
+function M.source(bufnr)
+  local raw = M.get_var(bufnr, 'diffs_source')
+  if raw == nil then
+    return nil, nil
+  end
+
+  local ok, source = pcall(M.normalize_source, raw)
+  if not ok then
+    return nil, tostring(source)
+  end
+
+  return source, nil
+end
+
+---@param bufnr integer
+---@param source diffs.GeneratedBufferSource|diffs.SplitEndpointSource
+function M.set_source(bufnr, source)
+  vim.api.nvim_buf_set_var(bufnr, 'diffs_source', source)
+end
+
+---@param repo_root string
+---@param diff_spec diffs.DiffSpec
+---@return diffs.GeneratedBufferSource
+function M.file_source(repo_root, diff_spec)
+  return {
+    version = 1,
+    kind = 'file',
+    repo_root = repo_root,
+    spec = diff_spec,
+  }
+end
+
+---@param repo_root string
+---@param edge "staged"|"unstaged"
+---@param path string
+---@param old_path string
+---@return diffs.GeneratedBufferSource
+function M.file_pair_source(repo_root, edge, path, old_path)
+  return {
+    version = 1,
+    kind = 'file_pair',
+    repo_root = repo_root,
+    edge = edge,
+    path = path,
+    old_path = old_path,
+  }
+end
+
+---@param repo_root string
+---@param section "staged"|"unstaged"
+---@return diffs.GeneratedBufferSource
+function M.section_source(repo_root, section)
+  return {
+    version = 1,
+    kind = 'section',
+    repo_root = repo_root,
+    section = section,
+  }
+end
+
+---@param repo_root string
+---@param path string
+---@param working_path string?
+---@return diffs.GeneratedBufferSource
+function M.unmerged_source(repo_root, path, working_path)
+  return {
+    version = 1,
+    kind = 'unmerged',
+    repo_root = repo_root,
+    path = path,
+    working_path = working_path,
+  }
+end
+
+---@param repo_root string
+---@param review diffs.GreviewSpec
+---@return diffs.GeneratedBufferSource
+function M.review_source(repo_root, review)
+  return {
+    version = 1,
+    kind = 'review',
+    repo_root = repo_root,
+    review = review,
+  }
+end
+
+---@param opts { repo_root: string, review: diffs.GreviewSpec, review_display?: string, selected_key?: string, selected_file?: string, path: string, spec: diffs.DiffSpec }
+---@return diffs.GeneratedBufferSource
+function M.review_file_source(opts)
+  return {
+    version = 1,
+    kind = 'review_file',
+    repo_root = opts.repo_root,
+    review = opts.review,
+    review_display = opts.review_display,
+    selected_key = opts.selected_key,
+    selected_file = opts.selected_file,
+    path = opts.path,
+    spec = opts.spec,
+  }
+end
+
+---@param opts { repo_root: string, spec: diffs.DiffSpec, side: "left"|"right", path: string, filetype?: string, quickfix?: boolean }
+---@return diffs.SplitEndpointSource
+function M.split_endpoint_source(opts)
+  return {
+    version = 1,
+    kind = 'split_endpoint',
+    repo_root = opts.repo_root,
+    spec = opts.spec,
+    side = opts.side,
+    path = opts.path,
+    filetype = opts.filetype,
+    quickfix = opts.quickfix,
+  }
+end
+
+return M

--- a/lua/diffs/hunks.lua
+++ b/lua/diffs/hunks.lua
@@ -120,15 +120,12 @@ local function is_review_section_header(line)
 end
 
 ---@param diff_spec diffs.DiffSpec?
----@return diffs.DiffSpec?, "index"|"worktree"|nil, boolean, boolean
+---@return diffs.DiffSpec?
 local function normalize_spec(diff_spec)
   if not diff_spec then
-    return nil, nil, false, false
+    return nil
   end
-  local spec = diffspec.new(diff_spec)
-  local target = diffspec.mutation_target(spec)
-  local actions = diffspec.patch_actions(spec)
-  return spec, target, actions.can_put, actions.can_obtain
+  return diffspec.new(diff_spec)
 end
 
 ---@param lines string[]
@@ -145,7 +142,7 @@ end
 ---@param diff_spec? diffs.DiffSpec
 ---@return diffs.GdiffHunk[]
 function M.parse(diff_lines, diff_spec)
-  local spec, target, can_put, can_obtain = normalize_spec(diff_spec)
+  local spec = normalize_spec(diff_spec)
   local hunks = {}
   local current_old_path = spec and spec.scope.kind == diffspec.scope_kind.file and spec.scope.path
     or nil
@@ -232,16 +229,6 @@ function M.parse(diff_lines, diff_spec)
             or nil,
           file_header_lines = file_header_lines,
           header = line,
-          diff_spec = spec,
-          edge = spec and {
-            left = diffspec.endpoint(spec.left),
-            right = diffspec.endpoint(spec.right),
-            mutation_target = target,
-          } or nil,
-          can_put = can_put,
-          can_obtain = can_obtain,
-          actionable = can_put or can_obtain,
-          mutation_target = target,
           source_lnum = source_lnum(new_range.start),
           lines = {},
         }
@@ -313,6 +300,42 @@ function M.parse(diff_lines, diff_spec)
 
   finish_hunk(#diff_lines)
 
+  return M.decorate_actionability(hunks, spec)
+end
+
+---@param hunk diffs.GdiffHunk
+---@param spec diffs.DiffSpec?
+---@param target "index"|"worktree"|nil
+---@param can_put boolean
+---@param can_obtain boolean
+local function decorate_hunk_actionability(hunk, spec, target, can_put, can_obtain)
+  hunk.diff_spec = spec
+  hunk.edge = spec
+      and {
+        left = diffspec.endpoint(spec.left),
+        right = diffspec.endpoint(spec.right),
+        mutation_target = target,
+      }
+    or nil
+  hunk.can_put = can_put
+  hunk.can_obtain = can_obtain
+  hunk.actionable = can_put or can_obtain
+  hunk.mutation_target = target
+end
+
+---@param hunks diffs.GdiffHunk[]
+---@param diff_spec? diffs.DiffSpec
+---@return diffs.GdiffHunk[]
+function M.decorate_actionability(hunks, diff_spec)
+  local spec = normalize_spec(diff_spec)
+  local target = spec and diffspec.mutation_target(spec) or nil
+  local patch_actions = spec and diffspec.patch_actions(spec) or nil
+  local can_put = patch_actions and patch_actions.can_put or false
+  local can_obtain = patch_actions and patch_actions.can_obtain or false
+
+  for _, hunk in ipairs(hunks or {}) do
+    decorate_hunk_actionability(hunk, spec, target, can_put, can_obtain)
+  end
   return hunks
 end
 

--- a/lua/diffs/lists.lua
+++ b/lua/diffs/lists.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local diffspec = require('diffs.spec')
+local generated = require('diffs.generated')
 local hunk_model = require('diffs.hunks')
 
 local generated_list_autocmds = {}
@@ -25,11 +25,7 @@ local group = vim.api.nvim_create_augroup('diffs_generated_lists', { clear = fal
 ---@param name string
 ---@return any
 local function get_buf_var(bufnr, name)
-  local ok, value = pcall(vim.api.nvim_buf_get_var, bufnr, name)
-  if ok then
-    return value
-  end
-  return nil
+  return generated.get_var(bufnr, name)
 end
 
 ---@param bufnr integer
@@ -186,12 +182,7 @@ local function file_entries(hunks, diff_lines, opts)
     hunk.section = entry.section
     hunk.section_label = entry.section_label
     if not hunk.diff_spec and entry.diff_spec then
-      hunk.diff_spec = entry.diff_spec
-      local actions = diffspec.patch_actions(entry.diff_spec)
-      hunk.can_put = actions.can_put
-      hunk.can_obtain = actions.can_obtain
-      hunk.actionable = actions.can_put or actions.can_obtain
-      hunk.mutation_target = diffspec.mutation_target(entry.diff_spec)
+      hunk_model.decorate_actionability({ hunk }, entry.diff_spec)
     end
   end
   return entries
@@ -789,7 +780,7 @@ function M.set_for_unified_buffer(bufnr, diff_lines, opts)
   local state = list_state(diff_lines, opts)
 
   if opts.store_hunks then
-    vim.api.nvim_buf_set_var(bufnr, 'diffs_hunks', state.hunks)
+    generated.set_hunks(bufnr, state.hunks)
   end
 
   generated_list_state[bufnr] = {

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local diffspec = require('diffs.spec')
+local generated = require('diffs.generated')
 local git = require('diffs.git')
 local lists = require('diffs.lists')
 local log = require('diffs.log')
@@ -763,16 +764,11 @@ function M.greview(spec, deps)
     name = target_name,
     lines = result,
     repo_root = review.repo_root,
-    source = {
-      version = 1,
-      kind = 'review',
-      repo_root = review.repo_root,
-      review = {
-        base = review.base,
-        target = review.target,
-        mode = review.mode,
-      },
-    },
+    source = generated.review_source(review.repo_root, {
+      base = review.base,
+      target = review.target,
+      mode = review.mode,
+    }),
     vars = {
       diffs_review_base = review.base,
       diffs_review_target = review.target,

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local diffspec = require('diffs.spec')
+local generated = require('diffs.generated')
 local hunk_model = require('diffs.hunks')
 local lists = require('diffs.lists')
 local log = require('diffs.log')
@@ -116,9 +117,9 @@ end
 ---@param source diffs.SplitEndpointSource
 ---@param split_hunks? diffs.GdiffHunk[]
 local function set_source_vars(bufnr, source, split_hunks)
-  vim.api.nvim_buf_set_var(bufnr, 'diffs_repo_root', source.repo_root)
-  vim.api.nvim_buf_set_var(bufnr, 'diffs_spec', diffspec.new(source.spec))
-  vim.api.nvim_buf_set_var(bufnr, 'diffs_source', source)
+  generated.set_repo_root(bufnr, source.repo_root)
+  generated.set_spec(bufnr, source.spec)
+  generated.set_source(bufnr, source)
   vim.api.nvim_buf_set_var(bufnr, 'diffs_split_side', source.side)
   if split_hunks then
     vim.api.nvim_buf_set_var(bufnr, 'diffs_split_hunks', split_hunks)
@@ -838,8 +839,6 @@ function M.open(opts)
   local filetype = opts.filetype
   local path = spec.scope.path
   local base_source = {
-    version = 1,
-    kind = 'split_endpoint',
     repo_root = opts.repo_root,
     spec = spec,
     path = path,
@@ -847,8 +846,10 @@ function M.open(opts)
     quickfix = opts.quickfix,
   }
 
-  local left_source = vim.tbl_extend('force', base_source, { side = 'left' })
-  local right_source = vim.tbl_extend('force', base_source, { side = 'right' })
+  local left_source =
+    generated.split_endpoint_source(vim.tbl_extend('force', base_source, { side = 'left' }))
+  local right_source =
+    generated.split_endpoint_source(vim.tbl_extend('force', base_source, { side = 'right' }))
   local left_lines, left_err = endpoint_lines(left_source, { worktree_lines = opts.worktree_lines })
   if not left_lines then
     return nil, left_err


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

This closes #342 and #343.

## Solution

The solution adds a generated-buffer metadata/accessor module for `diffs://` buffer vars and source normalization; moves hunk actionability decoration into the hunk model instead of list projection; and keeps generated buffer names, vars, reload behavior, qf/loclist metadata, and hunk action maps compatible.
