### PR TITLE
feat(commands): add :Diff command surface with review subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ highlighting driven by treesitter.
   more!
 - Character-level intra-line diff highlighting
 - Word-level diff highlighting
-- `:Gdiff` unified diff against any revision
-- `:Greview` full-repo review diff with qflist/loclist navigation
+- `:Diff` unified diff against any revision
+- `:Diff review` full-repo review diff with qflist/loclist navigation
 - Inline merge conflict detection, highlighting, and resolution
 - Email quoting/patch syntax support (`> diff ...`)
 - Vim syntax fallback

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -24,8 +24,8 @@ Features: ~
 - Vim syntax fallback for languages without a treesitter parser
 - Blended diff background colors that preserve syntax visibility
 - Optional diff prefix (`+`/`-`/` `) concealment
-- |:Gdiff| unified diff against any revision
-- |:Greview| full-repo review diff with qflist/loclist navigation
+- |:Diff| unified diff against any revision
+- |:Diff-review| full-repo review diff with qflist/loclist navigation
 - Email quoting/patch syntax support (`> diff ...`)
 
 ==============================================================================
@@ -377,13 +377,14 @@ COMMANDS                                                 *diffs.nvim-commands*
 
 diffs.nvim-owned views: ~
 
-|:Gdiff|, |:Greview|, split layouts, and Fugitive status maps create
+|:Diff|, |:Diff-review|, split layouts, and Fugitive status maps create
 diffs.nvim-owned `diffs://` views. Ordinary `git`, `gitcommit`, `diff`,
 `extra_filetypes`, picker previews, and third-party integration buffers remain
 highlight-only.
 
-:Gdiff [++layout=unified|stacked|split] [object]                      *:Gdiff*
-    Open a diff of the current file against a Fugitive-style object.
+:Diff [++layout=unified|stacked|split] [object]                        *:Diff*
+    Open a diff of the current file against a Fugitive-style object. Use
+    |:Diff-review| (`:Diff review`) for repository reviews.
     The default unified layout opens below the current window and reuses an
     existing `diffs://` window in the tabpage when one exists.
 
@@ -397,11 +398,16 @@ highlight-only.
     `++layout=split` opens paired old/new endpoint windows with native `&diff`
     alignment. See |diffs.nvim-paired-windows|.
 
-    Plain direct |:Gdiff| from a worktree file compares the index to the
+    Prefix with |:vertical| to open the generated `unified` and `stacked`
+    layouts in a vertical split (`:vertical Diff`). The modifier is ignored for
+    `++layout=split`, which manages its own two-window arrangement;
+    `:vertical Diff ++layout=split` warns and continues.
+
+    Plain direct |:Diff| from a worktree file compares the index to the
     worktree and shows only unstaged changes. Staged-only changes report no
     changes for that edge. To view staged changes, use a staged Fugitive status
     row with |diffs.nvim-du|/|diffs.nvim-dU| or an explicit supported object
-    form such as `:Gdiff :0:%`. |:Gdiff| does not provide a `--staged` flag.
+    form such as `:Diff :0:%`. |:Diff| does not provide a `--staged` flag.
 
     Parameters: ~
         ++layout=unified (optional) Open the default generated `diffs://` view
@@ -410,26 +416,28 @@ highlight-only.
                     context-aware line-number rail.
         ++layout=split (optional) Open the current single-file comparison as
                     paired old/new endpoint windows.
-        ++novertical (optional) Force a horizontal split. Useful with |:Gvdiff|
-                    or command wrappers.
+        ++novertical (optional) Force a horizontal split even under |:vertical|.
+                    Useful in command wrappers.
         {object}    (string, optional) Fugitive-style object to diff against.
                     Defaults to the current file in the index.
 
-    Completion covers `++layout=...`, supported object forms, and git refs.
+    Completion covers `++layout=...`, the `review` subcommand, supported object
+    forms, and git refs.
 
     Examples: >vim
-        :Gdiff          " diff against the index
-        :Gdiff main     " diff against main branch
-        :Gdiff HEAD~3   " diff against 3 commits ago
-        :Gdiff :0:%     " diff against the index explicitly
-        :Gdiff abc123   " diff against specific commit
-        :Gdiff ++layout=stacked
+        :Diff           " diff against the index
+        :Diff main      " diff against main branch
+        :Diff HEAD~3    " diff against 3 commits ago
+        :Diff :0:%      " diff against the index explicitly
+        :Diff abc123    " diff against specific commit
+        :Diff ++layout=stacked
+        :vertical Diff  " open the generated diff in a vertical split
 <
     Edge cases: ~
     - Untracked and added files render as all-added files.
     - Deleted files render as all-removed files.
     - Files with both staged and unstaged changes require one view per edge:
-      plain |:Gdiff| shows unstaged changes; staged status rows show staged
+      plain |:Diff| shows unstaged changes; staged status rows show staged
       changes.
     - Unmerged files open a merge diff view. Native 3-way `:Gdiffsplit!`
       windows are not emulated.
@@ -475,14 +483,10 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     the current row maps to worktree content.
 
 
-:Gvdiff [object]                                                     *:Gvdiff*
-    Like |:Gdiff| but opens in a vertical split.
-
-:Ghdiff [object]                                                     *:Ghdiff*
-    Like |:Gdiff| but explicitly opens in a horizontal split.
-
-:Greview [++layout=unified|stacked|split] [review-spec]             *:Greview*
-    Open a repository review.
+:Diff review [++layout=unified|stacked|split] [review-spec]     *:Diff-review*
+    Open a repository review. `review` must be the first argument; a revision
+    literally named `review` must be addressed another way (for example
+    `refs/heads/review`).
 
     With no arguments, reviews the current repository state against the
     remote default branch (detected via `git -C <repo> symbolic-ref
@@ -508,7 +512,7 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     already exists in the current tabpage, the new diff replaces its buffer
     instead of creating another split.
 
-    With `++layout=split`, |:Greview| opens a two-surface review workspace
+    With `++layout=split`, |:Diff-review| opens a two-surface review workspace
     instead of the full review map. The left window is a read-only generated
     diff for one review file. The right window is the real editable worktree
     file when possible; otherwise it is a read-only tree or index target.
@@ -518,7 +522,12 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     or location-list entries with the |diffs.nvim| mapped <CR> updates the
     existing workspace. Saving the right-side worktree buffer refreshes the
     generated diff on the left. Native Vim `&diff` mode is not used for
-    |:Greview| split workspaces, and the windows are not scroll-bound.
+    |:Diff-review| split workspaces, and the windows are not scroll-bound.
+
+    Prefix with |:vertical| to open the generated `unified` and `stacked`
+    review maps in a vertical split (`:vertical Diff review`). As with |:Diff|,
+    the modifier is ignored for `++layout=split`;
+    `:vertical Diff review ++layout=split` warns and continues.
 
     Parameters: ~
         ++layout=unified (optional) Open the default generated review map with
@@ -539,13 +548,13 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     Completion covers `++layout=...` and git refs.
 
     Examples: >vim
-        :Greview
-        :Greview ++layout=stacked origin/main
-        :Greview ++layout=split
-        :Greview origin/main
-        :Greview ++layout=split origin/main
-        :Greview origin/main...refs/forge/pr/42
-        :Greview origin/main..feature/topic
+        :Diff review
+        :Diff review ++layout=stacked origin/main
+        :Diff review ++layout=split
+        :Diff review origin/main
+        :vertical Diff review origin/main
+        :Diff review origin/main...refs/forge/pr/42
+        :Diff review origin/main..feature/topic
 <
 
     Lua command helper: >lua
@@ -571,34 +580,53 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
 
     Utilities: ~
         `require('diffs.commands').greview_split()` opens the currently
-        selected |:Greview| file in the same two-surface split workspace used
-        by `:Greview ++layout=split`. It uses the review buffer cursor,
+        selected |:Diff-review| file in the same two-surface split workspace used
+        by `:Diff review ++layout=split`. It uses the review buffer cursor,
         quickfix item, or loclist item as the file selection, and the review
         quickfix list remains the authoritative file list.
 
-    These helpers are command integration helpers for |:Greview|. The stable
+    These helpers are command integration helpers for |:Diff-review|. The stable
     root Lua API remains the small surface documented at |diffs.nvim-api|.
+
+Deprecated command aliases: ~              *diffs.nvim-deprecated-commands*
+
+    :Gdiff, :Gvdiff, :Ghdiff, and :Greview are deprecated aliases kept for the
+    pre-v0.4.0 migration window. Each warns on every use and will be removed in
+    v0.4.0. Use |:Diff| and |:Diff-review| instead.
+                                    *:Gdiff* *:Gvdiff* *:Ghdiff* *:Greview*
+        :Gdiff    ->  :Diff
+        :Gvdiff   ->  :vertical Diff
+        :Ghdiff   ->  :Diff
+        :Greview  ->  :Diff review
+
+    To recreate the old spellings as local commands after they are removed: >vim
+        command! -nargs=* -bar Gdiff Diff <args>
+        command! -nargs=* -bar Gvdiff vertical Diff <args>
+        command! -nargs=* -bar Ghdiff Diff <args>
+        command! -nargs=* -bar Greview Diff review <args>
+<
 
 ==============================================================================
 MAPPINGS                                                 *diffs.nvim-mappings*
 
                                                          *<Plug>(diffs-gdiff)*
 <Plug>(diffs-gdiff)     Show index-to-worktree unified diff in a horizontal
-                        split. Equivalent to |:Gdiff| with no arguments.
+                        split. Equivalent to |:Diff| with no arguments.
 
                                                         *<Plug>(diffs-gvdiff)*
 <Plug>(diffs-gvdiff)    Show index-to-worktree unified diff in a vertical
-                        split. Equivalent to |:Gvdiff| with no arguments.
+                        split. Equivalent to `:vertical Diff` with no
+                        arguments.
 
                                              *<Plug>(diffs-gdiff-open-source)*
 <Plug>(diffs-gdiff-open-source)
-                        Open the real worktree file at the current |:Gdiff|
+                        Open the real worktree file at the current |:Diff|
                         hunk location. `diffs://` buffers map this to
                         <CR> by default.
 
                                             *<Plug>(diffs-greview-open-split)*
 <Plug>(diffs-greview-open-split)
-                        Open the currently selected |:Greview| file in a
+                        Open the currently selected |:Diff-review| file in a
                         two-surface split workspace: generated per-file diff on
                         the left, editable worktree or read-only target view on
                         the right.
@@ -672,14 +700,14 @@ Example configuration: >lua
 Diff buffer mappings: ~
                                                                 *diffs.nvim-q*
     q               Close the diff window. Available in all `diffs://`
-                    buffers created by |:Gdiff|, |:Gvdiff|, |:Ghdiff|,
-                    or the fugitive status keymaps. In paired split
-                    views, close the pair; see |diffs.nvim-paired-windows|.
-    ]c              Jump to the next hunk boundary in unified |:Gdiff|
+                    buffers created by |:Diff| or the fugitive status
+                    keymaps. In paired split views, close the pair; see
+                    |diffs.nvim-paired-windows|.
+    ]c              Jump to the next hunk boundary in unified |:Diff|
                     buffers.
-    [c              Jump to the previous hunk boundary in unified |:Gdiff|
+    [c              Jump to the previous hunk boundary in unified |:Diff|
                     buffers.
-    <CR>            Open the real worktree file at the current |:Gdiff| hunk
+    <CR>            Open the real worktree file at the current |:Diff| hunk
                     location when the current endpoint row is worktree-backed.
     dp              In Normal mode, stage the current whole hunk when the
                     buffer compares the index to the worktree. In Visual mode,
@@ -725,7 +753,7 @@ Enable vim-fugitive (https://github.com/tpope/vim-fugitive) support: >lua
 <
 
 `:Git` status and commit views receive treesitter syntax, line backgrounds,
-and intra-line diffs. |:Gdiff| opens a unified diff against any revision (see
+and intra-line diffs. |:Diff| opens a unified diff against any revision (see
 |diffs.nvim-commands|).
 
 Fugitive status keymaps: ~
@@ -1007,11 +1035,11 @@ User events: ~
 ==============================================================================
 MERGE DIFF RESOLUTION                                       *diffs.nvim-merge*
 
-When running plain |:Gdiff| or an explicit index-object comparison (for
-example `:Gdiff :%`) on an unmerged worktree file, or pressing `du`/`dU` on an
+When running plain |:Diff| or an explicit index-object comparison (for
+example `:Diff :%`) on an unmerged worktree file, or pressing `du`/`dU` on an
 unmerged (`U`) file in the fugitive status buffer, diffs.nvim opens a unified
 diff of ours (`git show :2:path`) vs theirs (`git show :3:path`) with full
-treesitter and intra-line highlighting. Revision comparisons such as `:Gdiff
+treesitter and intra-line highlighting. Revision comparisons such as `:Diff
 HEAD` keep rendering that revision against the conflicted worktree buffer.
 
 When `conflict.keymaps` is configured, those same conflict resolution mappings
@@ -1047,7 +1075,7 @@ merged working file in Neovim:
 
 When the file opens, diffs.nvim detects conflict markers automatically.
 Configure `conflict.keymaps` to enable buffer-local resolution mappings; see
-|diffs.nvim-conflict|. From a Git-unmerged file, |:Gdiff| can also open the
+|diffs.nvim-conflict|. From a Git-unmerged file, |:Diff| can also open the
 generated ours-vs-theirs merge diff view documented above.
 
 Save and quit after resolving conflicts. Use `:cq` to abort.

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -592,6 +592,21 @@ local function rail_style_for_layout(layout)
   return 'dual'
 end
 
+local function warn_legacy_command()
+  notify(
+    ':Gdiff, :Gvdiff, :Ghdiff, and :Greview are deprecated. '
+      .. 'Use :Diff and :Diff review instead. These aliases will be removed in 0.4.0.',
+    vim.log.levels.WARN
+  )
+end
+
+local function warn_vertical_split_ignored()
+  notify(
+    '++layout=split ignores the :vertical modifier; the split layout manages its own windows',
+    vim.log.levels.WARN
+  )
+end
+
 local gdiff_objects = {
   ':',
   ':%',
@@ -600,6 +615,7 @@ local gdiff_objects = {
 }
 
 local command_names = {
+  Diff = true,
   Gdiff = true,
   Gvdiff = true,
   Ghdiff = true,
@@ -641,8 +657,8 @@ end
 ---@param arglead string
 ---@param cmdline? string
 ---@param cursorpos? integer
----@return { has_layout: boolean, has_value: boolean }
-local function completion_context(arglead, cmdline, cursorpos)
+---@return string[] # completed argument tokens before the cursor, excluding the command name
+local function command_arg_tokens(arglead, cmdline, cursorpos)
   local before = cmdline or ''
   if type(cursorpos) == 'number' and cursorpos > 0 then
     before = before:sub(1, cursorpos)
@@ -663,10 +679,21 @@ local function completion_context(arglead, cmdline, cursorpos)
     command_index = 1
   end
 
+  local args = {}
+  for i = command_index + 1, #tokens do
+    args[#args + 1] = tokens[i]
+  end
+  return args
+end
+
+---@param args string[]
+---@param from? integer # first argument index to scan (defaults to 1)
+---@return { has_layout: boolean, has_value: boolean }
+local function args_context(args, from)
   local has_layout = false
   local has_value = false
-  for i = command_index + 1, #tokens do
-    local token = tokens[i]
+  for i = from or 1, #args do
+    local token = args[i]
     if token:match('^%+%+layout=') then
       has_layout = true
     elseif not token:match('^%+%+') then
@@ -677,6 +704,14 @@ local function completion_context(arglead, cmdline, cursorpos)
     has_layout = has_layout,
     has_value = has_value,
   }
+end
+
+---@param arglead string
+---@param cmdline? string
+---@param cursorpos? integer
+---@return { has_layout: boolean, has_value: boolean }
+local function completion_context(arglead, cmdline, cursorpos)
+  return args_context(command_arg_tokens(arglead, cmdline, cursorpos))
 end
 
 ---@param arglead string
@@ -715,11 +750,9 @@ local function complete_gdiff_split_command(arglead, cmdline, cursorpos)
 end
 
 ---@param arglead string
----@param cmdline? string
----@param cursorpos? integer
+---@param context { has_layout: boolean, has_value: boolean }
 ---@return string[]
-local function complete_greview_command(arglead, cmdline, cursorpos)
-  local context = completion_context(arglead, cmdline, cursorpos)
+local function complete_review_args(arglead, context)
   if context.has_value then
     return {}
   end
@@ -739,12 +772,40 @@ local function complete_greview_command(arglead, cmdline, cursorpos)
   return matches
 end
 
+---@param arglead string
+---@param cmdline? string
+---@param cursorpos? integer
+---@return string[]
+local function complete_greview_command(arglead, cmdline, cursorpos)
+  return complete_review_args(arglead, completion_context(arglead, cmdline, cursorpos))
+end
+
+---@param arglead string
+---@param cmdline? string
+---@param cursorpos? integer
+---@return string[]
+local function complete_diff_command(arglead, cmdline, cursorpos)
+  local args = command_arg_tokens(arglead, cmdline, cursorpos)
+  if args[1] == 'review' then
+    return complete_review_args(arglead, args_context(args, 2))
+  end
+  local matches = {}
+  if #args == 0 and not arglead:match('^%+%+') and starts_with('review', arglead) then
+    matches[#matches + 1] = 'review'
+  end
+  vim.list_extend(matches, complete_gdiff_command(arglead, cmdline, cursorpos))
+  return matches
+end
+
 ---@type fun(spec?: diffs.GreviewSpec, opts?: { selection?: diffs.GeneratedFileSelection, replace_win?: integer }): integer?
 local open_greview_workspace
 
 ---@param args? string
+---@param vertical? boolean
+---@param opts? { warn_vertical_split?: boolean }
 ---@return integer?
-function M.greview_command(args)
+function M.greview_command(args, vertical, opts)
+  opts = opts or {}
   local parsed, err = review.parse_command_args(args)
   if not parsed then
     notify(err, vim.log.levels.ERROR)
@@ -752,13 +813,38 @@ function M.greview_command(args)
   end
 
   if parsed.layout == 'split' then
+    if opts.warn_vertical_split then
+      warn_vertical_split_ignored()
+    end
     return open_greview_workspace(parsed.spec)
   end
 
+  parsed.spec.vertical = vertical or false
   local bufnr = M.greview(parsed.spec, {
     rail_style = rail_style_for_layout(parsed.layout),
   })
   return bufnr
+end
+
+--- Primary `:Diff` command handler. Routes `:Diff review ...` to the review
+--- surface and everything else to the current-file diff, threading the
+--- `:vertical` modifier through to generated layouts.
+---@param args? string
+---@param vertical? boolean
+---@return integer?
+function M.diff_command(args, vertical)
+  vertical = vertical or false
+  if args then
+    local sub, remainder = args:match('^%s*(%S+)%s*(.*)$')
+    if sub == 'review' then
+      return M.greview_command(
+        remainder ~= '' and remainder or nil,
+        vertical,
+        { warn_vertical_split = vertical }
+      )
+    end
+  end
+  return M.gdiff(args, vertical, { warn_vertical_split = vertical })
 end
 
 ---@param repo_root string
@@ -1586,7 +1672,9 @@ end
 
 ---@param args? string
 ---@param vertical? boolean
-function M.gdiff(args, vertical)
+---@param opts? { warn_vertical_split?: boolean }
+function M.gdiff(args, vertical, opts)
+  opts = opts or {}
   local bufnr = vim.api.nvim_get_current_buf()
   local filepath = vim.api.nvim_buf_get_name(bufnr)
 
@@ -1608,6 +1696,10 @@ function M.gdiff(args, vertical)
   if not parsed then
     notify(parse_err, vim.log.levels.ERROR)
     return
+  end
+
+  if parsed.layout == 'split' and opts.warn_vertical_split then
+    warn_vertical_split_ignored()
   end
 
   if parsed.novertical then
@@ -2033,44 +2125,58 @@ function M.read_buffer(bufnr)
 end
 
 function M.setup()
+  vim.api.nvim_create_user_command('Diff', function(opts)
+    M.diff_command(opts.args ~= '' and opts.args or nil, opts.smods.vertical)
+  end, {
+    nargs = '*',
+    bar = true,
+    complete = complete_diff_command,
+    desc = 'Show a current-file diff, or a repository review with :Diff review',
+  })
+
   vim.api.nvim_create_user_command('Gdiff', function(opts)
+    warn_legacy_command()
     M.gdiff(opts.args ~= '' and opts.args or nil, false)
   end, {
     nargs = '*',
     bar = true,
     complete = complete_gdiff_command,
-    desc = 'Show current-file diff against a Fugitive object',
+    desc = 'Deprecated alias for :Diff',
   })
 
   vim.api.nvim_create_user_command('Gvdiff', function(opts)
+    warn_legacy_command()
     M.gdiff(opts.args ~= '' and opts.args or nil, true)
   end, {
     nargs = '*',
     bar = true,
     complete = complete_gdiff_split_command,
-    desc = 'Show unified diff against a Fugitive object in vertical split',
+    desc = 'Deprecated alias for :vertical Diff',
   })
 
   vim.api.nvim_create_user_command('Ghdiff', function(opts)
+    warn_legacy_command()
     M.gdiff(opts.args ~= '' and opts.args or nil, false)
   end, {
     nargs = '*',
     bar = true,
     complete = complete_gdiff_split_command,
-    desc = 'Show unified diff against a Fugitive object in horizontal split',
+    desc = 'Deprecated alias for :Diff',
   })
 
   vim.api.nvim_create_user_command('Greview', function(opts)
+    warn_legacy_command()
     M.greview_command(opts.args ~= '' and opts.args or nil)
   end, {
     nargs = '*',
     bar = true,
     complete = complete_greview_command,
-    desc = 'Review the repo against the default branch or a git review spec',
+    desc = 'Deprecated alias for :Diff review',
   })
 end
 
 M._test = {
+  complete_diff = complete_diff_command,
   complete_gdiff = complete_gdiff_command,
   complete_gdiff_object = complete_gdiff_object,
   complete_gdiff_split = complete_gdiff_split_command,

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -414,15 +414,122 @@ describe('commands', function()
   end)
 
   describe('setup', function()
-    it('registers Gdiff, Gvdiff, and Ghdiff commands', function()
+    it('registers the Diff command alongside the deprecated aliases', function()
       commands.setup()
       local cmds = vim.api.nvim_get_commands({})
+      assert.is_not_nil(cmds.Diff)
+      assert.is_true(cmds.Diff.bar)
       assert.is_not_nil(cmds.Gdiff)
       assert.is_not_nil(cmds.Gvdiff)
       assert.is_not_nil(cmds.Ghdiff)
+      assert.is_not_nil(cmds.Greview)
       assert.is_true(cmds.Gdiff.bar)
       assert.is_true(cmds.Gvdiff.bar)
       assert.is_true(cmds.Ghdiff.bar)
+      assert.is_true(cmds.Greview.bar)
+    end)
+  end)
+
+  describe('Diff command dispatch', function()
+    local function capture_dispatch(args, vertical)
+      local saved_gdiff = commands.gdiff
+      local saved_greview = commands.greview_command
+      local captured = {}
+      commands.gdiff = function(a, v, o)
+        captured.gdiff = { args = a, vertical = v, opts = o }
+      end
+      commands.greview_command = function(a, v, o)
+        captured.greview = { args = a, vertical = v, opts = o }
+      end
+      commands.diff_command(args, vertical)
+      commands.gdiff = saved_gdiff
+      commands.greview_command = saved_greview
+      return captured
+    end
+
+    it('routes plain arguments to the current-file diff', function()
+      local captured = capture_dispatch('HEAD~3', false)
+      assert.is_nil(captured.greview)
+      assert.are.same(
+        { args = 'HEAD~3', vertical = false, opts = { warn_vertical_split = false } },
+        captured.gdiff
+      )
+    end)
+
+    it('threads the :vertical modifier and the split warning into the diff path', function()
+      local captured = capture_dispatch(nil, true)
+      assert.is_nil(captured.greview)
+      assert.are.same(
+        { args = nil, vertical = true, opts = { warn_vertical_split = true } },
+        captured.gdiff
+      )
+    end)
+
+    it('routes a leading review subcommand to the review surface', function()
+      local captured = capture_dispatch('review origin/main', true)
+      assert.is_nil(captured.gdiff)
+      assert.are.same(
+        { args = 'origin/main', vertical = true, opts = { warn_vertical_split = true } },
+        captured.greview
+      )
+    end)
+
+    it('treats a bare review subcommand as a review with no spec', function()
+      local captured = capture_dispatch('review', false)
+      assert.is_nil(captured.gdiff)
+      assert.are.same(
+        { args = nil, vertical = false, opts = { warn_vertical_split = false } },
+        captured.greview
+      )
+    end)
+
+    it('only treats review as the subcommand when it is the first token', function()
+      local captured = capture_dispatch('++layout=split review', false)
+      assert.is_nil(captured.greview)
+      assert.are.same(
+        { args = '++layout=split review', vertical = false, opts = { warn_vertical_split = false } },
+        captured.gdiff
+      )
+    end)
+  end)
+
+  describe('deprecated command aliases', function()
+    local function count_deprecations(notifications)
+      local count = 0
+      for _, n in ipairs(notifications) do
+        if tostring(n.message):find('deprecated', 1, true) then
+          count = count + 1
+        end
+      end
+      return count
+    end
+
+    it('warns on use of every deprecated alias', function()
+      commands.setup()
+      local notifications = capture_notifications()
+      vim.cmd('enew')
+      vim.cmd('silent! Gdiff')
+      vim.cmd('silent! Gvdiff')
+      vim.cmd('silent! Ghdiff')
+      vim.cmd('silent! Greview ++layout=bogus')
+      assert.are.equal(4, count_deprecations(notifications))
+    end)
+
+    it('warns again on every repeated use of a deprecated alias', function()
+      commands.setup()
+      local notifications = capture_notifications()
+      vim.cmd('enew')
+      vim.cmd('silent! Gdiff')
+      vim.cmd('silent! Gdiff')
+      assert.are.equal(2, count_deprecations(notifications))
+    end)
+
+    it('does not warn for the :Diff command', function()
+      commands.setup()
+      local notifications = capture_notifications()
+      vim.cmd('enew')
+      vim.cmd('silent! Diff')
+      assert.are.equal(0, count_deprecations(notifications))
     end)
   end)
 
@@ -593,6 +700,70 @@ describe('commands', function()
 
     it('keeps Gvdiff and Ghdiff completion focused on objects', function()
       assert.are.same({}, commands._test.complete_gdiff_split('++l'))
+    end)
+
+    it('completes the Diff review subcommand, layout options, objects, and refs', function()
+      mock_repo_root(function()
+        return '/tmp/repo'
+      end)
+      mock_systemlist(function()
+        return { 'origin/main', 'feature/topic' }
+      end)
+
+      assert.are.same({
+        'review',
+        '++layout=unified',
+        '++layout=stacked',
+        '++layout=split',
+        ':',
+        ':%',
+        ':0:%',
+        '@:%',
+        'origin/main',
+        'feature/topic',
+      }, commands._test.complete_diff('', 'Diff ', #'Diff '))
+
+      assert.are.same({ 'review' }, commands._test.complete_diff('rev', 'Diff rev', #'Diff rev'))
+
+      assert.are.same({
+        '++layout=unified',
+        '++layout=stacked',
+        '++layout=split',
+      }, commands._test.complete_diff('++l', 'Diff ++l', #'Diff ++l'))
+
+      assert.are.same({
+        '++layout=unified',
+        '++layout=stacked',
+        '++layout=split',
+        'origin/main',
+        'feature/topic',
+      }, commands._test.complete_diff('', 'Diff review ', #'Diff review '))
+
+      assert.are.same(
+        {
+          'origin/main',
+          'feature/topic',
+        },
+        commands._test.complete_diff(
+          '',
+          'Diff review ++layout=split ',
+          #'Diff review ++layout=split '
+        )
+      )
+
+      assert.are.same(
+        {},
+        commands._test.complete_diff('', 'Diff review origin/main ', #'Diff review origin/main ')
+      )
+      assert.are.same(
+        {},
+        commands._test.complete_diff(
+          '',
+          'Diff review ++layout=split origin/main ',
+          #'Diff review ++layout=split origin/main '
+        )
+      )
+      assert.are.same({}, commands._test.complete_diff('', 'Diff HEAD ', #'Diff HEAD '))
     end)
   end)
 
@@ -1001,6 +1172,35 @@ describe('commands', function()
       assert.are.equal(1, #right_loc)
       assert.are.equal(left_buf, left_loc[1].bufnr)
       assert.are.equal(right_buf, right_loc[1].bufnr)
+    end)
+
+    it('warns and still opens the split when :vertical Diff ++layout=split is used', function()
+      local notifications = capture_notifications()
+      local saved_splitright = vim.o.splitright
+      vim.o.splitright = false
+      local ok, err = pcall(function()
+        mock_view_config({ prefix = true, change_bar = '┃', rail_separator = '│' })
+        create_split_source()
+        commands.diff_command('++layout=split', true)
+      end)
+      vim.o.splitright = saved_splitright
+      assert.is_true(ok, err)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+      local left_win, right_win = find_split_windows(left_buf, right_buf)
+      assert.is_not_nil(left_win)
+      assert.is_not_nil(right_win)
+
+      local warned = false
+      for _, n in ipairs(notifications) do
+        if tostring(n.message):find('++layout=split ignores the :vertical modifier', 1, true) then
+          warned = true
+        end
+      end
+      assert.is_true(warned)
     end)
 
     it('moves split hunk navigation through both endpoint windows', function()
@@ -2895,6 +3095,27 @@ describe('commands', function()
       assert.are.equal(1, #loc)
       assert.are.equal(diff_buf, loc[1].bufnr)
       assert.is_true(loc[1].text:find('file.txt', 1, true) ~= nil)
+    end)
+
+    it('warns and still opens the workspace for :vertical Diff review ++layout=split', function()
+      local repo_root = create_repo()
+      vim.fn.writefile({ 'line 1', 'line 2 changed' }, repo_root .. '/file.txt')
+      edit_file(repo_root .. '/file.txt')
+      mock_runtime_attach(function() end)
+      local notifications = capture_notifications()
+
+      local diff_buf =
+        commands.greview_command('++layout=split HEAD', true, { warn_vertical_split = true })
+      track_workspace(diff_buf)
+
+      local warned = false
+      for _, n in ipairs(notifications) do
+        if tostring(n.message):find('++layout=split ignores the :vertical modifier', 1, true) then
+          warned = true
+        end
+      end
+      assert.is_true(warned)
+      assert.are.equal(2, #main_windows())
     end)
 
     it('replaces the visible review buffer even when another window is current', function()


### PR DESCRIPTION
## Problem

`:Gdiff`, `:Gvdiff`, `:Ghdiff`, and `:Greview` collide with vim-fugitive's namespace and predate the layout work, leaving no generic primary command (#379).

## Solution

Add `:Diff` as the primary command, with reviews under a `review` subcommand (`:Diff review`) instead of a second top-level command. Semantics match the old `:Gdiff`/`:Greview`, and `review` is the subcommand only as the literal first token. `:vertical` controls the open direction for the `unified` and `stacked` layouts and warns-and-continues with `++layout=split`. The old commands stay as deprecated aliases that warn on every use and point at the new surface. Completion and docs (vimdoc + README) are updated with a migration reference for the old spellings.

The object/revision language stays in #381 and alias removal stays in #380.
