### PR TITLE
feat(commands): accept stacked layout option

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -561,6 +561,7 @@ end
 
 local layout_options = {
   '++layout=unified',
+  '++layout=stacked',
   '++layout=split',
 }
 

--- a/lua/diffs/gdiff.lua
+++ b/lua/diffs/gdiff.lua
@@ -9,7 +9,7 @@ local diffspec = require('diffs.spec')
 ---@class diffs.GdiffParseResult
 ---@field spec diffs.DiffSpec
 ---@field novertical boolean
----@field layout "unified"|"split"
+---@field layout "unified"|"stacked"|"split"
 
 local function normalize_rev(rev)
   if rev == '@' then
@@ -104,7 +104,7 @@ function M.parse(args, context)
         return nil, 'repeated ++layout option'
       end
       local value = tokens[1]:match('^%+%+layout=(.+)$')
-      if value ~= 'unified' and value ~= 'split' then
+      if value ~= 'unified' and value ~= 'stacked' and value ~= 'split' then
         return nil, 'unsupported layout ' .. tostring(value)
       end
       has_layout = true

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -19,7 +19,7 @@ local notify = log.notify
 
 ---@class diffs.GreviewCommandParseResult
 ---@field spec diffs.GreviewSpec
----@field layout "unified"|"split"
+---@field layout "unified"|"stacked"|"split"
 
 ---@class diffs.NormalizedGreview
 ---@field base string
@@ -183,7 +183,7 @@ function M.parse_command_args(args)
       return nil, 'repeated ++layout option'
     end
     local value = tokens[1]:match('^%+%+layout=(.+)$')
-    if value ~= 'unified' and value ~= 'split' then
+    if value ~= 'unified' and value ~= 'stacked' and value ~= 'split' then
       return nil, 'unsupported layout ' .. tostring(value)
     end
     has_layout = true

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -446,10 +446,12 @@ describe('commands', function()
 
       assert.are.same({
         '++layout=unified',
+        '++layout=stacked',
         '++layout=split',
       }, commands._test.complete_gdiff('++l'))
       assert.are.same({
         '++layout=unified',
+        '++layout=stacked',
         '++layout=split',
         ':',
         ':%',
@@ -2147,6 +2149,20 @@ describe('commands', function()
       }, parsed)
     end)
 
+    it('parses Greview command stacked layout option', function()
+      local parsed =
+        commands._test.parse_greview_command('++layout=stacked origin/main...refs/pull/42/head')
+
+      assert.are.same({
+        layout = 'stacked',
+        spec = {
+          base = 'origin/main',
+          target = 'refs/pull/42/head',
+          mode = 'merge-base',
+        },
+      }, parsed)
+    end)
+
     it('rejects unsupported Greview command layout options', function()
       local parsed, err = commands._test.parse_greview_command('++layout=tiled origin/main')
 
@@ -2255,6 +2271,7 @@ describe('commands', function()
 
       assert.are.same({
         '++layout=unified',
+        '++layout=stacked',
         '++layout=split',
       }, matches)
     end)
@@ -2269,6 +2286,7 @@ describe('commands', function()
 
       assert.are.same({
         '++layout=unified',
+        '++layout=stacked',
         '++layout=split',
         'origin/main',
         'feature/topic',
@@ -2304,6 +2322,7 @@ describe('commands', function()
       )
       assert.are.same({
         '++layout=unified',
+        '++layout=stacked',
         '++layout=split',
         '++topic',
       }, commands._test.complete_greview_command('++', 'Greview ++', #'Greview ++'))

--- a/spec/gdiff_spec.lua
+++ b/spec/gdiff_spec.lua
@@ -77,6 +77,14 @@ describe('diffs.gdiff', function()
     assert.are.equal('split', result.layout)
   end)
 
+  it('parses opt-in stacked layout separately from endpoint parsing', function()
+    local result = parse('++layout=stacked HEAD')
+
+    assert.are.same(diffspec.rev_to_worktree('HEAD', path), result.spec)
+    assert.is_false(result.novertical)
+    assert.are.equal('stacked', result.layout)
+  end)
+
   it('allows explicit unified layout', function()
     local result = parse('++layout=unified HEAD')
 


### PR DESCRIPTION
## Problem

Generated diff commands recognized only the existing unified and split layout values, so the stacked generated layout could not be selected from `:Gdiff` or `:Greview`. Command completion also did not advertise `++layout=stacked`, leaving the new layout value unavailable from the command surface.

This closes #361 and is part of #358.

## Solution

The command parsers now accept `++layout=stacked` for both `:Gdiff` and `:Greview`, and completion includes the stacked layout alongside the existing layout choices. This establishes the command-level surface for the stacked generated diff stack without changing generated rendering, default layout behavior, public configuration, or split layout behavior.
