### PR TITLE
feat(diff): define and implement the :Diff object language

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -383,8 +383,9 @@ diffs.nvim-owned `diffs://` views. Ordinary `git`, `gitcommit`, `diff`,
 highlight-only.
 
 :Diff [++layout=unified|stacked|split] [object]                        *:Diff*
-    Open a diff of the current file against a Fugitive-style object. Use
-    |:Diff-review| (`:Diff review`) for repository reviews.
+    Open a diff of the current file against a diff object. The object language
+    is defined at |diffs.nvim-diff-objects|. Use |:Diff-review| (`:Diff review`)
+    for repository reviews.
     The default unified layout opens below the current window and reuses an
     existing `diffs://` window in the tabpage when one exists.
 
@@ -418,8 +419,9 @@ highlight-only.
                     paired old/new endpoint windows.
         ++novertical (optional) Force a horizontal split even under |:vertical|.
                     Useful in command wrappers.
-        {object}    (string, optional) Fugitive-style object to diff against.
-                    Defaults to the current file in the index.
+        {object}    (string, optional) The object to diff against; see
+                    |diffs.nvim-diff-objects|. Defaults to the current file in
+                    the index.
 
     Completion covers `++layout=...`, the `review` subcommand, supported object
     forms, and git refs.
@@ -441,13 +443,47 @@ highlight-only.
       changes.
     - Unmerged files open a merge diff view. Native 3-way `:Gdiffsplit!`
       windows are not emulated.
-    - Mode-only changes, binary files, submodules, merge-stage objects, and pure
-      renames report a warning or no text changes.
+    - Mode-only changes, binary files, submodules, and pure renames report a
+      warning or no text changes.
 
     Hunk actions run `git apply --cached --check` before mutating the index.
     Stale hunks, context drift, and index mismatches fail without partial
     mutation. `dp` appears only for supported index -> worktree hunks/ranges;
     `do` appears only for supported tree -> index hunks/ranges.
+
+Diff objects: ~                                       *diffs.nvim-diff-objects*
+
+    `:Diff [object]` takes a single object that names one side of the diff; the
+    other side is that path's worktree (except the staged-context default). `%`
+    is the current file.
+
+    Supported objects: ~
+        (omitted)   Current file: index vs worktree (HEAD vs index in a staged
+                    context).
+        {rev}       Current file at {rev} vs worktree. {rev} is any git
+                    revision: `HEAD`, `@` (alias for HEAD), `HEAD~3`, a branch,
+                    a tag, or a commit hash.
+        :           Current file: index vs worktree. Also `:%` and `:0:%`.
+        {rev}:%     Current file at {rev} vs worktree. Also `@:%`, `HEAD:%`.
+        {rev}:{path} The {path} at {rev} vs the {path} worktree file, for
+                    example `:Diff HEAD:lua/foo.lua`.
+        :{path}     The {path} in the index vs its worktree file. Also
+                    `:0:{path}`.
+        :1:% :2:% :3:%
+                    The file at merge stage 1 (base), 2 (ours), or 3 (theirs)
+                    vs the worktree. Read-only, and valid only while the file is
+                    in a merge conflict. Also `:1:{path}` etc.
+
+    Unsupported objects: ~
+        These recognizable Fugitive forms are rejected with a specific error:
+        - `#`, `#N`                   alternate-buffer expansion
+        - `!`, `!:{path}`             owner-commit expansion
+        - `<cfile>`                   cursor-file expansion
+        - `./{path}`, `:(top){path}`  worktree-relative and pathspec-magic paths
+        - `:/{message}`               commit-message search
+        - `{a}..{b}`, `{a}...{b}`     ranges; use |:Diff-review| instead
+        - `{rev}:`                    tree objects
+        - `-`                         the previous object
 
 Stacked generated layout: ~                        *diffs.nvim-stacked-layout*
 

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -261,6 +261,12 @@ local function gdiff_buffer_label(diff_spec)
     return left.rev
   end
 
+  if
+    left.kind == diffspec.endpoint_kind.stage and right.kind == diffspec.endpoint_kind.worktree
+  then
+    return 'stage' .. left.stage
+  end
+
   return diffspec.label(diff_spec)
 end
 
@@ -607,6 +613,9 @@ local function warn_vertical_split_ignored()
   )
 end
 
+-- Always-available object literals offered in completion. Merge-stage objects
+-- (`:1:%`/`:2:%`/`:3:%`) are valid only during a conflict, so they are accepted
+-- by the parser but not advertised here.
 local gdiff_objects = {
   ':',
   ':%',
@@ -1716,6 +1725,13 @@ function M.gdiff(args, vertical, opts)
     return
   end
 
+  local diff_filepath = repo_root .. '/' .. diff_path
+
+  if diff_spec.left.kind == diffspec.endpoint_kind.stage and not git.is_unmerged(diff_filepath) then
+    notify(diff_path .. ' is not in a merge conflict', vim.log.levels.ERROR)
+    return
+  end
+
   if
     diff_spec.left.kind == diffspec.endpoint_kind.index
     and diff_spec.right.kind == diffspec.endpoint_kind.worktree
@@ -1735,7 +1751,9 @@ function M.gdiff(args, vertical, opts)
     return
   end
 
-  local worktree_lines = content.from_buffer(bufnr)
+  -- Only the current buffer's content stands in for the worktree side; an
+  -- explicit-path object targets a different file that must be read from disk.
+  local worktree_lines = diff_path == rel_path and content.from_buffer(bufnr) or nil
   local diff_lines, render_err = render.file(diff_spec, repo_root, {
     worktree_lines = worktree_lines,
   })

--- a/lua/diffs/gdiff.lua
+++ b/lua/diffs/gdiff.lua
@@ -40,28 +40,100 @@ local function is_worktree(endpoint)
   return endpoint.kind == diffspec.endpoint_kind.worktree
 end
 
+---@class diffs.GdiffParsedObject
+---@field left diffs.Endpoint
+---@field path? string # explicit path; nil means the current file
+---@field right_worktree? boolean # if set, the right endpoint is the worktree rather than `current`
+
+--- Parse a single `:Diff` object into its left endpoint, optional explicit
+--- path, and whether the right endpoint should be pinned to the worktree.
+--- Recognizable Fugitive forms that are intentionally unsupported are rejected
+--- with specific messages (see |diffs.nvim-diff-objects|).
 ---@param object string
----@return diffs.Endpoint?, string?
-local function parse_object_endpoint(object)
+---@return diffs.GdiffParsedObject?, string?
+local function parse_object(object)
+  if object == '#' or object:match('^#%d+$') then
+    return nil, 'alternate-buffer objects (#) are not supported'
+  end
+  if object:sub(1, 1) == '!' then
+    return nil, 'owner-commit objects (!) are not supported'
+  end
+  if object == '<cfile>' then
+    return nil, '<cfile> objects are not supported'
+  end
+  if object == '-' then
+    return nil, 'the previous-object form (-) is not supported'
+  end
+  if object == '.' or object:sub(1, 2) == './' or object:sub(1, 3) == '../' then
+    return nil, 'worktree-relative path objects (./) are not supported'
+  end
+  if object:find('..', 1, true) then
+    return nil, 'range objects are not supported; use :Diff review for ranges'
+  end
+  if object:match('^:/') then
+    return nil, 'commit-message search objects (:/) are not supported'
+  end
+  if object:match('^:%(') then
+    return nil, 'pathspec-magic objects (:(...)) are not supported'
+  end
+
   if object == ':' or object == ':%' or object == ':0:%' then
-    return diffspec.index(), nil
+    return { left = diffspec.index() }, nil
   end
 
-  local stage = object:match('^:(%d):%%$')
-  if stage then
-    return nil, 'unsupported index stage :' .. stage .. ':%'
+  local stage_digit, stage_rest = object:match('^:([0-3]):(.+)$')
+  if stage_digit then
+    local left
+    if stage_digit == '0' then
+      left = diffspec.index()
+    elseif stage_digit == '1' then
+      left = diffspec.stage(1)
+    elseif stage_digit == '2' then
+      left = diffspec.stage(2)
+    else
+      left = diffspec.stage(3)
+    end
+    return {
+      left = left,
+      path = stage_rest ~= '%' and stage_rest or nil,
+      right_worktree = true,
+    },
+      nil
   end
 
-  local rev = object:match('^(.+):%%$')
+  if object:match('^:[123]$') then
+    return nil,
+      'merge stage ' .. object .. ' needs a path; use ' .. object .. ':% for the current file'
+  end
+
+  if object:sub(1, 1) == ':' then
+    local object_path = object:sub(2)
+    if object_path == '%' then
+      return { left = diffspec.index() }, nil
+    end
+    return { left = diffspec.index(), path = object_path, right_worktree = true }, nil
+  end
+
+  if object:match(':$') then
+    return nil, 'tree objects (trailing :) are not supported'
+  end
+
+  -- Greedy: `a:b:c` splits at the last colon. Git revisions rarely contain
+  -- colons, and an invalid revision surfaces later when its content is read.
+  local rev, rev_path = object:match('^(.+):(.+)$')
   if rev then
-    return diffspec.tree(normalize_rev(rev)), nil
+    if rev_path == '%' then
+      return { left = diffspec.tree(normalize_rev(rev)) }, nil
+    end
+    return {
+      left = diffspec.tree(normalize_rev(rev)),
+      path = rev_path,
+      right_worktree = true,
+    },
+      nil
   end
 
-  if object:find(':', 1, true) then
-    return nil, 'unsupported Fugitive object: ' .. object
-  end
-
-  return diffspec.tree(normalize_rev(object)), nil
+  return { left = diffspec.tree(normalize_rev(object)) }, nil
 end
 
 ---@param current diffs.Endpoint
@@ -132,13 +204,15 @@ function M.parse(args, context)
       nil
   end
 
-  local endpoint, err = parse_object_endpoint(tokens[1])
-  if not endpoint then
+  local object, err = parse_object(tokens[1])
+  if not object then
     return nil, err
   end
 
+  local scope_path = object.path or path
+  local right = object.right_worktree and diffspec.worktree() or current
   return {
-    spec = diffspec.file(endpoint, current, path),
+    spec = diffspec.file(object.left, right, scope_path),
     novertical = novertical,
     layout = layout,
   },

--- a/lua/diffs/render.lua
+++ b/lua/diffs/render.lua
@@ -127,6 +127,8 @@ function M.read_endpoint(endpoint, filepath, opts)
   local lines, err
   if endpoint.kind == diffspec.endpoint_kind.tree then
     lines, err = git.get_file_content(endpoint.rev, filepath)
+  elseif endpoint.kind == diffspec.endpoint_kind.stage then
+    lines, err = git.get_file_content(':' .. endpoint.stage, filepath)
   elseif endpoint.kind == diffspec.endpoint_kind.index then
     lines, err = git.get_index_content(filepath)
   elseif endpoint.kind == diffspec.endpoint_kind.worktree then

--- a/lua/diffs/spec.lua
+++ b/lua/diffs/spec.lua
@@ -4,6 +4,7 @@ M.endpoint_kind = {
   tree = 'tree',
   index = 'index',
   worktree = 'worktree',
+  stage = 'stage',
 }
 
 M.scope_kind = {
@@ -32,7 +33,11 @@ end
 ---@class diffs.WorktreeEndpoint
 ---@field kind "worktree"
 
----@alias diffs.Endpoint diffs.TreeEndpoint|diffs.IndexEndpoint|diffs.WorktreeEndpoint
+---@class diffs.StageEndpoint
+---@field kind "stage"
+---@field stage 1|2|3
+
+---@alias diffs.Endpoint diffs.TreeEndpoint|diffs.IndexEndpoint|diffs.WorktreeEndpoint|diffs.StageEndpoint
 
 ---@class diffs.FileScope
 ---@field kind "file"
@@ -65,6 +70,15 @@ function M.worktree()
   return { kind = M.endpoint_kind.worktree }
 end
 
+---@param stage 1|2|3
+---@return diffs.StageEndpoint
+function M.stage(stage)
+  if stage ~= 1 and stage ~= 2 and stage ~= 3 then
+    error('diffs: stage endpoint must be 1, 2, or 3')
+  end
+  return { kind = M.endpoint_kind.stage, stage = stage }
+end
+
 ---@param endpoint diffs.Endpoint
 ---@return diffs.Endpoint
 function M.endpoint(endpoint)
@@ -80,6 +94,10 @@ function M.endpoint(endpoint)
 
   if endpoint.kind == M.endpoint_kind.worktree then
     return M.worktree()
+  end
+
+  if endpoint.kind == M.endpoint_kind.stage then
+    return M.stage(endpoint.stage)
   end
 
   error('diffs: unsupported endpoint kind: ' .. tostring(endpoint.kind))
@@ -162,6 +180,13 @@ function M.rev_to_rev(left_rev, right_rev, path)
   return M.file(M.tree(left_rev), M.tree(right_rev), path)
 end
 
+---@param stage 1|2|3
+---@param path string
+---@return diffs.DiffSpec
+function M.stage_to_worktree(stage, path)
+  return M.file(M.stage(stage), M.worktree(), path)
+end
+
 ---@param endpoint diffs.Endpoint
 ---@return string
 function M.endpoint_label(endpoint)
@@ -169,6 +194,10 @@ function M.endpoint_label(endpoint)
 
   if endpoint.kind == M.endpoint_kind.tree then
     return 'tree:' .. endpoint.rev
+  end
+
+  if endpoint.kind == M.endpoint_kind.stage then
+    return 'stage:' .. endpoint.stage
   end
 
   return endpoint.kind
@@ -196,6 +225,12 @@ end
 ---@return "index"|"worktree"|nil
 function M.mutation_target(diff_spec)
   diff_spec = M.new(diff_spec)
+
+  -- Merge-stage comparisons are read-only: a stage blob cannot be staged or
+  -- restored through hunk actions.
+  if diff_spec.left.kind == M.endpoint_kind.stage then
+    return nil
+  end
 
   if diff_spec.right.kind == M.endpoint_kind.index then
     return M.endpoint_kind.index

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1826,6 +1826,64 @@ describe('commands', function()
       }, vim.api.nvim_buf_get_var(unstaged_buf, 'diffs_source'))
     end)
 
+    it('renders an explicit-path object against that path worktree counterpart', function()
+      local repo_root = create_repo()
+      write_repo_file(repo_root, 'other.lua', { 'local a = 1', 'return a' })
+      git_cmd(repo_root, { 'add', 'other.lua' })
+      git_cmd(repo_root, { 'commit', '-qm', 'add other' })
+      vim.fn.writefile({ 'local a = 1', 'local b = 2', 'return a' }, repo_root .. '/other.lua')
+      edit_file(repo_root .. '/file.txt')
+      mock_runtime_attach(function() end)
+
+      commands.diff_command('HEAD:other.lua', false)
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+      assert.are.equal('diffs://HEAD:other.lua', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.same(
+        diffspec.rev_to_worktree('HEAD', 'other.lua'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      local text = table.concat(buffer_lines(diff_buf), '\n')
+      assert.is_true(text:find('+local b = 2', 1, true) ~= nil)
+    end)
+
+    it('renders a read-only merge-stage object against the worktree', function()
+      local _, filepath = create_conflicted_repo()
+      edit_file(filepath)
+      mock_runtime_attach(function() end)
+      assert.is_true(git.is_unmerged(filepath))
+
+      commands.diff_command(':2:%', false)
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+      assert.are.equal('diffs://stage2:file.txt', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.same(
+        diffspec.stage_to_worktree(2, 'file.txt'),
+        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+      )
+      assert.is_false(helpers.has_keymap(diff_buf, 'dp'))
+      assert.is_false(helpers.has_keymap(diff_buf, 'do'))
+    end)
+
+    it('rejects a merge-stage object when the file is not in a conflict', function()
+      local repo_root = create_repo()
+      edit_file(repo_root .. '/file.txt')
+      mock_runtime_attach(function() end)
+      local notifications = capture_notifications()
+
+      commands.diff_command(':2:%', false)
+
+      local rejected = false
+      for _, n in ipairs(notifications) do
+        if tostring(n.message):find('is not in a merge conflict', 1, true) then
+          rejected = true
+        end
+      end
+      assert.is_true(rejected)
+    end)
+
     it('routes direct :Gdiff on unmerged files to the generated unmerged view', function()
       local repo_root, filepath = create_conflicted_repo()
       edit_file(filepath)

--- a/spec/diffspec_spec.lua
+++ b/spec/diffspec_spec.lua
@@ -73,6 +73,32 @@ describe('diffs.spec', function()
     assert.are.equal('tree:origin/main -> tree:HEAD file:lua/foo.lua', diffspec.label(spec))
   end)
 
+  it('represents read-only merge-stage to worktree file diffs', function()
+    local spec = diffspec.stage_to_worktree(2, path)
+
+    assert.are.same({
+      left = { kind = 'stage', stage = 2 },
+      right = { kind = 'worktree' },
+      scope = { kind = 'file', path = path },
+      mode = 'unified',
+    }, spec)
+    assert.is_false(diffspec.is_index_target(spec))
+    assert.is_false(diffspec.is_worktree_target(spec))
+    assert.is_true(diffspec.is_read_only(spec))
+    assert.are.same({ read_only = true }, diffspec.mutability(spec))
+    assert.are.same({ can_put = false, can_obtain = false }, diffspec.patch_actions(spec))
+    assert.are.equal('stage:2 -> worktree file:lua/foo.lua', diffspec.label(spec))
+  end)
+
+  it('rejects invalid merge-stage numbers', function()
+    assert.has_error(function()
+      diffspec.stage(0)
+    end, 'diffs: stage endpoint must be 1, 2, or 3')
+    assert.has_error(function()
+      diffspec.stage(4)
+    end, 'diffs: stage endpoint must be 1, 2, or 3')
+  end)
+
   it('normalizes table-shaped specs without keeping caller-owned tables', function()
     local input = {
       left = { kind = 'tree', rev = 'HEAD' },

--- a/spec/gdiff_spec.lua
+++ b/spec/gdiff_spec.lua
@@ -127,10 +127,75 @@ describe('diffs.gdiff', function()
     assert.are.equal('expected at most one Fugitive object', err)
   end)
 
-  it('rejects unsupported index stages for now', function()
-    local result, err = gdiff.parse(':2:%', { path = path })
+  it('maps revision explicit-path objects to revision -> worktree of that path', function()
+    local result = parse('HEAD:lua/bar.lua')
 
-    assert.is_nil(result)
-    assert.are.equal('unsupported index stage :2:%', err)
+    assert.are.same(diffspec.rev_to_worktree('HEAD', 'lua/bar.lua'), result.spec)
   end)
+
+  it('normalizes @ in revision explicit-path objects', function()
+    local result = parse('@:lua/bar.lua')
+
+    assert.are.same(diffspec.rev_to_worktree('HEAD', 'lua/bar.lua'), result.spec)
+  end)
+
+  it('maps index explicit-path objects to index -> worktree of that path', function()
+    for _, object in ipairs({ ':lua/bar.lua', ':0:lua/bar.lua' }) do
+      local result = parse(object)
+
+      assert.are.same(diffspec.index_to_worktree('lua/bar.lua'), result.spec)
+    end
+  end)
+
+  it('maps merge-stage current-file objects to stage -> worktree', function()
+    for _, stage in ipairs({ 1, 2, 3 }) do
+      local result = parse((':%d:%%'):format(stage))
+
+      assert.are.same(diffspec.stage_to_worktree(stage, path), result.spec)
+    end
+  end)
+
+  it('maps merge-stage explicit-path objects to stage -> worktree of that path', function()
+    local result = parse(':3:lua/bar.lua')
+
+    assert.are.same(diffspec.stage_to_worktree(3, 'lua/bar.lua'), result.spec)
+  end)
+
+  it('pins explicit-path objects to the worktree even in a staged context', function()
+    local result = parse('HEAD:lua/bar.lua', diffspec.index())
+
+    assert.are.same(diffspec.rev_to_worktree('HEAD', 'lua/bar.lua'), result.spec)
+  end)
+
+  local rejected = {
+    { object = '#', err = 'alternate-buffer objects (#) are not supported' },
+    { object = '#2', err = 'alternate-buffer objects (#) are not supported' },
+    { object = '!', err = 'owner-commit objects (!) are not supported' },
+    { object = '!:lua/bar.lua', err = 'owner-commit objects (!) are not supported' },
+    { object = '<cfile>', err = '<cfile> objects are not supported' },
+    { object = '-', err = 'the previous-object form (-) is not supported' },
+    { object = './lua/bar.lua', err = 'worktree-relative path objects (./) are not supported' },
+    { object = '../lua/bar.lua', err = 'worktree-relative path objects (./) are not supported' },
+    {
+      object = 'main..other',
+      err = 'range objects are not supported; use :Diff review for ranges',
+    },
+    {
+      object = 'main...other',
+      err = 'range objects are not supported; use :Diff review for ranges',
+    },
+    { object = ':2', err = 'merge stage :2 needs a path; use :2:% for the current file' },
+    { object = ':/fix', err = 'commit-message search objects (:/) are not supported' },
+    { object = ':(top)lua/bar.lua', err = 'pathspec-magic objects (:(...)) are not supported' },
+    { object = 'master:', err = 'tree objects (trailing :) are not supported' },
+  }
+
+  for _, case in ipairs(rejected) do
+    it('rejects ' .. case.object, function()
+      local result, err = gdiff.parse(case.object, { path = path })
+
+      assert.is_nil(result)
+      assert.are.equal(case.err, err)
+    end)
+  end
 end)


### PR DESCRIPTION
## Problem

`:Diff [object]` advertised a vague "Fugitive-style object" but only accepted a narrow subset of forms, with no precise, tested grammar (#381).

## Solution

Define `:Diff`'s object language as a single object that names one endpoint and is diffed against that path's worktree (except the staged-context default). Add explicit-path objects (`<rev>:path`, `:path`, `:0:path`) that compare that path between the named endpoint and its own worktree file, and read-only merge-stage objects (`:1:%`/`:2:%`/`:3:%` and `:N:path`) modeled as a new `stage` endpoint that is valid only during a conflict. Recognizable but unsupported Fugitive forms — ranges, owner-commit, alternate-buffer, `<cfile>`, pathspec magic, worktree-relative paths, tree objects, and the previous-object form — are rejected with specific errors. The grammar is documented under a new vimdoc section, and completion stays scoped to the always-available forms.

Follows the command migration from #382; alias removal remains #380.
