### PR TITLE
feat(config): allow view glyph customization

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -88,6 +88,8 @@ Configuration is done via `vim.g.diffs`. Set options before the plugin loads:
       debug = false,
       view = {
         prefix = true,
+        change_bar = '▏',
+        rail_separator = '│',
       },
       integrations = {
         fugitive = false,
@@ -163,6 +165,16 @@ Pre-v0.4.0 migration window: ~
                              `false` to hide them with virtual text overlay.
                              When `highlights.background` is also enabled,
                              the overlay inherits the line's background color.
+
+        {change_bar}         (string, default: '▏')
+                             Glyph for changed-line bars in diffs.nvim-owned
+                             views. Colors come from `DiffsAddBar` and
+                             `DiffsDeleteBar`.
+
+        {rail_separator}     (string, default: '│')
+                             Glyph between generated old/new line-number
+                             rails and diff text. Surrounding padding is
+                             managed internally.
 
         {integrations}       (table, default: all false)
                              Integration toggles. Each key accepts `true` or

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -282,8 +282,10 @@ end
 local function set_diff_rails_var(bufnr, info)
   if info then
     vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_width', info.prefix_width)
+    vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_separator_width', info.separator_width)
   else
     pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_width')
+    pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_separator_width')
   end
 end
 
@@ -339,7 +341,9 @@ end
 ---@return integer
 local function create_generated_diff_buffer(opts)
   local bufnr = vim.api.nvim_create_buf(false, true)
-  local display_lines, rail_info = rails.annotate(opts.lines)
+  local display_lines, rail_info = rails.annotate(opts.lines, {
+    rail_separator = runtime.get_view_config().rail_separator,
+  })
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, display_lines)
   vim.api.nvim_buf_set_name(bufnr, opts.name)
   set_diff_rails_var(bufnr, rail_info)
@@ -386,7 +390,9 @@ end
 ---@param diff_lines string[]
 ---@param diff_spec? diffs.DiffSpec
 local function replace_generated_diff_buffer_lines(bufnr, diff_lines, diff_spec)
-  local display_lines, rail_info = rails.annotate(diff_lines)
+  local display_lines, rail_info = rails.annotate(diff_lines, {
+    rail_separator = runtime.get_view_config().rail_separator,
+  })
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, display_lines)
   set_diff_rails_var(bufnr, rail_info)
@@ -1626,6 +1632,7 @@ function M.gdiff(args, vertical)
       filetype = vim.api.nvim_get_option_value('filetype', { buf = bufnr }),
       worktree_lines = worktree_lines,
       diff_lines = diff_lines,
+      change_bar = runtime.get_view_config().change_bar,
     })
     if not opened then
       notify(split_err or 'cannot open split Gdiff', vim.log.levels.ERROR)
@@ -1850,7 +1857,9 @@ function M.read_buffer(bufnr)
   end
 
   if source and source.kind == 'split_endpoint' then
-    local ok, err = split.read_buffer(bufnr, source)
+    local ok, err = split.read_buffer(bufnr, source, {
+      change_bar = runtime.get_view_config().change_bar,
+    })
     if not ok then
       notify(err or 'cannot reload split diffs:// buffer', vim.log.levels.WARN)
     end

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -27,6 +27,8 @@ local integration_metadata = require('diffs.integrations')
 
 ---@class diffs.ViewConfig
 ---@field prefix boolean
+---@field change_bar string
+---@field rail_separator string
 
 ---@class diffs.Highlights
 ---@field background boolean
@@ -95,6 +97,8 @@ local DEFAULTS = {
   debug = false,
   view = {
     prefix = true,
+    change_bar = '▏',
+    rail_separator = '│',
   },
   extra_filetypes = {},
   highlights = {
@@ -337,6 +341,8 @@ function M.validate(opts)
   vim.validate('view', opts.view, 'table', true)
   if opts.view then
     vim.validate('view.prefix', opts.view.prefix, 'boolean', true)
+    vim.validate('view.change_bar', opts.view.change_bar, 'string', true)
+    vim.validate('view.rail_separator', opts.view.rail_separator, 'string', true)
   end
   vim.validate('integrations', opts.integrations, 'table', true)
   local integration_validator = function(v)

--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -4,7 +4,7 @@ local dbg = require('diffs.log').dbg
 local diff = require('diffs.diff')
 local rails = require('diffs.rails')
 
-local generated_change_bar = '▏'
+local default_change_bar = '▏'
 
 local vim_syntax_cache = {}
 local vim_syntax_cache_size = 0
@@ -148,6 +148,7 @@ end
 
 ---@class diffs.HunkOpts
 ---@field hide_prefix boolean
+---@field change_bar string
 ---@field highlights diffs.Highlights
 ---@field defer_vim_syntax? boolean
 ---@field syntax_only? boolean
@@ -163,6 +164,7 @@ end
 function M.hunk_opts(config, overrides)
   local opts = {
     hide_prefix = not config.view.prefix,
+    change_bar = config.view.change_bar,
     highlights = config.highlights,
   }
   if not overrides then
@@ -824,7 +826,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
             priority = p.syntax,
           })
 
-          local ranges = rails.ranges(hunk.rail_width)
+          local ranges = rails.ranges(hunk.rail_width, hunk.rail_separator_width)
           if ranges then
             pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, ranges.old_start, {
               end_col = ranges.old_end,
@@ -882,7 +884,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
 
       if hunk.rail_width and is_diff_line and opts.highlights.background then
         pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
-          virt_text = { { generated_change_bar, bar_hl } },
+          virt_text = { { opts.change_bar or default_change_bar, bar_hl } },
           virt_text_pos = 'overlay',
           hl_mode = 'replace',
           priority = p.char_bg + 10,

--- a/lua/diffs/merge.lua
+++ b/lua/diffs/merge.lua
@@ -25,11 +25,12 @@ local buffer_keymaps = {}
 function M.parse_hunks(bufnr)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   local rail_width = rails.width_for_buffer(bufnr)
+  local rail_separator_width = rails.separator_width_for_buffer(bufnr)
   local hunks = {}
   local current = nil
 
   for i, line in ipairs(lines) do
-    line = rails.strip(line, rail_width)
+    line = rails.strip(line, rail_width, rail_separator_width)
     local idx = i - 1
     if line:match('^@@') then
       if current then

--- a/lua/diffs/parser.lua
+++ b/lua/diffs/parser.lua
@@ -15,6 +15,7 @@
 ---@field prefix_width integer
 ---@field quote_width integer
 ---@field rail_width integer?
+---@field rail_separator_width integer?
 ---@field repo_root string?
 ---@field context_before string[]?
 ---@field context_after string[]?
@@ -154,11 +155,12 @@ function M.parse_buffer(bufnr)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   local repo_root = get_repo_root(bufnr)
   local rail_width = rails.width_for_buffer(bufnr)
+  local rail_separator_width = rails.separator_width_for_buffer(bufnr)
 
   local quote_prefix = nil
   local quote_width = 0
   for _, l in ipairs(lines) do
-    local logical = rails.strip(l, rail_width)
+    local logical = rails.strip(l, rail_width, rail_separator_width)
     local qp = logical:match('^(>+ )diff %-%-') or logical:match('^(>+ )@@ %-')
     if qp then
       quote_prefix = qp
@@ -224,6 +226,7 @@ function M.parse_buffer(bufnr)
         file_new_count = file_new_count,
         repo_root = repo_root,
         rail_width = rail_width > 0 and rail_width or nil,
+        rail_separator_width = rail_width > 0 and rail_separator_width or nil,
       }
       if hunk_count == 1 and header_start and #header_lines > 0 then
         hunk.header_start_line = header_start
@@ -244,7 +247,7 @@ function M.parse_buffer(bufnr)
   end
 
   for i, line in ipairs(lines) do
-    local without_rails = rails.strip(line, rail_width)
+    local without_rails = rails.strip(line, rail_width, rail_separator_width)
     local logical = without_rails
     if quote_prefix then
       if without_rails:sub(1, quote_width) == quote_prefix then

--- a/lua/diffs/rails.lua
+++ b/lua/diffs/rails.lua
@@ -2,13 +2,19 @@ local M = {}
 
 local hunk_model = require('diffs.hunks')
 
+local default_rail_separator = '│'
 local bar_slot = '  '
-local separator = ' │ '
-local compact_separator = separator:gsub('%s+$', '')
+
+---@param glyph string?
+---@return string
+local function separator_for(glyph)
+  return ' ' .. (glyph or default_rail_separator) .. ' '
+end
 
 ---@class diffs.RailInfo
 ---@field width integer
 ---@field prefix_width integer
+---@field separator_width integer
 
 ---@class diffs.RailRanges
 ---@field old_start integer
@@ -61,9 +67,10 @@ end
 
 ---@param line string
 ---@param prefix_width integer
+---@param separator_width? integer
 ---@return boolean
-local function has_context_rails(line, prefix_width)
-  local ranges = M.ranges(prefix_width)
+local function has_context_rails(line, prefix_width, separator_width)
+  local ranges = M.ranges(prefix_width, separator_width)
   return ranges ~= nil
     and has_number(line, ranges.old_start, ranges.old_end)
     and has_number(line, ranges.new_start, ranges.new_end)
@@ -86,8 +93,13 @@ local function collect_lines(lines)
 end
 
 ---@param lines string[]
+---@param opts? { rail_separator?: string }
 ---@return string[], diffs.RailInfo?
-function M.annotate(lines)
+function M.annotate(lines, opts)
+  opts = opts or {}
+  local separator = separator_for(opts.rail_separator)
+  local compact_separator = separator:gsub('%s+$', '')
+
   local by_lnum, max_lnum = collect_lines(lines)
   if vim.tbl_isempty(by_lnum) then
     return lines, nil
@@ -109,21 +121,24 @@ function M.annotate(lines)
       .. display_text
   end
 
-  return annotated, {
-    width = width,
-    prefix_width = prefix_width,
-  }
+  return annotated,
+    {
+      width = width,
+      prefix_width = prefix_width,
+      separator_width = #separator,
+    }
 end
 
 ---@param line string
 ---@param prefix_width integer?
+---@param separator_width? integer
 ---@return string
-function M.strip(line, prefix_width)
+function M.strip(line, prefix_width, separator_width)
   if type(prefix_width) ~= 'number' or prefix_width <= 0 then
     return line
   end
   local stripped = line:sub(prefix_width + 1)
-  if stripped == '' and has_context_rails(line, prefix_width) then
+  if stripped == '' and has_context_rails(line, prefix_width, separator_width) then
     return ' '
   end
   return stripped
@@ -131,27 +146,30 @@ end
 
 ---@param lines string[]
 ---@param prefix_width integer?
+---@param separator_width? integer
 ---@return string[]
-function M.strip_lines(lines, prefix_width)
+function M.strip_lines(lines, prefix_width, separator_width)
   if type(prefix_width) ~= 'number' or prefix_width <= 0 then
     return lines
   end
 
   local stripped = {}
   for i, line in ipairs(lines) do
-    stripped[i] = M.strip(line, prefix_width)
+    stripped[i] = M.strip(line, prefix_width, separator_width)
   end
   return stripped
 end
 
 ---@param prefix_width integer?
+---@param separator_width? integer
 ---@return diffs.RailRanges?
-function M.ranges(prefix_width)
+function M.ranges(prefix_width, separator_width)
   if type(prefix_width) ~= 'number' or prefix_width <= 0 then
     return nil
   end
+  separator_width = separator_width or #separator_for()
 
-  local width = (prefix_width - #bar_slot - 1 - #separator) / 2
+  local width = (prefix_width - #bar_slot - 1 - separator_width) / 2
   if width < 1 or width % 1 ~= 0 then
     return nil
   end
@@ -179,8 +197,19 @@ function M.width_for_buffer(bufnr)
   return 0
 end
 
+---@param bufnr integer
+---@return integer
+function M.separator_width_for_buffer(bufnr)
+  local ok, width = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_rail_separator_width')
+  if ok and type(width) == 'number' and width > 0 then
+    return width
+  end
+  return #separator_for()
+end
+
 M._test = {
   format_lnum = format_lnum,
+  separator_for = separator_for,
 }
 
 return M

--- a/lua/diffs/runtime/init.lua
+++ b/lua/diffs/runtime/init.lua
@@ -169,6 +169,12 @@ function M.get_conflict_config()
   return config.conflict
 end
 
+---@return diffs.ViewConfig
+function M.get_view_config()
+  init()
+  return config.view
+end
+
 ---@return diffs.HunkOpts
 function M.get_highlight_opts()
   init()

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -22,7 +22,7 @@ local peer_buffers = {}
 local pair_window_options = {}
 local syncing_cursor = false
 local split_bar_ns = vim.api.nvim_create_namespace('diffs_split_change_bar')
-local split_change_bar = '▏'
+local default_change_bar = '▏'
 
 ---@type fun(bufnr: integer)
 local clear_cursor_sync
@@ -37,6 +37,7 @@ local ensure_cursor_sync
 ---@field diff_lines? string[]
 ---@field hunk_index? integer
 ---@field quickfix? boolean
+---@field change_bar? string
 
 ---@class diffs.SplitEndpointSource
 ---@field version integer
@@ -131,7 +132,8 @@ end
 ---@param bufnr integer
 ---@param source diffs.SplitEndpointSource
 ---@param split_hunks? diffs.GdiffHunk[]
-local function set_split_change_bars(bufnr, source, split_hunks)
+---@param change_bar? string
+local function set_split_change_bars(bufnr, source, split_hunks, change_bar)
   vim.api.nvim_buf_clear_namespace(bufnr, split_bar_ns, 0, -1)
   for _, hunk in ipairs(split_hunks or {}) do
     for _, line in ipairs(hunk.lines or {}) do
@@ -147,7 +149,7 @@ local function set_split_change_bars(bufnr, source, split_hunks)
 
       if lnum and lnum >= 1 and lnum <= vim.api.nvim_buf_line_count(bufnr) then
         pcall(vim.api.nvim_buf_set_extmark, bufnr, split_bar_ns, lnum - 1, 0, {
-          sign_text = split_change_bar,
+          sign_text = change_bar or default_change_bar,
           sign_hl_group = hl_group,
           priority = 210,
         })
@@ -234,13 +236,14 @@ end
 ---@param source diffs.SplitEndpointSource
 ---@param lines string[]
 ---@param split_hunks? diffs.GdiffHunk[]
+---@param change_bar? string
 ---@return integer
-local function create_buffer(source, lines, split_hunks)
+local function create_buffer(source, lines, split_hunks, change_bar)
   local bufnr = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   vim.api.nvim_buf_set_name(bufnr, buffer_name(source))
   set_source_vars(bufnr, source, split_hunks)
-  set_split_change_bars(bufnr, source, split_hunks)
+  set_split_change_bars(bufnr, source, split_hunks, change_bar)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)
   return bufnr
@@ -670,11 +673,12 @@ end
 ---@param source diffs.SplitEndpointSource
 ---@param lines string[]
 ---@param split_hunks? diffs.GdiffHunk[]
-local function apply_buffer_lines(bufnr, source, lines, split_hunks)
+---@param change_bar? string
+local function apply_buffer_lines(bufnr, source, lines, split_hunks, change_bar)
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   set_source_vars(bufnr, source, split_hunks)
-  set_split_change_bars(bufnr, source, split_hunks)
+  set_split_change_bars(bufnr, source, split_hunks, change_bar)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)
   ensure_pair_cleanup(bufnr)
@@ -867,8 +871,8 @@ function M.open(opts)
     vim.api.nvim_set_current_win(invoking_win)
   end
 
-  local left_buf = create_buffer(left_source, left_lines, split_hunks)
-  local right_buf = create_buffer(right_source, right_lines, split_hunks)
+  local left_buf = create_buffer(left_source, left_lines, split_hunks, opts.change_bar)
+  local right_buf = create_buffer(right_source, right_lines, split_hunks, opts.change_bar)
   local left_win = vim.api.nvim_get_current_win()
   vim.cmd('rightbelow vsplit')
   local right_win = vim.api.nvim_get_current_win()
@@ -926,8 +930,10 @@ end
 
 ---@param bufnr integer
 ---@param source table
+---@param opts? { change_bar?: string }
 ---@return boolean, string?
-function M.read_buffer(bufnr, source)
+function M.read_buffer(bufnr, source, opts)
+  opts = opts or {}
   source = normalize_source(source)
 
   local peer = split_peer(bufnr)
@@ -965,9 +971,9 @@ function M.read_buffer(bufnr, source)
     split_hunks = split_hunks_for(diff_lines, source.spec)
   end
 
-  apply_buffer_lines(bufnr, source, current_lines, split_hunks)
+  apply_buffer_lines(bufnr, source, current_lines, split_hunks, opts.change_bar)
   if peer and peer_source and peer_lines then
-    apply_buffer_lines(peer, peer_source, peer_lines, split_hunks)
+    apply_buffer_lines(peer, peer_source, peer_lines, split_hunks, opts.change_bar)
     if source.side == 'left' then
       set_peers(bufnr, peer)
     else

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -10,6 +10,7 @@ local split = require('diffs.split')
 local saved_git = {}
 local saved_runtime_attach
 local saved_runtime_get_conflict_config
+local saved_runtime_get_view_config
 local saved_schedule
 local saved_systemlist
 local saved_notify
@@ -51,6 +52,13 @@ end
 local function mock_conflict_config(config)
   saved_runtime_get_conflict_config = runtime.get_conflict_config
   runtime.get_conflict_config = function()
+    return config
+  end
+end
+
+local function mock_view_config(config)
+  saved_runtime_get_view_config = runtime.get_view_config
+  runtime.get_view_config = function()
     return config
   end
 end
@@ -272,7 +280,7 @@ local function buffer_lines(bufnr)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
   local ok, rail_width = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_rail_width')
   if ok then
-    return rails.strip_lines(lines, rail_width)
+    return rails.strip_lines(lines, rail_width, rails.separator_width_for_buffer(bufnr))
   end
   return lines
 end
@@ -362,6 +370,10 @@ local function restore_mocks()
   if saved_runtime_get_conflict_config then
     runtime.get_conflict_config = saved_runtime_get_conflict_config
     saved_runtime_get_conflict_config = nil
+  end
+  if saved_runtime_get_view_config then
+    runtime.get_view_config = saved_runtime_get_view_config
+    saved_runtime_get_view_config = nil
   end
   if saved_schedule then
     vim.schedule = saved_schedule
@@ -655,6 +667,7 @@ describe('commands', function()
         return '/tmp/repo'
       end)
       mock_runtime_attach(function() end)
+      mock_view_config({ prefix = true, change_bar = '▏', rail_separator = '|' })
 
       commands.gdiff(nil, false)
 
@@ -686,11 +699,10 @@ describe('commands', function()
       assert.is_true(table.concat(lines, '\n'):find('+local x = 1', 1, true) ~= nil)
 
       local display_lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
-      assert.are.equal(10, vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_width'))
-      assert.are.equal('      │ diff --git a/lua/foo.lua b/lua/foo.lua', display_lines[1])
-      assert.is_true(
-        table.concat(display_lines, '\n'):find('    2 │ +local x = 1', 1, true) ~= nil
-      )
+      assert.are.equal(8, vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_width'))
+      assert.are.equal(3, vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_separator_width'))
+      assert.are.equal('      | diff --git a/lua/foo.lua b/lua/foo.lua', display_lines[1])
+      assert.is_true(table.concat(display_lines, '\n'):find('    2 | +local x = 1', 1, true) ~= nil)
 
       local qf = quickfix_items()
       assert.are.equal(1, #qf)
@@ -750,6 +762,7 @@ describe('commands', function()
       local saved_splitright = vim.o.splitright
       vim.o.splitright = false
       local ok, err = pcall(function()
+        mock_view_config({ prefix = true, change_bar = '┃', rail_separator = '│' })
         create_split_source()
         commands.gdiff('++layout=split', false)
       end)
@@ -824,7 +837,7 @@ describe('commands', function()
         if
           mark[2] == 1
           and details.sign_hl_group == 'DiffsAddBar'
-          and details.sign_text == '▏ '
+          and details.sign_text == '┃ '
         then
           has_added_line_bar = true
         end

--- a/spec/config_spec.lua
+++ b/spec/config_spec.lua
@@ -66,6 +66,35 @@ describe('diffs.config', function()
       assert.is_nil(opts.hide_prefix)
     end)
 
+    it('defaults view glyphs', function()
+      local opts = config.new()
+      assert.are.equal('▏', opts.view.change_bar)
+      assert.are.equal('│', opts.view.rail_separator)
+    end)
+
+    it('accepts custom view glyphs', function()
+      local opts = config.new({
+        view = {
+          change_bar = '┃',
+          rail_separator = '|',
+        },
+      })
+      assert.are.equal('┃', opts.view.change_bar)
+      assert.are.equal('|', opts.view.rail_separator)
+    end)
+
+    it('validates custom view glyphs', function()
+      local ok, err = pcall(config.new, { view = { change_bar = false } })
+      assert.is_false(ok)
+      assert.matches('view.change_bar', err, 1, true)
+      assert.matches('string', err, 1, true)
+
+      ok, err = pcall(config.new, { view = { rail_separator = false } })
+      assert.is_false(ok)
+      assert.matches('view.rail_separator', err, 1, true)
+      assert.matches('string', err, 1, true)
+    end)
+
     it('warns and maps deprecated hide_prefix = true to view.prefix = false', function()
       local saved_notify = vim.notify
       local notifications = {}

--- a/spec/highlight_spec.lua
+++ b/spec/highlight_spec.lua
@@ -8,6 +8,7 @@ describe('highlight', function()
       local opts = highlight.hunk_opts(config.new({ view = { prefix = false } }))
 
       assert.is_true(opts.hide_prefix)
+      assert.are.equal('▏', opts.change_bar)
       assert.are.same(
         { clear = 198, syntax = 199, line_bg = 200, char_bg = 201 },
         opts.highlights.priorities
@@ -94,12 +95,16 @@ describe('highlight', function()
           },
         },
       }
+      opts.change_bar = '▏'
       if overrides then
         if overrides.highlights then
           opts.highlights = vim.tbl_deep_extend('force', opts.highlights, overrides.highlights)
         end
         if overrides.hide_prefix ~= nil then
           opts.hide_prefix = overrides.hide_prefix
+        end
+        if overrides.change_bar ~= nil then
+          opts.change_bar = overrides.change_bar
         end
       end
       return opts
@@ -667,6 +672,7 @@ describe('highlight', function()
         hunk,
         default_opts({
           hide_prefix = true,
+          change_bar = '┃',
           highlights = {
             background = true,
             treesitter = { enabled = false },
@@ -681,7 +687,7 @@ describe('highlight', function()
           local group = d.virt_text[1][2]
           if group == 'DiffsAddBar' or group == 'DiffsDeleteBar' then
             bars[mark[2]] = group
-            assert.are.equal('▏', d.virt_text[1][1])
+            assert.are.equal('┃', d.virt_text[1][1])
             assert.are.equal(0, mark[3])
           end
         end
@@ -689,6 +695,62 @@ describe('highlight', function()
 
       assert.are.equal('DiffsDeleteBar', bars[1])
       assert.are.equal('DiffsAddBar', bars[2])
+      delete_buffer(bufnr)
+    end)
+
+    it('uses custom rail separator width for generated rails', function()
+      local bufnr = create_buffer({
+        '      | @@ -1,1 +1,1 @@',
+        '  1   | -old',
+        '    1 | +new',
+      })
+
+      local hunk = {
+        filename = 'test.lua',
+        lang = 'lua',
+        start_line = 1,
+        lines = { '-old', '+new' },
+        prefix_width = 1,
+        quote_width = 8,
+        rail_width = 8,
+        rail_separator_width = 3,
+      }
+
+      highlight.highlight_hunk(
+        bufnr,
+        ns,
+        hunk,
+        default_opts({
+          hide_prefix = true,
+          highlights = {
+            background = true,
+            treesitter = { enabled = false },
+          },
+        })
+      )
+
+      local rails = {}
+      local rail_numbers = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        local d = mark[4]
+        if d and d.hl_group == 'DiffsRail' then
+          rails[#rails + 1] = { row = mark[2], col = mark[3], end_col = d.end_col }
+        end
+        if d and d.hl_group == 'DiffsRailNr' then
+          rail_numbers[#rail_numbers + 1] = { row = mark[2], col = mark[3], end_col = d.end_col }
+        end
+      end
+
+      assert.are.same({
+        { row = 1, col = 0, end_col = 8 },
+        { row = 2, col = 0, end_col = 8 },
+      }, rails)
+      assert.are.same({
+        { row = 1, col = 2, end_col = 3 },
+        { row = 1, col = 4, end_col = 5 },
+        { row = 2, col = 2, end_col = 3 },
+        { row = 2, col = 4, end_col = 5 },
+      }, rail_numbers)
       delete_buffer(bufnr)
     end)
 

--- a/spec/rails_spec.lua
+++ b/spec/rails_spec.lua
@@ -20,6 +20,7 @@ describe('diffs.rails', function()
     assert.are.same({
       width = 2,
       prefix_width = 12,
+      separator_width = 5,
     }, info)
     assert.are.equal('        │ diff --git a/file.txt b/file.txt', annotated[1])
     assert.are.equal('        │ @@ -9,3 +10,4 @@', annotated[4])
@@ -50,6 +51,7 @@ describe('diffs.rails', function()
     assert.are.same({
       width = 1,
       prefix_width = 10,
+      separator_width = 5,
     }, info)
     assert.are.equal('  2 2 │', annotated[4])
     assert.is_nil(annotated[4]:match('%s$'))
@@ -63,5 +65,29 @@ describe('diffs.rails', function()
       new_start = 5,
       new_end = 7,
     }, rails.ranges(12))
+  end)
+
+  it('supports custom rail separators', function()
+    local annotated, info = rails.annotate({
+      'diff --git a/file.txt b/file.txt',
+      '@@ -9,2 +10,2 @@',
+      ' alpha',
+      '+beta',
+    }, { rail_separator = '|' })
+
+    assert.are.same({
+      width = 2,
+      prefix_width = 10,
+      separator_width = 3,
+    }, info)
+    assert.are.equal('        | diff --git a/file.txt b/file.txt', annotated[1])
+    assert.are.equal('   9 10 |  alpha', annotated[3])
+    assert.are.equal('     11 | +beta', annotated[4])
+    assert.are.same({
+      old_start = 2,
+      old_end = 4,
+      new_start = 5,
+      new_end = 7,
+    }, rails.ranges(info.prefix_width, info.separator_width))
   end)
 end)

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -93,7 +93,11 @@ end
 
 local function buffer_lines(bufnr)
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  return rails.strip_lines(lines, rails.width_for_buffer(bufnr))
+  return rails.strip_lines(
+    lines,
+    rails.width_for_buffer(bufnr),
+    rails.separator_width_for_buffer(bufnr)
+  )
 end
 
 local function review_diff_lines()


### PR DESCRIPTION
## Problem

The generated diff workspace stack needed this focused change so the `:Gdiff` and `:Greview` surfaces could continue moving toward a coherent generated-buffer model.

## Solution

The solution adds `view.change_bar` and `view.rail_separator` config fields; uses `change_bar` for generated unified change bars and split endpoint sign bars; uses `rail_separator` for generated line-number rails, including separator-width metadata so ASCII separators parse and highlight correctly; and documents the new fields in vimdoc.
