### PR TITLE
fix(highlight): support single rail consumers

### DIFF
--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -6,6 +6,23 @@ local rails = require('diffs.rails')
 
 local default_change_bar = '▏'
 
+---@param start_col integer
+---@param end_col integer
+---@param raw_len integer?
+---@return integer?, integer?
+local function clamp_cols(start_col, end_col, raw_len)
+  if raw_len then
+    if start_col >= raw_len then
+      return nil, nil
+    end
+    end_col = math.min(end_col, raw_len)
+  end
+  if end_col <= start_col then
+    return nil, nil
+  end
+  return start_col, end_col
+end
+
 local vim_syntax_cache = {}
 local vim_syntax_cache_size = 0
 local vim_syntax_cache_clock = 0
@@ -826,38 +843,41 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
             priority = p.syntax,
           })
 
-          local ranges = rails.ranges(hunk.rail_width, hunk.rail_separator_width)
-          if ranges then
-            pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, ranges.old_start, {
-              end_col = ranges.old_end,
-              hl_group = 'DiffsRailNr',
-              priority = p.syntax + 1,
-            })
-            pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, ranges.new_start, {
-              end_col = ranges.new_end,
-              hl_group = 'DiffsRailNr',
-              priority = p.syntax + 1,
-            })
+          local rail_style = hunk.rail_style or 'dual'
+          local rail_number_ranges =
+            rails.number_ranges(hunk.rail_width, hunk.rail_separator_width, rail_style)
+          if rail_number_ranges then
+            for _, range in ipairs(rail_number_ranges) do
+              local nr_start, nr_end = clamp_cols(range.start, range.finish, raw_len)
+              if nr_start and nr_end then
+                pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, nr_start, {
+                  end_col = nr_end,
+                  hl_group = 'DiffsRailNr',
+                  priority = p.syntax + 1,
+                })
+              end
+            end
           end
           local rail_nr_start, rail_nr_end, rail_nr_hl
-          if ranges and has_del then
-            rail_nr_start = ranges.old_start
-            rail_nr_end = ranges.new_end
-            rail_nr_hl = 'DiffsDeleteRailNr'
-          elseif ranges and has_add then
-            rail_nr_start = ranges.old_start
-            rail_nr_end = ranges.new_end
-            rail_nr_hl = 'DiffsAddRailNr'
+          if (has_del or has_add) and rail_number_ranges then
+            local first_range = rail_number_ranges[1]
+            local last_range = rail_style == 'single' and first_range
+              or rail_number_ranges[#rail_number_ranges]
+            if first_range and last_range then
+              rail_nr_start = first_range.start
+              rail_nr_end = last_range.finish
+              rail_nr_hl = has_del and 'DiffsDeleteRailNr' or 'DiffsAddRailNr'
+            end
           end
           if rail_nr_start and rail_nr_end and rail_nr_hl then
-            if raw_len and rail_nr_end > raw_len then
-              rail_nr_end = raw_len
+            rail_nr_start, rail_nr_end = clamp_cols(rail_nr_start, rail_nr_end, raw_len)
+            if rail_nr_start and rail_nr_end then
+              pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, rail_nr_start, {
+                end_col = rail_nr_end,
+                hl_group = rail_nr_hl,
+                priority = p.syntax + 2,
+              })
             end
-            pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, rail_nr_start, {
-              end_col = rail_nr_end,
-              hl_group = rail_nr_hl,
-              priority = p.syntax + 2,
-            })
           end
         end
         for ci = 0, pw - 1 do

--- a/lua/diffs/parser.lua
+++ b/lua/diffs/parser.lua
@@ -16,6 +16,7 @@
 ---@field quote_width integer
 ---@field rail_width integer?
 ---@field rail_separator_width integer?
+---@field rail_style diffs.RailStyle?
 ---@field repo_root string?
 ---@field context_before string[]?
 ---@field context_after string[]?
@@ -156,6 +157,7 @@ function M.parse_buffer(bufnr)
   local repo_root = get_repo_root(bufnr)
   local rail_width = rails.width_for_buffer(bufnr)
   local rail_separator_width = rails.separator_width_for_buffer(bufnr)
+  local rail_style = rail_width > 0 and rails.style_for_buffer(bufnr) or nil
 
   local quote_prefix = nil
   local quote_width = 0
@@ -227,6 +229,7 @@ function M.parse_buffer(bufnr)
         repo_root = repo_root,
         rail_width = rail_width > 0 and rail_width or nil,
         rail_separator_width = rail_width > 0 and rail_separator_width or nil,
+        rail_style = rail_style,
       }
       if hunk_count == 1 and header_start and #header_lines > 0 then
         hunk.header_start_line = header_start

--- a/spec/highlight_spec.lua
+++ b/spec/highlight_spec.lua
@@ -1,6 +1,7 @@
 require('spec.helpers')
 local config = require('diffs.config')
 local highlight = require('diffs.highlight')
+local rails = require('diffs.rails')
 
 describe('highlight', function()
   describe('hunk_opts', function()
@@ -827,6 +828,128 @@ describe('highlight', function()
         { row = 1, col = 2, end_col = 5, group = 'DiffsDeleteRailNr' },
         { row = 2, col = 2, end_col = 5, group = 'DiffsAddRailNr' },
       }, rail_numbers)
+      delete_buffer(bufnr)
+    end)
+
+    it('highlights single generated rail numbers for context and changed lines', function()
+      local annotated, info = rails.annotate({
+        '@@ -1,2 +1,2 @@',
+        ' local M = {}',
+        '-local old = false',
+        '+local new = true',
+      }, { rail_style = 'single' })
+      local bufnr = create_buffer(annotated)
+
+      local hunk = {
+        filename = 'test.lua',
+        lang = 'lua',
+        start_line = 1,
+        lines = {
+          ' local M = {}',
+          '-local old = false',
+          '+local new = true',
+        },
+        prefix_width = 1,
+        quote_width = info.prefix_width,
+        rail_width = info.prefix_width,
+        rail_separator_width = info.separator_width,
+        rail_style = info.style,
+      }
+
+      highlight.highlight_hunk(
+        bufnr,
+        ns,
+        hunk,
+        default_opts({
+          highlights = {
+            treesitter = { enabled = false },
+          },
+        })
+      )
+
+      local rail_marks = {}
+      local base_numbers = {}
+      local changed_numbers = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        local d = mark[4]
+        if d and d.hl_group == 'DiffsRail' then
+          rail_marks[#rail_marks + 1] = { row = mark[2], col = mark[3], end_col = d.end_col }
+        end
+        if d and d.hl_group == 'DiffsRailNr' then
+          base_numbers[#base_numbers + 1] = { row = mark[2], col = mark[3], end_col = d.end_col }
+        end
+        if d and (d.hl_group == 'DiffsAddRailNr' or d.hl_group == 'DiffsDeleteRailNr') then
+          changed_numbers[#changed_numbers + 1] =
+            { row = mark[2], col = mark[3], end_col = d.end_col, group = d.hl_group }
+        end
+      end
+
+      assert.are.same({
+        { row = 1, col = 0, end_col = info.prefix_width },
+        { row = 2, col = 0, end_col = info.prefix_width },
+        { row = 3, col = 0, end_col = info.prefix_width },
+      }, rail_marks)
+      assert.are.same({
+        { row = 1, col = 2, end_col = 3 },
+        { row = 2, col = 2, end_col = 3 },
+        { row = 3, col = 2, end_col = 3 },
+      }, base_numbers)
+      assert.are.same({
+        { row = 2, col = 2, end_col = 3, group = 'DiffsDeleteRailNr' },
+        { row = 3, col = 2, end_col = 3, group = 'DiffsAddRailNr' },
+      }, changed_numbers)
+      delete_buffer(bufnr)
+    end)
+
+    it('keeps hide_prefix overlay off single generated line-number rails', function()
+      local annotated, info = rails.annotate({
+        '@@ -1,1 +1,1 @@',
+        '-old',
+        '+new',
+      }, { rail_style = 'single' })
+      local bufnr = create_buffer(annotated)
+
+      local hunk = {
+        filename = 'test.lua',
+        lang = 'lua',
+        start_line = 1,
+        lines = { '-old', '+new' },
+        prefix_width = 1,
+        quote_width = info.prefix_width,
+        rail_width = info.prefix_width,
+        rail_separator_width = info.separator_width,
+        rail_style = info.style,
+      }
+
+      highlight.highlight_hunk(
+        bufnr,
+        ns,
+        hunk,
+        default_opts({
+          hide_prefix = true,
+          highlights = {
+            background = true,
+            treesitter = { enabled = false },
+          },
+        })
+      )
+
+      local overlays = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        local d = mark[4]
+        if d and d.virt_text and d.virt_text[1] then
+          local text, group = d.virt_text[1][1], d.virt_text[1][2]
+          if group == 'DiffsAdd' or group == 'DiffsDelete' then
+            overlays[#overlays + 1] = { row = mark[2], col = mark[3], text = text, group = group }
+            assert.is_true(mark[3] >= info.prefix_width)
+          end
+        end
+      end
+
+      assert.are.same({
+        { row = 1, col = info.prefix_width, text = ' ', group = 'DiffsDelete' },
+        { row = 2, col = info.prefix_width, text = ' ', group = 'DiffsAdd' },
+      }, overlays)
       delete_buffer(bufnr)
     end)
 

--- a/spec/merge_spec.lua
+++ b/spec/merge_spec.lua
@@ -402,6 +402,46 @@ describe('merge', function()
       cleanup()
     end)
 
+    it('matches and resolves conflicts from generated single-rail hunks', function()
+      local working_path = '/tmp/diffs_test_single_rail_resolve.lua'
+      local w_bufnr = create_working_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      }, working_path)
+
+      local annotated, info = rails.annotate({
+        'diff --git a/file.lua b/file.lua',
+        '--- a/file.lua',
+        '+++ b/file.lua',
+        '@@ -1,1 +1,1 @@',
+        '-local x = 1',
+        '+local x = 2',
+      }, { rail_style = 'single' })
+      local d_bufnr = create_diff_buffer(annotated, working_path)
+      vim.api.nvim_buf_set_var(d_bufnr, 'diffs_rail_width', info.prefix_width)
+      vim.api.nvim_buf_set_var(d_bufnr, 'diffs_rail_separator_width', info.separator_width)
+      vim.api.nvim_buf_set_var(d_bufnr, 'diffs_rail_style', info.style)
+      vim.api.nvim_set_current_buf(d_bufnr)
+
+      local hunks = merge.parse_hunks(d_bufnr)
+      assert.are.equal(1, #hunks)
+      assert.are.same({ 'local x = 1' }, hunks[1].del_lines)
+      assert.are.same({ 'local x = 2' }, hunks[1].add_lines)
+      assert.is_not_nil(merge.match_hunk_to_conflict(hunks[1], w_bufnr))
+
+      vim.api.nvim_win_set_cursor(0, { 5, 0 })
+      merge.resolve_theirs(d_bufnr, default_config())
+
+      local lines = vim.api.nvim_buf_get_lines(w_bufnr, 0, -1, false)
+      assert.are.same({ 'local x = 2' }, lines)
+
+      helpers.delete_buffer(d_bufnr)
+      helpers.delete_buffer(w_bufnr)
+    end)
+
     it('notifies when hunk is already resolved', function()
       setup_buffers()
       vim.api.nvim_win_set_cursor(0, { 5, 0 })

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -84,6 +84,35 @@ describe('parser', function()
       delete_buffer(bufnr)
     end)
 
+    it('records single generated rail style and keeps parsed hunk lines rail-free', function()
+      local annotated, info = rails.annotate({
+        'diff --git a/lua/test.lua b/lua/test.lua',
+        '--- a/lua/test.lua',
+        '+++ b/lua/test.lua',
+        '@@ -1,2 +1,3 @@',
+        ' local M = {}',
+        '-local old = false',
+        '+local new = true',
+      }, { rail_style = 'single' })
+      local bufnr = create_buffer(annotated)
+      vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_width', info.prefix_width)
+      vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_separator_width', info.separator_width)
+      vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_style', info.style)
+
+      local hunks = parser.parse_buffer(bufnr)
+
+      assert.are.equal(1, #hunks)
+      assert.are.equal('single', hunks[1].rail_style)
+      assert.are.equal(info.prefix_width, hunks[1].rail_width)
+      assert.are.equal(info.separator_width, hunks[1].rail_separator_width)
+      assert.are.same({
+        ' local M = {}',
+        '-local old = false',
+        '+local new = true',
+      }, hunks[1].lines)
+      delete_buffer(bufnr)
+    end)
+
     it('detects multiple hunks in same file', function()
       local bufnr = create_buffer({
         'M lua/test.lua',


### PR DESCRIPTION
## Problem

Stacked generated buffers render and persist single rails, but downstream consumers still treated generated rail numbers as dual old and new columns. Parsed hunk metadata, rail-number highlighting, prefix concealment, and merge or conflict helpers needed to account for both generated rail styles.

This closes #365 and is part of #358.

## Solution

Parsed generated hunks now carry the buffer rail style when rail metadata is present. Highlighting uses style-aware rail number ranges, prefix concealment respects the single number slot, and merge or conflict handling continues to strip generated rails by width so raw hunk content stays independent from the display style.
