### PR TITLE
feat(commands): wire stacked generated layout

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -455,13 +455,19 @@ local function replace_combined_diffs(raw_lines, repo_root)
   return result
 end
 
+---@class diffs.ReviewDepsOpts
+---@field rail_style? diffs.RailStyle
+
+---@param opts? diffs.ReviewDepsOpts
 ---@return diffs.ReviewDeps
-local function review_deps()
+local function review_deps(opts)
+  opts = opts or {}
   return {
     create_generated_diff_buffer = create_generated_diff_buffer,
     show_generated_diff_buffer = show_generated_diff_buffer,
     attach_generated_diff_buffer = attach_generated_diff_buffer,
     replace_combined_diffs = replace_combined_diffs,
+    rail_style = opts.rail_style,
   }
 end
 
@@ -558,9 +564,10 @@ local function file_pair_label(diff_label, rel_path, old_rel_path)
 end
 
 ---@param spec? diffs.GreviewSpec
+---@param opts? diffs.ReviewDepsOpts
 ---@return integer?
-function M.greview(spec)
-  return review.greview(spec, review_deps())
+function M.greview(spec, opts)
+  return review.greview(spec, review_deps(opts))
 end
 
 ---@param buf integer
@@ -575,6 +582,15 @@ local layout_options = {
   '++layout=stacked',
   '++layout=split',
 }
+
+---@param layout? "unified"|"stacked"|"split"
+---@return diffs.RailStyle
+local function rail_style_for_layout(layout)
+  if layout == 'stacked' then
+    return 'single'
+  end
+  return 'dual'
+end
 
 local gdiff_objects = {
   ':',
@@ -739,7 +755,9 @@ function M.greview_command(args)
     return open_greview_workspace(parsed.spec)
   end
 
-  local bufnr = M.greview(parsed.spec)
+  local bufnr = M.greview(parsed.spec, {
+    rail_style = rail_style_for_layout(parsed.layout),
+  })
   return bufnr
 end
 
@@ -1596,6 +1614,7 @@ function M.gdiff(args, vertical)
     vertical = false
   end
 
+  local rail_style = rail_style_for_layout(parsed.layout)
   local diff_spec = parsed.spec
   local diff_label = gdiff_buffer_label(diff_spec)
   local diff_path = diff_spec.scope.path
@@ -1619,6 +1638,7 @@ function M.gdiff(args, vertical)
     M.gdiff_file(filepath, {
       vertical = vertical,
       unmerged = true,
+      rail_style = rail_style,
     })
     return
   end
@@ -1658,6 +1678,7 @@ function M.gdiff(args, vertical)
     repo_root = repo_root,
     diff_spec = diff_spec,
     source = generated.file_source(repo_root, diff_spec),
+    rail_style = rail_style,
   })
   show_generated_diff_buffer(diff_buf, vertical)
   lists.set_for_unified_buffer(diff_buf, diff_lines, {
@@ -1674,6 +1695,7 @@ end
 ---@field unmerged? boolean
 ---@field old_filepath? string
 ---@field hunk_position? { hunk_header: string, offset: integer }
+---@field rail_style? diffs.RailStyle
 
 ---@param filepath string
 ---@param opts? diffs.GdiffFileOpts
@@ -1775,6 +1797,7 @@ function M.gdiff_file(filepath, opts)
     repo_root = repo_root,
     diff_spec = diff_spec,
     source = source,
+    rail_style = opts.rail_style,
     vars = {
       diffs_old_filepath = old_rel_path ~= rel_path and old_rel_path or nil,
     },

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -35,6 +35,7 @@ local notify = log.notify
 ---@field show_generated_diff_buffer fun(bufnr: integer, vertical?: boolean)
 ---@field attach_generated_diff_buffer fun(bufnr: integer)
 ---@field replace_combined_diffs fun(lines: string[], repo_root: string): string[]
+---@field rail_style? diffs.RailStyle
 
 ---@param bufnr integer
 ---@param name string
@@ -769,6 +770,7 @@ function M.greview(spec, deps)
       target = review.target,
       mode = review.mode,
     }),
+    rail_style = deps.rail_style,
     vars = {
       diffs_review_base = review.base,
       diffs_review_target = review.target,

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -832,6 +832,36 @@ describe('commands', function()
       assert.is_true(loc[1].text:find('lua/foo.lua', 1, true) ~= nil)
     end)
 
+    it('opens stacked :Gdiff as a generated buffer with single rails', function()
+      mock_runtime_attach(function() end)
+      mock_view_config({ prefix = true, change_bar = '▏', rail_separator = '|' })
+      create_split_source()
+
+      commands.gdiff('++layout=stacked', false)
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+      local display_lines = vim.api.nvim_buf_get_lines(diff_buf, 0, -1, false)
+
+      assert.are.equal('diffs://unstaged:lua/foo.lua', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.same(
+        diffspec.index_to_worktree('lua/foo.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      assert.are.equal(6, vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_width'))
+      assert.are.equal(3, vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_separator_width'))
+      assert.are.equal('single', vim.api.nvim_buf_get_var(diff_buf, 'diffs_rail_style'))
+      assert.are.equal('single', rails.style_for_buffer(diff_buf))
+      assert.are.equal('    | diff --git a/lua/foo.lua b/lua/foo.lua', display_lines[1])
+      assert.is_true(table.concat(display_lines, '\n'):find('  2 | +local x = 1', 1, true) ~= nil)
+      assert.is_false(has_buf_var(diff_buf, 'diffs_split_peer'))
+
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local name = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(win))
+        assert.is_false(name:match('^diffs://split:') ~= nil)
+      end
+    end)
+
     it('opens default :Gdiff for untracked files as index to worktree additions', function()
       local source_buf = vim.api.nvim_create_buf(false, true)
       table.insert(test_buffers, source_buf)
@@ -1613,7 +1643,7 @@ describe('commands', function()
       local diff_buf = vim.api.nvim_get_current_buf()
       table.insert(test_buffers, diff_buf)
 
-      local function assert_unmerged_view(bufnr)
+      local function assert_unmerged_view(bufnr, expected_rail_style)
         local lines = buffer_lines(bufnr)
         local text = table.concat(lines, '\n')
 
@@ -1638,6 +1668,9 @@ describe('commands', function()
         assert.is_true(text:find('<<<<<<<', 1, true) == nil)
         assert.is_true(helpers.has_keymap(bufnr, 'go'))
         assert.is_true(helpers.has_keymap(bufnr, 'gt'))
+        if expected_rail_style then
+          assert.are.equal(expected_rail_style, vim.api.nvim_buf_get_var(bufnr, 'diffs_rail_style'))
+        end
       end
 
       assert_unmerged_view(diff_buf)
@@ -1650,6 +1683,22 @@ describe('commands', function()
 
       assert_unmerged_view(diff_buf)
       helpers.delete_buffer(diff_buf)
+
+      vim.api.nvim_set_current_win(source_win)
+      commands.gdiff('++layout=stacked', false)
+
+      local stacked_unmerged_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, stacked_unmerged_buf)
+      assert_unmerged_view(stacked_unmerged_buf, 'single')
+
+      vim.api.nvim_set_option_value('modifiable', true, { buf = stacked_unmerged_buf })
+      vim.api.nvim_buf_set_lines(stacked_unmerged_buf, 0, -1, false, { 'stale unmerged content' })
+      vim.api.nvim_set_option_value('modifiable', false, { buf = stacked_unmerged_buf })
+
+      commands.read_buffer(stacked_unmerged_buf)
+
+      assert_unmerged_view(stacked_unmerged_buf, 'single')
+      helpers.delete_buffer(stacked_unmerged_buf)
 
       for _, object in ipairs({ ':%', ':0:%' }) do
         vim.api.nvim_set_current_win(source_win)
@@ -2698,6 +2747,44 @@ describe('commands', function()
       assert.are.equal('branch:lua/dup.lua', qf[2].user_data.diffs.key)
       assert.are.equal('staged:lua/dup.lua', qf[3].user_data.diffs.key)
       assert.are.equal('unstaged:lua/dup.lua', qf[5].user_data.diffs.key)
+    end)
+
+    it('opens Greview stacked layout as a single generated review map with single rails', function()
+      local repo = create_current_state_review_repo()
+      edit_file(repo.repo_root .. '/lua/branch.lua')
+      mock_runtime_attach(function() end)
+      mock_view_config({ prefix = true, change_bar = '▏', rail_separator = '|' })
+
+      local bufnr = commands.greview_command(('++layout=stacked %s'):format(repo.base))
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+
+      local display_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      local text = buffer_text(bufnr)
+
+      assert.are.equal('diffs://review:' .. repo.base, vim.api.nvim_buf_get_name(bufnr))
+      assert.are.equal('single', vim.api.nvim_buf_get_var(bufnr, 'diffs_rail_style'))
+      assert.are.equal('single', rails.style_for_buffer(bufnr))
+      assert.is_true(display_lines[1]:find('    | # Branch:', 1, true) ~= nil)
+      assert.is_true(text:find('# Branch:', 1, true) ~= nil)
+      assert.is_true(text:find('# Staged:', 1, true) ~= nil)
+      assert.is_true(text:find('# Unstaged:', 1, true) ~= nil)
+      assert.is_true(text:find('# Untracked:', 1, true) ~= nil)
+      assert.is_true(text:find('+branch head', 1, true) ~= nil)
+      assert.is_nil(commands._test.greview_workspace_state(bufnr))
+
+      local qf = quickfix_items()
+      assert.are.equal(7, #qf)
+      assert.are.equal(bufnr, qf[1].bufnr)
+      assert.are.equal('branch:lua/branch.lua', qf[1].user_data.diffs.key)
+      assert.are.equal('staged:lua/dup.lua', qf[3].user_data.diffs.key)
+      assert.are.equal('unstaged:lua/dup.lua', qf[5].user_data.diffs.key)
+
+      for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local name = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(win))
+        assert.is_false(name:match('^diffs://review%-split:') ~= nil)
+        assert.is_false(name:match('^diffs://review%-target:') ~= nil)
+      end
     end)
 
     local function main_windows()


### PR DESCRIPTION
## Problem

The stacked layout value was accepted by the command parsers, and generated buffers could render single rails internally, but command execution still treated stacked like the default generated layout. Users could not yet open `:Gdiff ++layout=stacked` or `:Greview ++layout=stacked` as generated single-column views with single side-aware rails.

This closes #364 and is part of #358.

## Solution

Generated command layouts now map to the appropriate rail style, with unified using dual rails and stacked using single rails. The mapped rail style is threaded through generated `:Gdiff`, `:Greview`, and special generated paths such as unmerged diffs, while split continues to use the existing paired endpoint-window behavior.
