### PR TITLE
docs: document Git mergetool setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ fzf-lua is supported out-of-the-box.
 
 See the documentation for more information.
 
+**Q: Can I use diffs.nvim as a Git mergetool?**
+
+Yes. Configure Git to open `$MERGED` with Neovim; diffs.nvim will detect
+conflict markers automatically. See `:help diffs.nvim-git-mergetool`.
+
 ## Known Limitations
 
 - **Incomplete syntax context**: Treesitter parses each diff hunk in isolation.

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -996,6 +996,25 @@ The working file buffer is modified in place; save it when ready. Inline
 conflict highlights (see |diffs.nvim-conflict|) are refreshed automatically
 after each resolution.
 
+Git mergetool:                                      *diffs.nvim-git-mergetool*
+
+diffs.nvim can be used with `git mergetool` by configuring Git to open the
+merged working file in Neovim:
+>gitconfig
+    [merge]
+        tool = diffs-nvim
+
+    [mergetool "diffs-nvim"]
+        cmd = nvim "$MERGED"
+<
+
+When the file opens, diffs.nvim detects conflict markers automatically.
+Configure `conflict.keymaps` to enable buffer-local resolution mappings; see
+|diffs.nvim-conflict|. From a Git-unmerged file, |:Gdiff| can also open the
+generated ours-vs-theirs merge diff view documented above.
+
+Save and quit after resolving conflicts. Use `:cq` to abort.
+
 ==============================================================================
 API                                                           *diffs.nvim-api*
 


### PR DESCRIPTION
## Problem

Users can already open conflicted files in Neovim and have diffs.nvim detect conflict markers, but the docs did not explain the simple `git mergetool` setup or why `trustExitCode` should stay unset for plain `nvim "$MERGED"`.

## Solution

- Add a vimdoc subsection for using diffs.nvim with Git mergetool.
- Point README readers to `:help diffs.nvim-git-mergetool`.
- Document the simple `$MERGED` command and clarify that plain Neovim exit codes do not prove conflicts are resolved.

closes #373