### PR TITLE
docs: document stacked layout

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -172,9 +172,9 @@ Pre-v0.4.0 migration window: ~
                              `DiffsDeleteBar`.
 
         {rail_separator}     (string, default: '│')
-                             Glyph between generated old/new line-number
-                             rails and diff text. Surrounding padding is
-                             managed internally.
+                             Glyph between the generated line-number area and
+                             diff text. Surrounding padding is managed
+                             internally.
 
         {integrations}       (table, default: all false)
                              Integration toggles. Each key accepts `true` or
@@ -382,14 +382,17 @@ diffs.nvim-owned `diffs://` views. Ordinary `git`, `gitcommit`, `diff`,
 `extra_filetypes`, picker previews, and third-party integration buffers remain
 highlight-only.
 
-:Gdiff [++layout=unified|split] [object]                              *:Gdiff*
-    Open a unified diff of the current file against a Fugitive-style object.
+:Gdiff [++layout=unified|stacked|split] [object]                      *:Gdiff*
+    Open a diff of the current file against a Fugitive-style object.
     The default unified layout opens below the current window and reuses an
     existing `diffs://` window in the tabpage when one exists.
 
-    `diffs://` unified buffers include old and new line-number columns before
-    the unified diff text. The default unified layout does not enter native Vim
-    `&diff` mode or open writable Fugitive object buffers.
+    `++layout=unified` and `++layout=stacked` create generated `diffs://`
+    buffers. Unified buffers include old and new line-number rails before the
+    unified diff text. Stacked buffers use the same generated diff text with a
+    single context-aware line-number rail; see |diffs.nvim-stacked-layout|.
+    Generated layouts do not enter native Vim `&diff` mode or open writable
+    Fugitive object buffers.
 
     `++layout=split` opens paired old/new endpoint windows with native `&diff`
     alignment. See |diffs.nvim-paired-windows|.
@@ -401,7 +404,10 @@ highlight-only.
     form such as `:Gdiff :0:%`. |:Gdiff| does not provide a `--staged` flag.
 
     Parameters: ~
-        ++layout=unified (optional) Open the default unified `diffs://` view.
+        ++layout=unified (optional) Open the default generated `diffs://` view
+                    with old and new line-number rails.
+        ++layout=stacked (optional) Open a generated `diffs://` view with one
+                    context-aware line-number rail.
         ++layout=split (optional) Open the current single-file comparison as
                     paired old/new endpoint windows.
         ++novertical (optional) Force a horizontal split. Useful with |:Gvdiff|
@@ -417,6 +423,7 @@ highlight-only.
         :Gdiff HEAD~3   " diff against 3 commits ago
         :Gdiff :0:%     " diff against the index explicitly
         :Gdiff abc123   " diff against specific commit
+        :Gdiff ++layout=stacked
 <
     Edge cases: ~
     - Untracked and added files render as all-added files.
@@ -433,6 +440,28 @@ highlight-only.
     Stale hunks, context drift, and index mismatches fail without partial
     mutation. `dp` appears only for supported index -> worktree hunks/ranges;
     `do` appears only for supported tree -> index hunks/ranges.
+
+Stacked generated layout: ~                        *diffs.nvim-stacked-layout*
+
+    `++layout=stacked` creates a generated single-column `diffs://` layout. It
+    keeps normal unified diff text, but replaces the two old/new line-number
+    rails used by the unified generated layout with one context-aware rail.
+
+    In the stacked rail:
+    - `-` lines display old-side line numbers.
+    - `+` lines display new-side line numbers.
+    - Context lines display new-side line numbers.
+    - Headers and metadata do not display file line numbers.
+
+    Replacements can therefore repeat a number: a deleted old-side line and the
+    added new-side line that replaces it may both show the same value.
+>diff
+     | @@ -9,3 +9,3 @@
+   9 |  alpha
+  10 | -beta
+  10 | +beta changed
+  11 |  gamma
+<
 
 Paired-window behavior: ~                          *diffs.nvim-paired-windows*
 
@@ -452,7 +481,7 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
 :Ghdiff [object]                                                     *:Ghdiff*
     Like |:Gdiff| but explicitly opens in a horizontal split.
 
-:Greview [++layout=unified|split] [review-spec]                     *:Greview*
+:Greview [++layout=unified|stacked|split] [review-spec]             *:Greview*
     Open a repository review.
 
     With no arguments, reviews the current repository state against the
@@ -465,11 +494,15 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     using merge-base semantics. With `A..B`, reviews explicit target `B`
     against base `A` as a direct two-endpoint comparison.
 
-    Without `++layout=split`, populates the quickfix list with file entries
-    (one per changed file, with `+N`/`-M` stats) and the location list with hunk
-    entries (one per `@@` header, with filename and hunk number). All entries
-    point into the diff buffer, so `:cnext`/`:cprev` navigate between files and
-    `:lnext`/`:lprev` navigate between hunks within the buffer.
+    `++layout=unified` and `++layout=stacked` both create full generated review
+    maps. Unified review maps use old and new line-number rails; stacked review
+    maps use one context-aware line-number rail as described at
+    |diffs.nvim-stacked-layout|. These layouts populate the quickfix list with
+    file entries (one per changed file, with `+N`/`-M` stats) and the location
+    list with hunk entries (one per `@@` header, with filename and hunk number).
+    All entries point into the diff buffer, so `:cnext`/`:cprev` navigate
+    between files and `:lnext`/`:lprev` navigate between hunks within the
+    buffer.
 
     Reloading with `:edit` refreshes the same review. If a `diffs://` window
     already exists in the current tabpage, the new diff replaces its buffer
@@ -488,7 +521,10 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     |:Greview| split workspaces.
 
     Parameters: ~
-        ++layout=unified (optional) Open the default unified review buffer.
+        ++layout=unified (optional) Open the default generated review map with
+                       old and new line-number rails.
+        ++layout=stacked (optional) Open a generated review map with one
+                       context-aware line-number rail.
         ++layout=split (optional) Open the two-surface split workspace for the
                        first renderable changed review file.
         {review-spec}  (string, optional) One of:
@@ -504,6 +540,7 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
 
     Examples: >vim
         :Greview
+        :Greview ++layout=stacked origin/main
         :Greview ++layout=split
         :Greview origin/main
         :Greview ++layout=split origin/main
@@ -1094,7 +1131,7 @@ can override them before diffs.nvim loads, or users can override them with
 `highlights.overrides`.
 
 
-Fugitive unified diff highlights: ~
+Diff and generated rail highlights: ~
                                                                   *DiffsClear*
     DiffsClear          Clears underlying diff foreground colors while preserving
                         the normal foreground.
@@ -1106,18 +1143,16 @@ Fugitive unified diff highlights: ~
     DiffsDelete         Background for `-` lines.
 
                                                                    *DiffsRail*
-    DiffsRail           Generated old/new line-number rail and separator.
+    DiffsRail           Generated line-number rails and separators.
 
                                                                  *DiffsRailNr*
-    DiffsRailNr         Generated old/new line numbers on context lines.
+    DiffsRailNr         Context line numbers in generated rails.
 
                                                               *DiffsAddRailNr*
-    DiffsAddRailNr      Generated number rail on `+` lines, including the
-                        missing old-side number slot.
+    DiffsAddRailNr      Add line-number rails on generated `+` lines.
 
                                                            *DiffsDeleteRailNr*
-    DiffsDeleteRailNr   Generated number rail on `-` lines, including the
-                        missing new-side number slot.
+    DiffsDeleteRailNr   Delete line-number rails on generated `-` lines.
 
                                                                  *DiffsAddBar*
     DiffsAddBar         Change bar for `+` lines in diffs.nvim-owned views.

--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -6,11 +6,14 @@ local rails = require('diffs.rails')
 
 local default_change_bar = '▏'
 
----@param start_col integer
----@param end_col integer
+---@param start_col integer?
+---@param end_col integer?
 ---@param raw_len integer?
 ---@return integer?, integer?
 local function clamp_cols(start_col, end_col, raw_len)
+  if not start_col or not end_col then
+    return nil, nil
+  end
   if raw_len then
     if start_col >= raw_len then
       return nil, nil
@@ -870,10 +873,12 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
             end
           end
           if rail_nr_start and rail_nr_end and rail_nr_hl then
-            rail_nr_start, rail_nr_end = clamp_cols(rail_nr_start, rail_nr_end, raw_len)
-            if rail_nr_start and rail_nr_end then
-              pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, rail_nr_start, {
-                end_col = rail_nr_end,
+            local nr_start = rail_nr_start
+            local nr_end = rail_nr_end
+            nr_start, nr_end = clamp_cols(nr_start, nr_end, raw_len)
+            if nr_start and nr_end then
+              pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, nr_start, {
+                end_col = nr_end,
                 hl_group = rail_nr_hl,
                 priority = p.syntax + 2,
               })

--- a/spec/highlight_spec.lua
+++ b/spec/highlight_spec.lua
@@ -730,12 +730,12 @@ describe('highlight', function()
         })
       )
 
-      local rails = {}
+      local rail_marks = {}
       local rail_numbers = {}
       for _, mark in ipairs(get_extmarks(bufnr)) do
         local d = mark[4]
         if d and d.hl_group == 'DiffsRail' then
-          rails[#rails + 1] = { row = mark[2], col = mark[3], end_col = d.end_col }
+          rail_marks[#rail_marks + 1] = { row = mark[2], col = mark[3], end_col = d.end_col }
         end
         if d and d.hl_group == 'DiffsRailNr' then
           rail_numbers[#rail_numbers + 1] = { row = mark[2], col = mark[3], end_col = d.end_col }
@@ -745,7 +745,7 @@ describe('highlight', function()
       assert.are.same({
         { row = 1, col = 0, end_col = 8 },
         { row = 2, col = 0, end_col = 8 },
-      }, rails)
+      }, rail_marks)
       assert.are.same({
         { row = 1, col = 2, end_col = 3 },
         { row = 1, col = 4, end_col = 5 },
@@ -786,7 +786,7 @@ describe('highlight', function()
       )
 
       local overlays = {}
-      local rails = {}
+      local rail_marks = {}
       local base_rail_numbers = {}
       local rail_numbers = {}
       for _, mark in ipairs(get_extmarks(bufnr)) do
@@ -798,7 +798,7 @@ describe('highlight', function()
           end
         end
         if d and d.hl_group == 'DiffsRail' then
-          rails[#rails + 1] = { row = mark[2], col = mark[3], end_col = d.end_col }
+          rail_marks[#rail_marks + 1] = { row = mark[2], col = mark[3], end_col = d.end_col }
         end
         if d and d.hl_group == 'DiffsRailNr' then
           base_rail_numbers[#base_rail_numbers + 1] =
@@ -817,7 +817,7 @@ describe('highlight', function()
       assert.are.same({
         { row = 1, col = 0, end_col = 10 },
         { row = 2, col = 0, end_col = 10 },
-      }, rails)
+      }, rail_marks)
       assert.are.same({
         { row = 1, col = 2, end_col = 3 },
         { row = 1, col = 4, end_col = 5 },


### PR DESCRIPTION
## Problem

The stacked layout is implemented across generated diff buffers, but the help text still described command layouts and generated rails in terms of the older unified and split choices. Users reading `:help :Gdiff`, `:help :Greview`, or the generated rail highlight groups would not see the stacked layout name, its single-column generated-buffer behavior, or its side-aware line-number semantics.

This closes #366 and is part of #358.

## Solution

The command documentation now includes `++layout=stacked` for both `:Gdiff` and `:Greview`, explains how unified and stacked both create generated `diffs://` views, and keeps split documented as the paired endpoint-window layout. A dedicated stacked layout section describes the single context-aware rail, the old-side and new-side line-number rules for changed and context lines, and a replacement example where repeated numbers are expected. The generated rail highlight descriptions now avoid dual-rail-only wording so they apply to both generated rail styles.
