### PR TITLE
docs: clarify Greview split scroll behavior

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -517,9 +517,8 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     and the location list is the active file's hunk index. Selecting quickfix
     or location-list entries with the |diffs.nvim| mapped <CR> updates the
     existing workspace. Saving the right-side worktree buffer refreshes the
-    generated diff on the left. Native Vim `&diff` mode and `scrollbind` are not
-    used for |:Greview| split workspaces; ordinary manual scrolling remains
-    independent between the generated diff and target windows.
+    generated diff on the left. Native Vim `&diff` mode is not used for
+    |:Greview| split workspaces, and the windows are not scroll-bound.
 
     Parameters: ~
         ++layout=unified (optional) Open the default generated review map with

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -517,8 +517,9 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     and the location list is the active file's hunk index. Selecting quickfix
     or location-list entries with the |diffs.nvim| mapped <CR> updates the
     existing workspace. Saving the right-side worktree buffer refreshes the
-    generated diff on the left. Native Vim `&diff` mode is not used for
-    |:Greview| split workspaces.
+    generated diff on the left. Native Vim `&diff` mode and `scrollbind` are not
+    used for |:Greview| split workspaces; ordinary manual scrolling remains
+    independent between the generated diff and target windows.
 
     Parameters: ~
         ++layout=unified (optional) Open the default generated review map with


### PR DESCRIPTION
## Problem

The Greview split workspace documentation says native Vim diff mode is not used, but it did not explicitly say whether the two workspace windows are scroll-bound. That omission can make the two-surface review workspace sound closer to Gdiff split than it is.

## Solution

The Greview split documentation now clarifies that these workspaces do not use native Vim diff mode and that the two windows are not scroll-bound.
