### PR TITLE
docs: clarify incomplete syntax context limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ conflict markers automatically. See `:help diffs.nvim-git-mergetool`.
 ## Known Limitations
 
 - **Incomplete syntax context**: Treesitter parses each diff hunk in isolation.
-  Context lines within the hunk provide syntactic context for the parser. In
-  rare cases, hunks that start or end mid-expression may produce imperfect
+  Context lines within the hunk provide syntactic context for the parser. With
+  or without context, hunks that start or end mid-expression may produce imperfect
   highlights due to treesitter error recovery.
 
 - **Syntax "flashing"**: `diffs.nvim` hooks into the `FileType fugitive` event


### PR DESCRIPTION
## Problem

#386 reports that diffs rendered with surrounding context can look worse than the same hunks highlighted in isolation. That is real, but it is expected behavior rather than a bug. Treesitter parses each diff hunk as an isolated fragment and leans on error recovery to highlight it, so a hunk that starts or ends mid-expression can trip that recovery. The surrounding context lines can introduce an error just as easily as they can resolve one, which means enabling context is not a guaranteed improvement. The README, however, implied that imperfect highlights only happened "in rare cases" once context was available.

## Solution

Reword the "Incomplete syntax context" known limitation so it states that imperfect highlights can occur with or without context. This keeps the documented behavior in line with what actually happens and frames the contextual-versus-isolated difference as a known limitation.

Closes #386.
