### PR TITLE
fix(commands): align alias deprecation warning

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -600,8 +600,8 @@ end
 
 local function warn_legacy_command()
   notify(
-    ':Gdiff, :Gvdiff, :Ghdiff, and :Greview are deprecated. '
-      .. 'Use :Diff and :Diff review instead. These aliases will be removed in 0.4.0.',
+    ':Gdiff, :Gvdiff, :Ghdiff, and :Greview are deprecated, use :Diff and :Diff review instead.\n'
+      .. 'Feature will be removed in diffs.nvim 0.4.0',
     vim.log.levels.WARN
   )
 end

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -494,6 +494,9 @@ describe('commands', function()
   end)
 
   describe('deprecated command aliases', function()
+    local command_deprecation = '[diffs]: :Gdiff, :Gvdiff, :Ghdiff, and :Greview are deprecated, use :Diff and :Diff review instead.\n'
+      .. 'Feature will be removed in diffs.nvim 0.4.0'
+
     local function count_deprecations(notifications)
       local count = 0
       for _, n in ipairs(notifications) do
@@ -513,6 +516,7 @@ describe('commands', function()
       vim.cmd('silent! Ghdiff')
       vim.cmd('silent! Greview ++layout=bogus')
       assert.are.equal(4, count_deprecations(notifications))
+      assert.are.equal(command_deprecation, notifications[1].message)
     end)
 
     it('warns again on every repeated use of a deprecated alias', function()


### PR DESCRIPTION
## Problem

The deprecated `:Gdiff`, `:Gvdiff`, `:Ghdiff`, and `:Greview` aliases intentionally warn on every use, but their warning text does not match Neovim's standard deprecation phrasing. That makes this command deprecation look different from the existing config deprecations that use `vim.deprecate()`.

## Solution

Keep the explicit every-use warning behavior for command aliases, but format the message like `vim.deprecate()` by using the standard "is deprecated, use ... instead" sentence and the "Feature will be removed in diffs.nvim 0.4.0" removal line.
