### PR TITLE
feat(rails): add single rail style

### DIFF
--- a/lua/diffs/rails.lua
+++ b/lua/diffs/rails.lua
@@ -5,6 +5,8 @@ local hunk_model = require('diffs.hunks')
 local default_rail_separator = '│'
 local bar_slot = '  '
 
+---@alias diffs.RailStyle "dual"|"single"
+
 ---@param glyph string?
 ---@return string
 local function separator_for(glyph)
@@ -15,12 +17,26 @@ end
 ---@field width integer
 ---@field prefix_width integer
 ---@field separator_width integer
+---@field style diffs.RailStyle
 
 ---@class diffs.RailRanges
 ---@field old_start integer
 ---@field old_end integer
 ---@field new_start integer
 ---@field new_end integer
+
+---@class diffs.RailNumberRange
+---@field start integer
+---@field finish integer
+
+---@param style diffs.RailStyle?
+---@return diffs.RailStyle
+local function normalize_rail_style(style)
+  if style == 'single' then
+    return 'single'
+  end
+  return 'dual'
+end
 
 ---@param value integer?
 ---@param width integer
@@ -51,6 +67,21 @@ local function new_lnum(line)
 end
 
 ---@param line diffs.GdiffHunkLine?
+---@return integer?
+local function single_lnum(line)
+  if not line then
+    return nil
+  end
+  if line.kind == 'delete' then
+    return line.old_lnum
+  end
+  if line.kind == 'context' or line.kind == 'add' then
+    return line.new_lnum
+  end
+  return nil
+end
+
+---@param line diffs.GdiffHunkLine?
 ---@param text string
 ---@return boolean
 local function is_empty_context_line(line, text)
@@ -66,14 +97,24 @@ local function has_number(line, start_col, end_col)
 end
 
 ---@param line string
+---@param ranges diffs.RailNumberRange[]?
+---@return boolean
+local function any_range_has_number(line, ranges)
+  for _, range in ipairs(ranges or {}) do
+    if has_number(line, range.start, range.finish) then
+      return true
+    end
+  end
+  return false
+end
+
+---@param line string
 ---@param prefix_width integer
 ---@param separator_width? integer
 ---@return boolean
-local function has_context_rails(line, prefix_width, separator_width)
-  local ranges = M.ranges(prefix_width, separator_width)
-  return ranges ~= nil
-    and has_number(line, ranges.old_start, ranges.old_end)
-    and has_number(line, ranges.new_start, ranges.new_end)
+local function has_rail_number(line, prefix_width, separator_width)
+  return any_range_has_number(line, M.number_ranges(prefix_width, separator_width, 'dual'))
+    or any_range_has_number(line, M.number_ranges(prefix_width, separator_width, 'single'))
 end
 
 ---@param lines string[]
@@ -93,10 +134,11 @@ local function collect_lines(lines)
 end
 
 ---@param lines string[]
----@param opts? { rail_separator?: string }
+---@param opts? { rail_separator?: string, rail_style?: diffs.RailStyle }
 ---@return string[], diffs.RailInfo?
 function M.annotate(lines, opts)
   opts = opts or {}
+  local rail_style = normalize_rail_style(opts.rail_style)
   local separator = separator_for(opts.rail_separator)
   local compact_separator = separator:gsub('%s+$', '')
 
@@ -106,19 +148,27 @@ function M.annotate(lines, opts)
   end
 
   local width = math.max(1, #tostring(max_lnum))
-  local prefix_width = #bar_slot + width + 1 + width + #separator
+  local prefix_width = rail_style == 'single' and (#bar_slot + width + #separator)
+    or (#bar_slot + width + 1 + width + #separator)
   local annotated = {}
 
   for lnum, text in ipairs(lines) do
     local line = by_lnum[lnum]
     local line_separator = is_empty_context_line(line, text) and compact_separator or separator
     local display_text = is_empty_context_line(line, text) and '' or text
-    annotated[lnum] = bar_slot
-      .. format_lnum(old_lnum(line), width)
-      .. ' '
-      .. format_lnum(new_lnum(line), width)
-      .. line_separator
-      .. display_text
+    if rail_style == 'single' then
+      annotated[lnum] = bar_slot
+        .. format_lnum(single_lnum(line), width)
+        .. line_separator
+        .. display_text
+    else
+      annotated[lnum] = bar_slot
+        .. format_lnum(old_lnum(line), width)
+        .. ' '
+        .. format_lnum(new_lnum(line), width)
+        .. line_separator
+        .. display_text
+    end
   end
 
   return annotated,
@@ -126,6 +176,7 @@ function M.annotate(lines, opts)
       width = width,
       prefix_width = prefix_width,
       separator_width = #separator,
+      style = rail_style,
     }
 end
 
@@ -138,7 +189,7 @@ function M.strip(line, prefix_width, separator_width)
     return line
   end
   local stripped = line:sub(prefix_width + 1)
-  if stripped == '' and has_context_rails(line, prefix_width, separator_width) then
+  if stripped == '' and has_rail_number(line, prefix_width, separator_width) then
     return ' '
   end
   return stripped
@@ -184,6 +235,47 @@ function M.ranges(prefix_width, separator_width)
     old_end = old_end,
     new_start = new_start,
     new_end = new_end,
+  }
+end
+
+---@param prefix_width integer?
+---@param separator_width? integer
+---@param rail_style? diffs.RailStyle
+---@return diffs.RailNumberRange[]?
+function M.number_ranges(prefix_width, separator_width, rail_style)
+  if type(prefix_width) ~= 'number' or prefix_width <= 0 then
+    return nil
+  end
+  separator_width = separator_width or #separator_for()
+
+  if normalize_rail_style(rail_style) == 'single' then
+    local width = prefix_width - #bar_slot - separator_width
+    if width < 1 or width % 1 ~= 0 then
+      return nil
+    end
+
+    return {
+      {
+        start = #bar_slot,
+        finish = #bar_slot + width,
+      },
+    }
+  end
+
+  local ranges = M.ranges(prefix_width, separator_width)
+  if not ranges then
+    return nil
+  end
+
+  return {
+    {
+      start = ranges.old_start,
+      finish = ranges.old_end,
+    },
+    {
+      start = ranges.new_start,
+      finish = ranges.new_end,
+    },
   }
 end
 

--- a/spec/rails_spec.lua
+++ b/spec/rails_spec.lua
@@ -21,6 +21,7 @@ describe('diffs.rails', function()
       width = 2,
       prefix_width = 12,
       separator_width = 5,
+      style = 'dual',
     }, info)
     assert.are.equal('        │ diff --git a/file.txt b/file.txt', annotated[1])
     assert.are.equal('        │ @@ -9,3 +10,4 @@', annotated[4])
@@ -40,6 +41,36 @@ describe('diffs.rails', function()
     assert.is_nil(info)
   end)
 
+  it('adds a single side-aware line-number rail to unified diff lines', function()
+    local annotated, info = rails.annotate({
+      'diff --git a/file.txt b/file.txt',
+      '--- a/file.txt',
+      '+++ b/file.txt',
+      '@@ -9,3 +10,4 @@',
+      ' alpha',
+      '-beta',
+      '+beta changed',
+      ' gamma',
+      '+delta',
+      '\\ No newline at end of file',
+    }, { rail_style = 'single' })
+
+    assert.are.same({
+      width = 2,
+      prefix_width = 9,
+      separator_width = 5,
+      style = 'single',
+    }, info)
+    assert.are.equal('     │ diff --git a/file.txt b/file.txt', annotated[1])
+    assert.are.equal('     │ @@ -9,3 +10,4 @@', annotated[4])
+    assert.are.equal('  10 │  alpha', annotated[5])
+    assert.are.equal('  10 │ -beta', annotated[6])
+    assert.are.equal('  11 │ +beta changed', annotated[7])
+    assert.are.equal('  12 │  gamma', annotated[8])
+    assert.are.equal('  13 │ +delta', annotated[9])
+    assert.are.equal('     │ \\ No newline at end of file', annotated[10])
+  end)
+
   it('does not render trailing spaces for empty context lines', function()
     local annotated, info = rails.annotate({
       'diff --git a/file.txt b/file.txt',
@@ -52,10 +83,28 @@ describe('diffs.rails', function()
       width = 1,
       prefix_width = 10,
       separator_width = 5,
+      style = 'dual',
     }, info)
     assert.are.equal('  2 2 │', annotated[4])
     assert.is_nil(annotated[4]:match('%s$'))
     assert.are.equal(' ', rails.strip(annotated[4], info.prefix_width))
+  end)
+
+  it('strips single rail display lines back to raw unified diff lines', function()
+    local lines = {
+      'diff --git a/file.txt b/file.txt',
+      '@@ -1,3 +1,3 @@',
+      ' first',
+      ' ',
+      '-old',
+      '+new',
+    }
+    local annotated, info = rails.annotate(lines, { rail_style = 'single' })
+
+    assert.are.equal('  2 │', annotated[4])
+    assert.is_nil(annotated[4]:match('%s$'))
+    assert.are.equal(' ', rails.strip(annotated[4], info.prefix_width, info.separator_width))
+    assert.are.same(lines, rails.strip_lines(annotated, info.prefix_width, info.separator_width))
   end)
 
   it('returns byte ranges for old and new rail number columns', function()
@@ -65,6 +114,25 @@ describe('diffs.rails', function()
       new_start = 5,
       new_end = 7,
     }, rails.ranges(12))
+  end)
+
+  it('returns style-aware byte ranges for rail number columns', function()
+    assert.are.same({
+      {
+        start = 2,
+        finish = 4,
+      },
+      {
+        start = 5,
+        finish = 7,
+      },
+    }, rails.number_ranges(12, nil, 'dual'))
+    assert.are.same({
+      {
+        start = 2,
+        finish = 4,
+      },
+    }, rails.number_ranges(9, nil, 'single'))
   end)
 
   it('supports custom rail separators', function()
@@ -79,6 +147,7 @@ describe('diffs.rails', function()
       width = 2,
       prefix_width = 10,
       separator_width = 3,
+      style = 'dual',
     }, info)
     assert.are.equal('        | diff --git a/file.txt b/file.txt', annotated[1])
     assert.are.equal('   9 10 |  alpha', annotated[3])
@@ -89,5 +158,31 @@ describe('diffs.rails', function()
       new_start = 5,
       new_end = 7,
     }, rails.ranges(info.prefix_width, info.separator_width))
+  end)
+
+  it('supports empty custom rail separators for single rails', function()
+    local annotated, info = rails.annotate({
+      'diff --git a/file.txt b/file.txt',
+      '@@ -9,2 +10,2 @@',
+      ' alpha',
+      '+beta',
+    }, { rail_style = 'single', rail_separator = '' })
+
+    assert.are.same({
+      width = 2,
+      prefix_width = 6,
+      separator_width = 2,
+      style = 'single',
+    }, info)
+    assert.are.equal('      diff --git a/file.txt b/file.txt', annotated[1])
+    assert.are.equal('  10   alpha', annotated[3])
+    assert.are.equal('  11  +beta', annotated[4])
+    assert.are.equal(' alpha', rails.strip(annotated[3], info.prefix_width, info.separator_width))
+    assert.are.same({
+      {
+        start = 2,
+        finish = 4,
+      },
+    }, rails.number_ranges(info.prefix_width, info.separator_width, info.style))
   end)
 end)


### PR DESCRIPTION
## Problem

Generated diff buffers only had the existing dual old and new line-number rails. The stacked layout needed an internal single side-aware rail style that could render unified diff text with one file line-number slot while keeping the existing generated view behavior unchanged by default.

This closes #362 and is part of #358.

## Solution

Generated rail annotation now supports an internal single rail style in addition to the default dual rail style. The single rail uses old-side numbers for deleted lines, new-side numbers for added and context lines, and no file line number for headers or metadata, while preserving custom rail separator behavior and raw unified diff recovery.
