### PR TITLE
feat(generated): preserve rail style on reload

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -283,9 +283,15 @@ local function set_diff_rails_var(bufnr, info)
   if info then
     vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_width', info.prefix_width)
     vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_separator_width', info.separator_width)
+    if info.style == 'single' or info.style == 'dual' then
+      vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_style', info.style)
+    else
+      pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_style')
+    end
   else
     pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_width')
     pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_separator_width')
+    pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_style')
   end
 end
 
@@ -336,6 +342,7 @@ end
 ---@field diff_spec? diffs.DiffSpec
 ---@field source? diffs.GeneratedBufferSource
 ---@field vars? table<string, any>
+---@field rail_style? diffs.RailStyle
 
 ---@param opts diffs.GeneratedDiffBufferOpts
 ---@return integer
@@ -343,6 +350,7 @@ local function create_generated_diff_buffer(opts)
   local bufnr = vim.api.nvim_create_buf(false, true)
   local display_lines, rail_info = rails.annotate(opts.lines, {
     rail_separator = runtime.get_view_config().rail_separator,
+    rail_style = opts.rail_style,
   })
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, display_lines)
   vim.api.nvim_buf_set_name(bufnr, opts.name)
@@ -389,9 +397,12 @@ end
 ---@param bufnr integer
 ---@param diff_lines string[]
 ---@param diff_spec? diffs.DiffSpec
-local function replace_generated_diff_buffer_lines(bufnr, diff_lines, diff_spec)
+---@param opts? { rail_style?: diffs.RailStyle }
+local function replace_generated_diff_buffer_lines(bufnr, diff_lines, diff_spec, opts)
+  opts = opts or {}
   local display_lines, rail_info = rails.annotate(diff_lines, {
     rail_separator = runtime.get_view_config().rail_separator,
+    rail_style = opts.rail_style or rails.style_for_buffer(bufnr),
   })
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, display_lines)
@@ -2042,7 +2053,9 @@ M._test = {
   complete_gdiff_split = complete_gdiff_split_command,
   complete_greview = review.complete,
   complete_greview_command = complete_greview_command,
+  create_generated_diff_buffer = create_generated_diff_buffer,
   gdiff_buffer_label = gdiff_buffer_label,
+  replace_generated_diff_buffer_lines = replace_generated_diff_buffer_lines,
   close_greview_workspace = close_greview_workspace,
   greview_workspace_state = function(bufnr)
     return greview_workspaces[bufnr]

--- a/lua/diffs/rails.lua
+++ b/lua/diffs/rails.lua
@@ -299,6 +299,16 @@ function M.separator_width_for_buffer(bufnr)
   return #separator_for()
 end
 
+---@param bufnr integer
+---@return diffs.RailStyle
+function M.style_for_buffer(bufnr)
+  local ok, style = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_rail_style')
+  if ok and style == 'single' then
+    return 'single'
+  end
+  return 'dual'
+end
+
 M._test = {
   format_lnum = format_lnum,
   separator_for = separator_for,

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('spec.helpers')
 
 local commands = require('diffs.commands')
 local diffspec = require('diffs.spec')
+local generated = require('diffs.generated')
 local git = require('diffs.git')
 local rails = require('diffs.rails')
 local runtime = require('diffs.runtime')
@@ -425,6 +426,117 @@ describe('commands', function()
     end)
   end)
 
+  describe('generated rail style metadata', function()
+    local function diff_lines(change)
+      return {
+        'diff --git a/lua/foo.lua b/lua/foo.lua',
+        '--- a/lua/foo.lua',
+        '+++ b/lua/foo.lua',
+        '@@ -1,2 +1,3 @@',
+        ' local M = {}',
+        '+' .. change,
+        ' return M',
+      }
+    end
+
+    local function assert_single_rail_display(bufnr, change)
+      local display_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+      assert.are.equal(6, vim.api.nvim_buf_get_var(bufnr, 'diffs_rail_width'))
+      assert.are.equal(3, vim.api.nvim_buf_get_var(bufnr, 'diffs_rail_separator_width'))
+      assert.are.equal('single', vim.api.nvim_buf_get_var(bufnr, 'diffs_rail_style'))
+      assert.are.equal('single', rails.style_for_buffer(bufnr))
+      assert.are.equal('    | diff --git a/lua/foo.lua b/lua/foo.lua', display_lines[1])
+      assert.is_true(table.concat(display_lines, '\n'):find('  2 | +' .. change, 1, true) ~= nil)
+    end
+
+    it('creates single-rail generated buffers and keeps hunk metadata raw', function()
+      mock_view_config({ prefix = true, change_bar = '▏', rail_separator = '|' })
+
+      local diff_spec = diffspec.index_to_worktree('lua/foo.lua')
+      local bufnr = commands._test.create_generated_diff_buffer({
+        name = 'diffs://unstaged:lua/foo.lua',
+        lines = diff_lines('local x = 1'),
+        repo_root = '/tmp/repo',
+        diff_spec = diff_spec,
+        source = generated.file_source('/tmp/repo', diff_spec),
+        rail_style = 'single',
+      })
+      table.insert(test_buffers, bufnr)
+
+      assert_single_rail_display(bufnr, 'local x = 1')
+
+      local diff_hunks = vim.api.nvim_buf_get_var(bufnr, 'diffs_hunks')
+      assert.are.equal(1, #diff_hunks)
+      assert.are.equal('diff --git a/lua/foo.lua b/lua/foo.lua', diff_hunks[1].file_header_lines[1])
+      assert.are.equal('@@ -1,2 +1,3 @@', diff_hunks[1].header)
+      assert.are.equal('@@ -1,2 +1,3 @@', diff_hunks[1].lines[1].text)
+      assert.are.equal(' local M = {}', diff_hunks[1].lines[2].text)
+      assert.are.equal('+local x = 1', diff_hunks[1].lines[3].text)
+      assert.are.equal(' return M', diff_hunks[1].lines[4].text)
+    end)
+
+    it('preserves single rails when generated buffers reload without an explicit style', function()
+      mock_view_config({ prefix = true, change_bar = '▏', rail_separator = '|' })
+      mock_runtime_attach(function() end)
+      mock_systemlist(function(cmd)
+        assert.are.same({
+          'git',
+          '-C',
+          '/tmp/repo',
+          'diff',
+          '--no-ext-diff',
+          '--no-color',
+        }, cmd)
+        return diff_lines('local reloaded = true')
+      end)
+
+      local bufnr = commands._test.create_generated_diff_buffer({
+        name = 'diffs://unstaged:all',
+        lines = diff_lines('local stale = true'),
+        repo_root = '/tmp/repo',
+        source = generated.section_source('/tmp/repo', 'unstaged'),
+        rail_style = 'single',
+      })
+      table.insert(test_buffers, bufnr)
+
+      commands.read_buffer(bufnr)
+
+      assert_single_rail_display(bufnr, 'local reloaded = true')
+      assert.is_true(buffer_text(bufnr):find('+local reloaded = true', 1, true) ~= nil)
+      assert.is_false(buffer_text(bufnr):find('+local stale = true', 1, true) ~= nil)
+    end)
+
+    it('lets generated buffer replacement override an existing rail style', function()
+      mock_view_config({ prefix = true, change_bar = '▏', rail_separator = '|' })
+
+      local bufnr = commands._test.create_generated_diff_buffer({
+        name = 'diffs://unstaged:all',
+        lines = diff_lines('local single = true'),
+        repo_root = '/tmp/repo',
+        rail_style = 'single',
+      })
+      table.insert(test_buffers, bufnr)
+
+      commands._test.replace_generated_diff_buffer_lines(
+        bufnr,
+        diff_lines('local dual = true'),
+        nil,
+        { rail_style = 'dual' }
+      )
+
+      local display_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      assert.are.equal(8, vim.api.nvim_buf_get_var(bufnr, 'diffs_rail_width'))
+      assert.are.equal(3, vim.api.nvim_buf_get_var(bufnr, 'diffs_rail_separator_width'))
+      assert.are.equal('dual', vim.api.nvim_buf_get_var(bufnr, 'diffs_rail_style'))
+      assert.are.equal('dual', rails.style_for_buffer(bufnr))
+      assert.are.equal('      | diff --git a/lua/foo.lua b/lua/foo.lua', display_lines[1])
+      assert.is_true(
+        table.concat(display_lines, '\n'):find('    2 | +local dual = true', 1, true) ~= nil
+      )
+    end)
+  end)
+
   describe('command completion', function()
     it('completes Gdiff layout options and Fugitive-style objects', function()
       mock_repo_root(function()
@@ -703,6 +815,7 @@ describe('commands', function()
       local display_lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
       assert.are.equal(8, vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_width'))
       assert.are.equal(3, vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_separator_width'))
+      assert.are.equal('dual', vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_style'))
       assert.are.equal('      | diff --git a/lua/foo.lua b/lua/foo.lua', display_lines[1])
       assert.is_true(table.concat(display_lines, '\n'):find('    2 | +local x = 1', 1, true) ~= nil)
 

--- a/spec/rails_spec.lua
+++ b/spec/rails_spec.lua
@@ -1,4 +1,4 @@
-require('spec.helpers')
+local helpers = require('spec.helpers')
 
 local rails = require('diffs.rails')
 
@@ -184,5 +184,25 @@ describe('diffs.rails', function()
         finish = 4,
       },
     }, rails.number_ranges(info.prefix_width, info.separator_width, info.style))
+  end)
+
+  it('reads buffer rail style with a dual compatibility default', function()
+    local bufnr = helpers.create_buffer({})
+
+    assert.are.equal('dual', rails.style_for_buffer(bufnr))
+
+    vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_style', 'single')
+    assert.are.equal('single', rails.style_for_buffer(bufnr))
+
+    vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_style', 'dual')
+    assert.are.equal('dual', rails.style_for_buffer(bufnr))
+
+    vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_style', 'stacked')
+    assert.are.equal('dual', rails.style_for_buffer(bufnr))
+
+    pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_style')
+    assert.are.equal('dual', rails.style_for_buffer(bufnr))
+
+    helpers.delete_buffer(bufnr)
   end)
 end)


### PR DESCRIPTION
## Problem

Generated buffers can render either dual or single rails, but the chosen rail style needed to survive buffer replacement and `:edit` reloads. Without persisted rail-style metadata, stacked generated buffers could fall back to the default dual rails during refresh paths.

This closes #363 and is part of #358.

## Solution

Generated buffers now store their rail style alongside the existing rail width metadata, and generated line replacement reads that style when no explicit override is provided. Reloaded generated buffers preserve stacked single rails while keeping raw hunk metadata independent from display rail prefixes.
