### PR TITLE
fix(commands): guide deprecated aliases individually

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -598,10 +598,22 @@ local function rail_style_for_layout(layout)
   return 'dual'
 end
 
-local function warn_legacy_command()
+local legacy_command_replacements = {
+  Gdiff = ':Diff',
+  Gvdiff = ':vertical Diff',
+  Ghdiff = ':Diff',
+  Greview = ':Diff review',
+}
+
+---@param command "Gdiff"|"Gvdiff"|"Ghdiff"|"Greview"
+local function warn_legacy_command(command)
   notify(
-    ':Gdiff, :Gvdiff, :Ghdiff, and :Greview are deprecated, use :Diff and :Diff review instead.\n'
-      .. 'Feature will be removed in diffs.nvim 0.4.0',
+    ':'
+      .. command
+      .. ' is deprecated, use '
+      .. legacy_command_replacements[command]
+      .. ' instead.\n'
+      .. 'Feature will be removed in diffs.nvim 0.4.0. See :help diffs.nvim-deprecated-commands',
     vim.log.levels.WARN
   )
 end
@@ -2153,7 +2165,7 @@ function M.setup()
   })
 
   vim.api.nvim_create_user_command('Gdiff', function(opts)
-    warn_legacy_command()
+    warn_legacy_command('Gdiff')
     M.gdiff(opts.args ~= '' and opts.args or nil, false)
   end, {
     nargs = '*',
@@ -2163,7 +2175,7 @@ function M.setup()
   })
 
   vim.api.nvim_create_user_command('Gvdiff', function(opts)
-    warn_legacy_command()
+    warn_legacy_command('Gvdiff')
     M.gdiff(opts.args ~= '' and opts.args or nil, true)
   end, {
     nargs = '*',
@@ -2173,7 +2185,7 @@ function M.setup()
   })
 
   vim.api.nvim_create_user_command('Ghdiff', function(opts)
-    warn_legacy_command()
+    warn_legacy_command('Ghdiff')
     M.gdiff(opts.args ~= '' and opts.args or nil, false)
   end, {
     nargs = '*',
@@ -2183,7 +2195,7 @@ function M.setup()
   })
 
   vim.api.nvim_create_user_command('Greview', function(opts)
-    warn_legacy_command()
+    warn_legacy_command('Greview')
     M.greview_command(opts.args ~= '' and opts.args or nil)
   end, {
     nargs = '*',

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -494,8 +494,16 @@ describe('commands', function()
   end)
 
   describe('deprecated command aliases', function()
-    local command_deprecation = '[diffs]: :Gdiff, :Gvdiff, :Ghdiff, and :Greview are deprecated, use :Diff and :Diff review instead.\n'
-      .. 'Feature will be removed in diffs.nvim 0.4.0'
+    local deprecations = {
+      Gdiff = '[diffs]: :Gdiff is deprecated, use :Diff instead.\n'
+        .. 'Feature will be removed in diffs.nvim 0.4.0. See :help diffs.nvim-deprecated-commands',
+      Gvdiff = '[diffs]: :Gvdiff is deprecated, use :vertical Diff instead.\n'
+        .. 'Feature will be removed in diffs.nvim 0.4.0. See :help diffs.nvim-deprecated-commands',
+      Ghdiff = '[diffs]: :Ghdiff is deprecated, use :Diff instead.\n'
+        .. 'Feature will be removed in diffs.nvim 0.4.0. See :help diffs.nvim-deprecated-commands',
+      Greview = '[diffs]: :Greview is deprecated, use :Diff review instead.\n'
+        .. 'Feature will be removed in diffs.nvim 0.4.0. See :help diffs.nvim-deprecated-commands',
+    }
 
     local function count_deprecations(notifications)
       local count = 0
@@ -507,6 +515,16 @@ describe('commands', function()
       return count
     end
 
+    local function deprecation_messages(notifications)
+      local messages = {}
+      for _, n in ipairs(notifications) do
+        if tostring(n.message):find('deprecated', 1, true) then
+          messages[#messages + 1] = n.message
+        end
+      end
+      return messages
+    end
+
     it('warns on use of every deprecated alias', function()
       commands.setup()
       local notifications = capture_notifications()
@@ -516,7 +534,12 @@ describe('commands', function()
       vim.cmd('silent! Ghdiff')
       vim.cmd('silent! Greview ++layout=bogus')
       assert.are.equal(4, count_deprecations(notifications))
-      assert.are.equal(command_deprecation, notifications[1].message)
+      assert.are.same({
+        deprecations.Gdiff,
+        deprecations.Gvdiff,
+        deprecations.Ghdiff,
+        deprecations.Greview,
+      }, deprecation_messages(notifications))
     end)
 
     it('warns again on every repeated use of a deprecated alias', function()


### PR DESCRIPTION
## Problem

The deprecated `:G*` command aliases share one family warning, so users do not get the exact replacement for the alias they invoked or a direct pointer to the migration table.

## Solution

Emit a per-alias warning that names the invoked command, names its exact replacement, and points users to `:help diffs.nvim-deprecated-commands` for the full migration reference.
