### PR TITLE
feat(commands): rebuild :Diff review split as a two-pane endpoint diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ highlighting driven by treesitter.
   more!
 - Character-level intra-line diff highlighting
 - Word-level diff highlighting
-- `:Diff` unified diff against any revision
+- `:Diff` for [pierre-style](https://diffs.com) unified, stacked, or split diffs against any revision
 - `:Diff review` full-repo review diff with qflist/loclist navigation
 - Inline merge conflict detection, highlighting, and resolution
 - Email quoting/patch syntax support (`> diff ...`)

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -396,8 +396,8 @@ highlight-only.
     Generated layouts do not enter native Vim `&diff` mode or open writable
     Fugitive object buffers.
 
-    `++layout=split` opens paired old/new endpoint windows with native `&diff`
-    alignment. See |diffs.nvim-paired-windows|.
+    `++layout=split` opens plugin-aligned paired old/new endpoint windows.
+    See |diffs.nvim-paired-windows|.
 
     Prefix with |:vertical| to open the generated `unified` and `stacked`
     layouts in a vertical split (`:vertical Diff`). The modifier is ignored for
@@ -511,12 +511,23 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
 
     `++layout=split` opens a single-file comparison as paired old/new endpoint
     windows: the old/removed endpoint on the left, the new/added endpoint on the
-    right. Endpoint buffers are read-only `diffs://` views; edits happen in
-    real source buffers opened from the view. Native `&diff` aligns rows and the
-    windows are scroll- and cursor-bound, but diff folds are disabled. Changed
-    regions within a line carry the same intra-line word-diff highlighting as
-    generated buffers, honoring `highlights.intra` (including the `vscode`
-    algorithm).
+    right. Endpoint buffers are read-only `diffs://` views holding the real file
+    content of each side; edits happen in real source buffers opened from the
+    view.
+
+    The panes are not native `&diff` windows. They are plugin-rendered: the
+    plugin aligns both sides row-for-row by inserting blank filler rows, then
+    keeps the windows in lockstep with `scrollbind`/`cursorbind`. Because the
+    panes hold real, contiguous file content, treesitter highlights them as the
+    target language. Each changed line is painted with the same palette as
+    generated buffers, so its background is continuous across the gutter and the
+    text, and changed regions within a line carry the same intra-line word-diff
+    highlighting, honoring `highlights.intra` (including the `vscode` algorithm).
+
+    Each pane renders its own side's real line numbers in a `statuscolumn` rail
+    (blank on filler rows), so the rail does not depend on or conflict with a
+    global `number`/`statuscolumn` setting; the originals are restored when the
+    pair closes. Diff folds are disabled.
 
     `q` closes the pair. `:edit` refreshes the same comparison. `]c`/`[c`
     navigate hunks from either side. `<CR>` opens a real worktree file only when
@@ -555,9 +566,10 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     With `++layout=split`, |:Diff-review| opens one review file as a paired
     side-by-side diff instead of the full review map: the old/removed endpoint
     on the left, the new/added endpoint on the right. Both panes are read-only
-    `diffs://` endpoint views aligned with native Vim `&diff` and bound for
-    synchronized scrolling and cursor movement, with the same intra-line
-    word-diff highlighting as generated buffers (see |diffs.nvim-paired-windows|).
+    plugin-rendered `diffs://` endpoint views, row-aligned with filler rows and
+    bound for synchronized scrolling and cursor movement, with the same line and
+    intra-line word-diff highlighting as generated buffers
+    (see |diffs.nvim-paired-windows|).
 
     In split layout, the quickfix list remains the repo-wide review file index
     and the location list is the active file's hunk index. Selecting a quickfix

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -513,13 +513,10 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     windows: the old/removed endpoint on the left, the new/added endpoint on the
     right. Endpoint buffers are read-only `diffs://` views; edits happen in
     real source buffers opened from the view. Native `&diff` aligns rows and the
-    windows are scroll- and cursor-bound, but diff folds are disabled. Native
-    diff coloring is suppressed; the panes are painted with the same palette as
-    generated buffers, so each changed line gets a continuous background across
-    its gutter (change bar, line-number rail) and text, plus the intra-line
-    word-diff highlighting that honors `highlights.intra` (including the
-    `vscode` algorithm). Each pane shows its own side's line numbers. A custom
-    `statuscolumn` that paints its own background is left as-is.
+    windows are scroll- and cursor-bound, but diff folds are disabled. Changed
+    regions within a line carry the same intra-line word-diff highlighting as
+    generated buffers, honoring `highlights.intra` (including the `vscode`
+    algorithm).
 
     `q` closes the pair. `:edit` refreshes the same comparison. `]c`/`[c`
     navigate hunks from either side. `<CR>` opens a real worktree file only when

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -510,9 +510,13 @@ Stacked generated layout: ~                        *diffs.nvim-stacked-layout*
 Paired-window behavior: ~                          *diffs.nvim-paired-windows*
 
     `++layout=split` opens a single-file comparison as paired old/new endpoint
-    windows. Endpoint buffers are read-only `diffs://` views; edits happen in
-    real source buffers opened from the view. Native `&diff` aligns rows, but
-    diff folds are disabled.
+    windows: the old/removed endpoint on the left, the new/added endpoint on the
+    right. Endpoint buffers are read-only `diffs://` views; edits happen in
+    real source buffers opened from the view. Native `&diff` aligns rows and the
+    windows are scroll- and cursor-bound, but diff folds are disabled. Changed
+    regions within a line carry the same intra-line word-diff highlighting as
+    generated buffers, honoring `highlights.intra` (including the `vscode`
+    algorithm).
 
     `q` closes the pair. `:edit` refreshes the same comparison. `]c`/`[c`
     navigate hunks from either side. `<CR>` opens a real worktree file only when
@@ -548,17 +552,19 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     already exists in the current tabpage, the new diff replaces its buffer
     instead of creating another split.
 
-    With `++layout=split`, |:Diff-review| opens a two-surface review workspace
-    instead of the full review map. The left window is a read-only generated
-    diff for one review file. The right window is the real editable worktree
-    file when possible; otherwise it is a read-only tree or index target.
+    With `++layout=split`, |:Diff-review| opens one review file as a paired
+    side-by-side diff instead of the full review map: the old/removed endpoint
+    on the left, the new/added endpoint on the right. Both panes are read-only
+    `diffs://` endpoint views aligned with native Vim `&diff` and bound for
+    synchronized scrolling and cursor movement, with the same intra-line
+    word-diff highlighting as generated buffers (see |diffs.nvim-paired-windows|).
 
     In split layout, the quickfix list remains the repo-wide review file index
-    and the location list is the active file's hunk index. Selecting quickfix
-    or location-list entries with the |diffs.nvim| mapped <CR> updates the
-    existing workspace. Saving the right-side worktree buffer refreshes the
-    generated diff on the left. Native Vim `&diff` mode is not used for
-    |:Diff-review| split workspaces, and the windows are not scroll-bound.
+    and the location list is the active file's hunk index. Selecting a quickfix
+    entry with the |diffs.nvim| mapped <CR> swaps the displayed pair to that
+    file in place, reusing the two windows; the review file index is preserved.
+    `]c`/`[c` navigate hunks within the active file across both panes, and `q`
+    closes the pair.
 
     Prefix with |:vertical| to open the generated `unified` and `stacked`
     review maps in a vertical split (`:vertical Diff review`). As with |:Diff|,
@@ -570,8 +576,8 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
                        old and new line-number rails.
         ++layout=stacked (optional) Open a generated review map with one
                        context-aware line-number rail.
-        ++layout=split (optional) Open the two-surface split workspace for the
-                       first renderable changed review file.
+        ++layout=split (optional) Open the first renderable changed review file
+                       as a paired side-by-side endpoint diff.
         {review-spec}  (string, optional) One of:
                        - empty: review current repo state against the repo
                          default branch
@@ -616,7 +622,7 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
 
     Utilities: ~
         `require('diffs.commands').greview_split()` opens the currently
-        selected |:Diff-review| file in the same two-surface split workspace used
+        selected |:Diff-review| file in the same paired side-by-side diff used
         by `:Diff review ++layout=split`. It uses the review buffer cursor,
         quickfix item, or loclist item as the file selection, and the review
         quickfix list remains the authoritative file list.
@@ -662,10 +668,9 @@ MAPPINGS                                                 *diffs.nvim-mappings*
 
                                             *<Plug>(diffs-greview-open-split)*
 <Plug>(diffs-greview-open-split)
-                        Open the currently selected |:Diff-review| file in a
-                        two-surface split workspace: generated per-file diff on
-                        the left, editable worktree or read-only target view on
-                        the right.
+                        Open the currently selected |:Diff-review| file as a
+                        paired side-by-side diff: the old/removed endpoint on
+                        the left, the new/added endpoint on the right.
 
 Example configuration: >lua
     vim.keymap.set('n', '<leader>gd', '<Plug>(diffs-gdiff)')

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -513,10 +513,13 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     windows: the old/removed endpoint on the left, the new/added endpoint on the
     right. Endpoint buffers are read-only `diffs://` views; edits happen in
     real source buffers opened from the view. Native `&diff` aligns rows and the
-    windows are scroll- and cursor-bound, but diff folds are disabled. Changed
-    regions within a line carry the same intra-line word-diff highlighting as
-    generated buffers, honoring `highlights.intra` (including the `vscode`
-    algorithm).
+    windows are scroll- and cursor-bound, but diff folds are disabled. Native
+    diff coloring is suppressed; the panes are painted with the same palette as
+    generated buffers, so each changed line gets a continuous background across
+    its gutter (change bar, line-number rail) and text, plus the intra-line
+    word-diff highlighting that honors `highlights.intra` (including the
+    `vscode` algorithm). Each pane shows its own side's line numbers. A custom
+    `statuscolumn` that paints its own background is left as-is.
 
     `q` closes the pair. `:edit` refreshes the same comparison. `]c`/`[c`
     navigate hunks from either side. `<CR>` opens a real worktree file only when

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -1090,17 +1090,16 @@ end
 ---@param selected diffs.GeneratedFileSelection
 ---@return boolean
 local function switch_review_split_file(state, selected)
-  if
-    not vim.api.nvim_win_is_valid(state.left_win)
-    or not vim.api.nvim_win_is_valid(state.right_win)
-  then
-    return false
-  end
-
   local diff_spec, diff_lines, err, level =
     render_review_file_selection(state.review, state.repo_root, selected)
   if not diff_spec or not diff_lines then
     notify(err or 'cannot render review split file', level or vim.log.levels.WARN)
+    return false
+  end
+
+  local left_win = first_window_for_buffer(state.left_buf)
+  local right_win = first_window_for_buffer(state.right_buf)
+  if not left_win or not right_win then
     return false
   end
 
@@ -1113,7 +1112,7 @@ local function switch_review_split_file(state, selected)
     change_bar = runtime.get_view_config().change_bar,
     title = 'review: ' .. state.display,
     hunk_index = selected.hunk_index or 1,
-    reuse_wins = { left = state.left_win, right = state.right_win },
+    reuse_wins = { left = left_win, right = right_win },
   })
   if not opened then
     notify(split_err or 'cannot open review split', vim.log.levels.ERROR)

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -17,8 +17,8 @@ local split = require('diffs.split')
 
 local dbg = log.dbg
 local notify = log.notify
-local greview_workspace_group =
-  vim.api.nvim_create_augroup('diffs_greview_workspace', { clear = false })
+local review_split_group =
+  vim.api.nvim_create_augroup('diffs_review_split', { clear = false })
 
 ---@class diffs.HunkKeymap
 ---@field mode string
@@ -30,25 +30,23 @@ local hunk_keymaps = {}
 ---@type table<integer, integer>
 local hunk_keymap_autocmds = {}
 
----@class diffs.GreviewWorkspaceState
----@field diff_buf integer
----@field diff_win integer?
----@field target_buf integer?
----@field target_win integer?
----@field target_scratch boolean
+---@class diffs.ReviewSplitState
+---@field left_buf integer
+---@field right_buf integer
+---@field left_win integer
+---@field right_win integer
 ---@field review diffs.GreviewSpec
----@field display string
 ---@field repo_root string
+---@field display string
 ---@field review_lines string[]
 ---@field list_opts table?
+---@field selected_file string
 ---@field selected_key string?
----@field selected_file string?
----@field selected_diff_spec diffs.DiffSpec?
----@field selected_hunk_index integer?
+---@field selected_diff_spec diffs.DiffSpec
 ---@field autocmds integer[]
 
----@type table<integer, diffs.GreviewWorkspaceState>
-local greview_workspaces = {}
+---@type table<integer, diffs.ReviewSplitState>
+local review_split_states = {}
 
 ---@param bufnr integer
 ---@param mode string
@@ -542,16 +540,6 @@ local function render_source(source)
     return review_lines, nil, 'review', list_opts
   end
 
-  if source.kind == 'review_file' then
-    local diff_lines, read_err = render.file(source.spec, source.repo_root, {
-      empty_on_missing = true,
-    })
-    if not diff_lines then
-      return nil, nil, read_err, nil
-    end
-    return diff_lines, source.spec, 'review:' .. (source.selected_key or source.path), nil
-  end
-
   local abs_path = source.repo_root .. '/' .. source.path
   local old_lines = git.get_file_content(':2', abs_path) or {}
   local new_lines = git.get_file_content(':3', abs_path) or {}
@@ -819,7 +807,7 @@ local function complete_diff_command(arglead, cmdline, cursorpos)
 end
 
 ---@type fun(spec?: diffs.GreviewSpec, opts?: { selection?: diffs.GeneratedFileSelection, replace_win?: integer }): integer?
-local open_greview_workspace
+local open_review_split
 
 ---@param args? string
 ---@param vertical? boolean
@@ -837,7 +825,7 @@ function M.greview_command(args, vertical, opts)
     if opts.warn_vertical_split then
       warn_vertical_split_ignored()
     end
-    return open_greview_workspace(parsed.spec)
+    return open_review_split(parsed.spec)
   end
 
   parsed.spec.vertical = vertical or false
@@ -975,349 +963,6 @@ local function selected_review_diff_spec(review_spec, repo_root, selected)
   return review.diff_spec_for_file(review_spec, repo_root, selected.file, selected)
 end
 
----@param state diffs.GreviewWorkspaceState
-local function clear_greview_workspace_autocmds(state)
-  for _, id in ipairs(state.autocmds or {}) do
-    pcall(vim.api.nvim_del_autocmd, id)
-  end
-  state.autocmds = {}
-end
-
----@param bufnr integer
-local function close_greview_workspace(bufnr)
-  local state = greview_workspaces[bufnr]
-  if not state then
-    pcall(vim.api.nvim_win_close, 0, true)
-    return
-  end
-
-  clear_greview_workspace_autocmds(state)
-  greview_workspaces[bufnr] = nil
-
-  local focus_win
-  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
-    if vim.api.nvim_win_is_valid(win) then
-      local buf = vim.api.nvim_win_get_buf(win)
-      if buf ~= state.diff_buf and buf ~= state.target_buf then
-        focus_win = win
-        break
-      end
-    end
-  end
-
-  for _, win in ipairs({ state.target_win, state.diff_win }) do
-    if type(win) == 'number' and vim.api.nvim_win_is_valid(win) then
-      pcall(vim.api.nvim_win_close, win, true)
-    end
-  end
-
-  if
-    state.target_scratch
-    and type(state.target_buf) == 'number'
-    and vim.api.nvim_buf_is_valid(state.target_buf)
-  then
-    pcall(vim.api.nvim_buf_delete, state.target_buf, { force = true })
-  end
-  if vim.api.nvim_buf_is_valid(state.diff_buf) then
-    pcall(vim.api.nvim_buf_delete, state.diff_buf, { force = true })
-  end
-
-  if focus_win and vim.api.nvim_win_is_valid(focus_win) then
-    vim.api.nvim_set_current_win(focus_win)
-  elseif #vim.api.nvim_list_wins() > 0 then
-    pcall(vim.cmd.enew)
-  end
-end
-
----@param state diffs.GreviewWorkspaceState
----@param wins table<integer, boolean>
----@return boolean
-local function greview_workspace_visible_in_wins(state, wins)
-  for _, win in ipairs({ state.diff_win, state.target_win }) do
-    if type(win) == 'number' and wins[win] then
-      return true
-    end
-  end
-
-  for win in pairs(wins) do
-    if vim.api.nvim_win_is_valid(win) then
-      local buf = vim.api.nvim_win_get_buf(win)
-      if buf == state.diff_buf or buf == state.target_buf then
-        return true
-      end
-    end
-  end
-  return false
-end
-
----@param display string
-local function close_existing_greview_workspace(display)
-  local current_wins = {}
-  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
-    current_wins[win] = true
-  end
-
-  local to_close = {}
-  for bufnr, state in pairs(greview_workspaces) do
-    if greview_workspace_visible_in_wins(state, current_wins) then
-      to_close[#to_close + 1] = bufnr
-    end
-  end
-  for _, bufnr in ipairs(to_close) do
-    close_greview_workspace(bufnr)
-  end
-
-  local existing_buf = vim.fn.bufnr('diffs://review-split:' .. display)
-  if existing_buf ~= -1 and vim.api.nvim_buf_is_valid(existing_buf) then
-    pcall(vim.api.nvim_buf_delete, existing_buf, { force = true })
-  end
-end
-
----@param win integer
----@param lnum integer
-local function set_window_lnum(win, lnum)
-  if not vim.api.nvim_win_is_valid(win) then
-    return
-  end
-  local bufnr = vim.api.nvim_win_get_buf(win)
-  local line_count = vim.api.nvim_buf_line_count(bufnr)
-  vim.api.nvim_win_set_cursor(win, { math.max(1, math.min(lnum, line_count)), 0 })
-end
-
----@param hunk diffs.GdiffHunk
----@return integer
-local function hunk_right_lnum(hunk)
-  local range = hunk.new_range
-  return math.max(1, range and range.start or 1)
-end
-
----@param state diffs.GreviewWorkspaceState
----@return diffs.GdiffHunk[]
-local function greview_workspace_hunks(state)
-  return generated.hunks(state.diff_buf)
-end
-
----@param state diffs.GreviewWorkspaceState
----@param hunk_index integer?
----@return diffs.GdiffHunk?
-local function greview_workspace_hunk(state, hunk_index)
-  local hunks = greview_workspace_hunks(state)
-  return hunks[hunk_index or 1]
-end
-
----@param state diffs.GreviewWorkspaceState
----@param hunk diffs.GdiffHunk?
-local function move_greview_workspace_to_hunk(state, hunk)
-  if not hunk then
-    return
-  end
-
-  local diff_win = type(state.diff_win) == 'number'
-      and vim.api.nvim_win_is_valid(state.diff_win)
-      and state.diff_win
-    or first_window_for_buffer(state.diff_buf)
-  if diff_win then
-    set_window_lnum(diff_win, hunk.buffer_range.start)
-  end
-  if type(state.target_win) == 'number' and vim.api.nvim_win_is_valid(state.target_win) then
-    set_window_lnum(state.target_win, hunk_right_lnum(hunk))
-  end
-  state.selected_hunk_index = hunk.index
-end
-
----@param bufnr integer
----@param direction "next"|"prev"
-local function greview_workspace_goto_hunk(bufnr, direction)
-  local state = greview_workspaces[bufnr]
-  if not state then
-    return
-  end
-
-  local hunks = greview_workspace_hunks(state)
-  if #hunks == 0 then
-    return
-  end
-
-  local diff_win = type(state.diff_win) == 'number'
-      and vim.api.nvim_win_is_valid(state.diff_win)
-      and state.diff_win
-    or first_window_for_buffer(state.diff_buf)
-  local cursor_line = diff_win and vim.api.nvim_win_get_cursor(diff_win)[1] or 1
-  local hunk
-  if direction == 'next' then
-    hunk = hunk_model.next_hunk(hunks, cursor_line) or hunks[1]
-    if hunk == hunks[1] and hunk.buffer_range.start <= cursor_line then
-      notify('wrapped to first hunk', vim.log.levels.INFO)
-    end
-  else
-    hunk = hunk_model.prev_hunk(hunks, cursor_line) or hunks[#hunks]
-    if hunk == hunks[#hunks] and hunk.buffer_range.start >= cursor_line then
-      notify('wrapped to last hunk', vim.log.levels.INFO)
-    end
-  end
-
-  move_greview_workspace_to_hunk(state, hunk)
-end
-
----@param bufnr integer
-local function set_greview_workspace_keymaps(bufnr)
-  vim.keymap.set('n', 'q', function()
-    close_greview_workspace(bufnr)
-  end, { buffer = bufnr, desc = 'Close Greview split workspace' })
-  vim.keymap.set('n', ']c', function()
-    greview_workspace_goto_hunk(bufnr, 'next')
-  end, { buffer = bufnr, desc = 'Next diff hunk' })
-  vim.keymap.set('n', '[c', function()
-    greview_workspace_goto_hunk(bufnr, 'prev')
-  end, { buffer = bufnr, desc = 'Previous diff hunk' })
-end
-
----@param state diffs.GreviewWorkspaceState
----@param selected diffs.GeneratedFileSelection
----@param diff_spec diffs.DiffSpec
----@return diffs.GeneratedBufferSource
-local function review_file_source(state, selected, diff_spec)
-  return generated.review_file_source({
-    repo_root = state.repo_root,
-    review = state.review,
-    review_display = state.display,
-    selected_key = selected.key,
-    selected_file = selected.file,
-    path = selected.file,
-    spec = diff_spec,
-  })
-end
-
----@param bufnr integer
----@param state diffs.GreviewWorkspaceState
----@param selected diffs.GeneratedFileSelection
----@param diff_spec diffs.DiffSpec
----@param diff_lines string[]
-local function replace_review_file_buffer(bufnr, state, selected, diff_spec, diff_lines)
-  set_diff_spec_var(bufnr, diff_spec)
-  generated.set_repo_root(bufnr, state.repo_root)
-  generated.set_source(bufnr, review_file_source(state, selected, diff_spec))
-  replace_generated_diff_buffer_lines(bufnr, diff_lines, diff_spec)
-  lists.set_for_unified_buffer(bufnr, diff_lines, {
-    title = 'review: ' .. (selected.key or selected.file),
-    loclist_title = 'review hunks: ' .. (selected.key or selected.file),
-    diff_spec = diff_spec,
-    quickfix = false,
-  })
-  M.setup_diff_buf(bufnr)
-  set_greview_workspace_keymaps(bufnr)
-  runtime.attach(bufnr)
-end
-
----@param repo_root string
----@param path string
----@return string
-local function worktree_path(repo_root, path)
-  return repo_root .. '/' .. path
-end
-
----@param endpoint diffs.Endpoint
----@return string
-local function endpoint_name(endpoint)
-  endpoint = diffspec.endpoint(endpoint)
-  if endpoint.kind == diffspec.endpoint_kind.tree then
-    return endpoint.rev
-  end
-  return endpoint.kind
-end
-
----@param lines diffs.ContentLines|string[]
----@return string[]
-local function plain_lines(lines)
-  local result = {}
-  for i, line in ipairs(lines or {}) do
-    result[i] = line
-  end
-  return result
-end
-
----@param state diffs.GreviewWorkspaceState
----@return integer
-local function ensure_target_window(state)
-  if type(state.target_win) == 'number' and vim.api.nvim_win_is_valid(state.target_win) then
-    return state.target_win
-  end
-
-  local diff_win = type(state.diff_win) == 'number'
-      and vim.api.nvim_win_is_valid(state.diff_win)
-      and state.diff_win
-    or first_window_for_buffer(state.diff_buf)
-  if diff_win then
-    vim.api.nvim_set_current_win(diff_win)
-  end
-  vim.cmd('rightbelow vsplit')
-  state.target_win = vim.api.nvim_get_current_win()
-  return state.target_win
-end
-
----@param state diffs.GreviewWorkspaceState
----@param diff_spec diffs.DiffSpec
----@param selected diffs.GeneratedFileSelection
----@return boolean
-local function open_workspace_target(state, diff_spec, selected)
-  local target_win = ensure_target_window(state)
-  local previous_win = vim.api.nvim_get_current_win()
-  vim.api.nvim_set_current_win(target_win)
-  pcall(vim.api.nvim_set_option_value, 'diff', false, { win = target_win })
-
-  local target = diffspec.endpoint(diff_spec.right)
-  local path = worktree_path(state.repo_root, selected.file)
-  local previous_target_buf = state.target_buf
-  local previous_target_scratch = state.target_scratch
-
-  if target.kind == diffspec.endpoint_kind.worktree and vim.fn.filereadable(path) == 1 then
-    vim.cmd.edit(vim.fn.fnameescape(path))
-    state.target_buf = vim.api.nvim_get_current_buf()
-    state.target_scratch = false
-    if
-      previous_target_scratch
-      and type(previous_target_buf) == 'number'
-      and previous_target_buf ~= state.target_buf
-      and vim.api.nvim_buf_is_valid(previous_target_buf)
-    then
-      pcall(vim.api.nvim_buf_delete, previous_target_buf, { force = true })
-    end
-  else
-    local lines, err = render.read_endpoint(target, path, { empty_on_missing = true })
-    if not lines then
-      notify(err or 'cannot read review target', vim.log.levels.WARN)
-      restore_window(previous_win)
-      return false
-    end
-    local target_buf = previous_target_scratch and previous_target_buf or nil
-    if type(target_buf) ~= 'number' or not vim.api.nvim_buf_is_valid(target_buf) then
-      target_buf = vim.api.nvim_create_buf(false, true)
-    end
-    local target_name = 'diffs://review-target:' .. endpoint_name(target) .. ':' .. selected.file
-    local existing = vim.fn.bufnr(target_name)
-    if existing ~= -1 and existing ~= target_buf and vim.api.nvim_buf_is_valid(existing) then
-      pcall(vim.api.nvim_buf_delete, existing, { force = true })
-    end
-    vim.api.nvim_set_option_value('modifiable', true, { buf = target_buf })
-    vim.api.nvim_buf_set_lines(target_buf, 0, -1, false, plain_lines(lines))
-    vim.api.nvim_buf_set_name(target_buf, target_name)
-    vim.api.nvim_set_option_value('buftype', 'nowrite', { buf = target_buf })
-    vim.api.nvim_set_option_value('bufhidden', 'delete', { buf = target_buf })
-    vim.api.nvim_set_option_value('swapfile', false, { buf = target_buf })
-    vim.api.nvim_set_option_value('modifiable', false, { buf = target_buf })
-    local ft = filetype_for_path(state.repo_root, selected.file)
-    if ft then
-      vim.api.nvim_set_option_value('filetype', ft, { buf = target_buf })
-    end
-    vim.api.nvim_win_set_buf(target_win, target_buf)
-    state.target_buf = target_buf
-    state.target_scratch = true
-  end
-
-  restore_window(previous_win)
-  return true
-end
-
 ---@param review_spec diffs.GreviewSpec
 ---@param repo_root string
 ---@param selected diffs.GeneratedFileSelection
@@ -1397,154 +1042,144 @@ local function review_selection_from_item(item)
   }
 end
 
-local attach_greview_workspace_autocmds
-local refresh_greview_workspace_after_write
-
----@param state diffs.GreviewWorkspaceState
----@param selected diffs.GeneratedFileSelection
----@param opts? { restore_focus?: boolean, restore_win?: integer, refresh_index?: boolean }
----@return boolean
-local function show_greview_workspace_selection(state, selected, opts)
-  opts = opts or {}
-  local restore_win = opts.restore_win or vim.api.nvim_get_current_win()
-  local diff_spec, _, spec_err = selected_review_diff_spec(state.review, state.repo_root, selected)
-  if not diff_spec then
-    notify(spec_err or 'cannot build Greview split diff spec', vim.log.levels.ERROR)
-    return false
+---@param state diffs.ReviewSplitState
+local function clear_review_split_autocmds(state)
+  for _, id in ipairs(state.autocmds or {}) do
+    pcall(vim.api.nvim_del_autocmd, id)
   end
-
-  local diff_lines, render_err =
-    render.file(diff_spec, state.repo_root, { empty_on_missing = true })
-  if not diff_lines then
-    notify(render_err or 'cannot render Greview split file', vim.log.levels.ERROR)
-    return false
-  end
-
-  replace_review_file_buffer(state.diff_buf, state, selected, diff_spec, diff_lines)
-  if opts.refresh_index then
-    lists.set_review_workspace_quickfix(state.diff_buf, state.review_lines, {
-      title = 'review: ' .. state.display,
-      loclist_title = 'review hunks: ' .. state.display,
-      metadata_for_line = state.list_opts and state.list_opts.metadata_for_line,
-      sections = state.list_opts and state.list_opts.sections,
-      store_hunks = state.list_opts and state.list_opts.store_hunks,
-    })
-  end
-
-  local hunk = greview_workspace_hunk(state, selected.hunk_index)
-  if not open_workspace_target(state, diff_spec, selected) then
-    return false
-  end
-  state.selected_key = selected.key or selected.file
-  state.selected_file = selected.file
-  state.selected_diff_spec = diff_spec
-  state.selected_hunk_index = selected.hunk_index
-  move_greview_workspace_to_hunk(state, hunk)
-  attach_greview_workspace_autocmds(state)
-
-  if opts.restore_focus then
-    restore_window(restore_win)
-  elseif type(state.diff_win) == 'number' and vim.api.nvim_win_is_valid(state.diff_win) then
-    vim.api.nvim_set_current_win(state.diff_win)
-  end
-  return true
+  state.autocmds = {}
 end
 
----@param state diffs.GreviewWorkspaceState
-local function refresh_greview_workspace_index(state)
-  local normalized, normalize_err = review.normalize(state.review, state.repo_root)
-  if not normalized then
-    notify(normalize_err or 'cannot normalize Greview split', vim.log.levels.WARN)
-    return
-  end
-  local review_lines, render_err, list_opts = review.render(normalized, review_deps())
-  if not review_lines then
-    notify(render_err or 'cannot refresh Greview split', vim.log.levels.WARN)
-    return
-  end
-  state.review_lines = review_lines
-  state.list_opts = list_opts
-  lists.set_review_workspace_quickfix(state.diff_buf, review_lines, {
+---@param state diffs.ReviewSplitState
+local function forget_review_split(state)
+  clear_review_split_autocmds(state)
+  review_split_states[state.left_buf] = nil
+  review_split_states[state.right_buf] = nil
+end
+
+---@param state diffs.ReviewSplitState
+local function review_split_quickfix(state)
+  lists.set_review_workspace_quickfix(state.left_buf, state.review_lines, {
     title = 'review: ' .. state.display,
     loclist_title = 'review hunks: ' .. state.display,
-    metadata_for_line = list_opts and list_opts.metadata_for_line,
-    sections = list_opts and list_opts.sections,
-    store_hunks = list_opts and list_opts.store_hunks,
+    metadata_for_line = state.list_opts and state.list_opts.metadata_for_line,
+    sections = state.list_opts and state.list_opts.sections,
+    store_hunks = state.list_opts and state.list_opts.store_hunks,
   })
 end
 
----@param state diffs.GreviewWorkspaceState
-attach_greview_workspace_autocmds = function(state)
-  clear_greview_workspace_autocmds(state)
-  state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd('BufWipeout', {
-    group = greview_workspace_group,
-    buffer = state.diff_buf,
-    once = true,
-    callback = function(args)
-      local current = greview_workspaces[args.buf]
-      if current then
-        clear_greview_workspace_autocmds(current)
-        greview_workspaces[args.buf] = nil
-      end
-    end,
-  })
-  if
-    type(state.target_buf) == 'number'
-    and vim.api.nvim_buf_is_valid(state.target_buf)
-    and not state.target_scratch
-  then
-    local diff_buf = state.diff_buf
-    state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd('BufWritePost', {
-      group = greview_workspace_group,
-      buffer = state.target_buf,
+---@param state diffs.ReviewSplitState
+local function attach_review_split_autocmds(state)
+  clear_review_split_autocmds(state)
+  for _, buf in ipairs({ state.left_buf, state.right_buf }) do
+    state.autocmds[#state.autocmds + 1] = vim.api.nvim_create_autocmd('BufWipeout', {
+      group = review_split_group,
+      buffer = buf,
+      once = true,
       callback = function()
-        refresh_greview_workspace_after_write(diff_buf)
+        local current = review_split_states[buf]
+        if current then
+          forget_review_split(current)
+        end
       end,
     })
   end
 end
 
-refresh_greview_workspace_after_write = function(diff_buf)
-  local state = greview_workspaces[diff_buf]
-  if not state or not state.selected_file then
-    return
+---@param state diffs.ReviewSplitState
+---@param selected diffs.GeneratedFileSelection
+---@return boolean
+local function switch_review_split_file(state, selected)
+  if
+    not vim.api.nvim_win_is_valid(state.left_win)
+    or not vim.api.nvim_win_is_valid(state.right_win)
+  then
+    return false
   end
-  refresh_greview_workspace_index(state)
-  show_greview_workspace_selection(state, {
-    bufnr = state.diff_buf,
-    file = state.selected_file,
-    key = state.selected_key,
-    diff_spec = state.selected_diff_spec,
-    hunk_index = state.selected_hunk_index,
-  }, { restore_focus = true, refresh_index = false })
+
+  local diff_spec, diff_lines, err, level =
+    render_review_file_selection(state.review, state.repo_root, selected)
+  if not diff_spec or not diff_lines then
+    notify(err or 'cannot render review split file', level or vim.log.levels.WARN)
+    return false
+  end
+
+  local opened, split_err = split.open({
+    spec = diff_spec,
+    repo_root = state.repo_root,
+    filetype = filetype_for_path(state.repo_root, selected.file),
+    diff_lines = diff_lines,
+    quickfix = false,
+    change_bar = runtime.get_view_config().change_bar,
+    title = 'review: ' .. state.display,
+    hunk_index = selected.hunk_index or 1,
+    reuse_wins = { left = state.left_win, right = state.right_win },
+  })
+  if not opened then
+    notify(split_err or 'cannot open review split', vim.log.levels.ERROR)
+    return false
+  end
+
+  forget_review_split(state)
+  state.left_buf = opened.left_buf
+  state.right_buf = opened.right_buf
+  state.left_win = opened.left_win
+  state.right_win = opened.right_win
+  state.selected_file = selected.file
+  state.selected_key = selected.key or selected.file
+  state.selected_diff_spec = diff_spec
+  review_split_states[state.left_buf] = state
+  review_split_states[state.right_buf] = state
+  review_split_quickfix(state)
+  attach_review_split_autocmds(state)
+  return true
 end
 
-local function refresh_greview_jump_callback()
+local function register_review_split_jump()
   lists.set_generated_jump_callback(function(item)
     local selected = review_selection_from_item(item)
     if not selected or type(selected.bufnr) ~= 'number' then
       return
     end
-    local state = greview_workspaces[selected.bufnr]
+    local state = review_split_states[selected.bufnr]
     if not state then
       return
     end
     vim.schedule(function()
-      show_greview_workspace_selection(state, selected, {
-        restore_focus = true,
-        restore_win = vim.api.nvim_get_current_win(),
-      })
+      if review_split_states[selected.bufnr] == state then
+        switch_review_split_file(state, selected)
+      end
     end)
   end)
 end
 
-open_greview_workspace = function(spec, opts)
+local function close_existing_review_splits()
+  ---@type table<diffs.ReviewSplitState, boolean>
+  local seen = {}
+  for _, state in pairs(review_split_states) do
+    if not seen[state] then
+      seen[state] = true
+      forget_review_split(state)
+      if vim.api.nvim_buf_is_valid(state.left_buf) then
+        split.close_pair(state.left_buf)
+      elseif vim.api.nvim_buf_is_valid(state.right_buf) then
+        split.close_pair(state.right_buf)
+      end
+    end
+  end
+end
+
+---@param spec diffs.GreviewSpec?
+---@param opts? { selection?: diffs.GeneratedFileSelection, replace_win?: integer }
+---@return integer?
+open_review_split = function(spec, opts)
   opts = opts or {}
   local normalized, normalize_err = review.normalize(spec)
   if not normalized then
     notify(normalize_err, vim.log.levels.ERROR)
     return nil
   end
+
   local review_lines, render_err, list_opts = review.render(normalized, review_deps())
   if not review_lines then
     notify(render_err, vim.log.levels.ERROR)
@@ -1557,14 +1192,13 @@ open_greview_workspace = function(spec, opts)
 
   local review_spec = stored_review_spec(normalized)
   local first = opts.selection
-  local diff_spec
-  local diff_lines
+  local diff_spec, diff_lines
   if first then
     local err, level
     diff_spec, diff_lines, err, level =
       render_review_file_selection(review_spec, normalized.repo_root, first)
     if not diff_spec or not diff_lines then
-      notify(err or 'cannot render Greview split file', level or vim.log.levels.ERROR)
+      notify(err or 'cannot render review split file', level or vim.log.levels.ERROR)
       return nil
     end
   else
@@ -1572,93 +1206,62 @@ open_greview_workspace = function(spec, opts)
     first, diff_spec, diff_lines, err, level =
       first_renderable_review_file(review_spec, normalized.repo_root, review_lines, list_opts)
     if not first or not diff_spec or not diff_lines then
-      notify(err or 'no Greview file selected', level or vim.log.levels.INFO)
+      notify(err or 'no review file selected', level or vim.log.levels.INFO)
       return nil
     end
-  end
-  if not first then
-    notify('no Greview file selected', vim.log.levels.INFO)
-    return nil
   end
 
   local restore_win = vim.api.nvim_get_current_win()
-  close_existing_greview_workspace(normalized.display)
-  local replace_win = opts.replace_win
-  if type(replace_win) == 'number' then
-    if not vim.api.nvim_win_is_valid(replace_win) then
-      notify('Greview split replacement window is no longer valid', vim.log.levels.WARN)
+  close_existing_review_splits()
+  if type(opts.replace_win) == 'number' then
+    if not vim.api.nvim_win_is_valid(opts.replace_win) then
+      notify('review split replacement window is no longer valid', vim.log.levels.WARN)
       return nil
     end
-    vim.api.nvim_set_current_win(replace_win)
+    vim.api.nvim_set_current_win(opts.replace_win)
   else
     restore_window(restore_win)
   end
 
-  local diff_buf = create_generated_diff_buffer({
-    name = 'diffs://review-split:' .. normalized.display,
-    lines = diff_lines,
+  local opened, split_err = split.open({
+    spec = diff_spec,
     repo_root = normalized.repo_root,
-    diff_spec = diff_spec,
-    source = generated.review_file_source({
-      repo_root = normalized.repo_root,
-      review = review_spec,
-      review_display = normalized.display,
-      selected_key = first.key,
-      selected_file = first.file,
-      path = first.file,
-      spec = diff_spec,
-    }),
-  })
-
-  local diff_win = vim.api.nvim_get_current_win()
-  clear_generated_diff_window_bindings(diff_win)
-  pcall(vim.api.nvim_set_option_value, 'diff', false, { win = diff_win })
-  vim.api.nvim_win_set_buf(diff_win, diff_buf)
-  local state = {
-    diff_buf = diff_buf,
-    diff_win = diff_win,
-    review = review_spec,
-    display = normalized.display,
-    repo_root = normalized.repo_root,
-    review_lines = review_lines,
-    list_opts = list_opts,
-    selected_key = first.key or first.file,
-    selected_file = first.file,
-    selected_diff_spec = diff_spec,
-    selected_hunk_index = first.hunk_index,
-    target_scratch = false,
-    autocmds = {},
-  }
-  greview_workspaces[diff_buf] = state
-
-  lists.set_review_workspace_quickfix(diff_buf, review_lines, {
-    title = 'review: ' .. normalized.display,
-    loclist_title = 'review hunks: ' .. normalized.display,
-    metadata_for_line = list_opts and list_opts.metadata_for_line,
-    sections = list_opts and list_opts.sections,
-    store_hunks = list_opts and list_opts.store_hunks,
-  })
-  lists.set_for_unified_buffer(diff_buf, diff_lines, {
-    title = 'review: ' .. (first.key or first.file),
-    loclist_title = 'review hunks: ' .. (first.key or first.file),
-    diff_spec = diff_spec,
+    filetype = filetype_for_path(normalized.repo_root, first.file),
+    diff_lines = diff_lines,
     quickfix = false,
+    change_bar = runtime.get_view_config().change_bar,
+    title = 'review: ' .. normalized.display,
+    hunk_index = first.hunk_index or 1,
   })
-  attach_generated_diff_buffer(diff_buf)
-  set_greview_workspace_keymaps(diff_buf)
-  refresh_greview_jump_callback()
-  if not open_workspace_target(state, diff_spec, first) then
-    close_greview_workspace(diff_buf)
+  if not opened then
+    notify(split_err or 'cannot open review split', vim.log.levels.ERROR)
     return nil
   end
-  move_greview_workspace_to_hunk(state, greview_workspace_hunk(state, first.hunk_index))
-  attach_greview_workspace_autocmds(state)
 
-  if diff_win and vim.api.nvim_win_is_valid(diff_win) then
-    vim.api.nvim_set_current_win(diff_win)
-  end
+  ---@type diffs.ReviewSplitState
+  local state = {
+    left_buf = opened.left_buf,
+    right_buf = opened.right_buf,
+    left_win = opened.left_win,
+    right_win = opened.right_win,
+    review = review_spec,
+    repo_root = normalized.repo_root,
+    display = normalized.display,
+    review_lines = review_lines,
+    list_opts = list_opts,
+    selected_file = first.file,
+    selected_key = first.key or first.file,
+    selected_diff_spec = diff_spec,
+    autocmds = {},
+  }
+  review_split_states[opened.left_buf] = state
+  review_split_states[opened.right_buf] = state
+  review_split_quickfix(state)
+  register_review_split_jump()
+  attach_review_split_autocmds(state)
 
-  return diff_buf
+  dbg('opened review split %d/%d (%s)', opened.left_buf, opened.right_buf, normalized.display)
+  return opened.left_buf
 end
 
 ---@param opts? diffs.GreviewSplitOpts
@@ -1668,7 +1271,7 @@ function M.greview_split(opts)
   local context, err, level = greview_split_context(opts)
   if not context then
     restore_window(restore_win)
-    notify(err or 'cannot open Greview split', level or vim.log.levels.WARN)
+    notify(err or 'cannot open review split', level or vim.log.levels.WARN)
     return nil
   end
 
@@ -1677,7 +1280,7 @@ function M.greview_split(opts)
     restore_window(restore_win)
     notify(
       source_err and ('invalid diffs_source metadata: ' .. tostring(source_err))
-        or 'selected file is not from a Greview buffer',
+        or 'selected file is not from a review buffer',
       vim.log.levels.WARN
     )
     return nil
@@ -1685,7 +1288,7 @@ function M.greview_split(opts)
 
   local review_spec = vim.deepcopy(source.review)
   review_spec.repo = context.repo_root
-  return open_greview_workspace(review_spec, {
+  return open_review_split(review_spec, {
     selection = context.selected,
     replace_win = context.replace_win,
   })
@@ -2105,40 +1708,6 @@ function M.read_buffer(bufnr)
     debug_label = debug_label or ((label or '?') .. ':' .. (path or '?'))
   end
 
-  if source and source.kind == 'review_file' then
-    local state = greview_workspaces[bufnr]
-    if state then
-      local selected_file = source.selected_file or source.path
-      if not selected_file then
-        notify('cannot reload Greview split buffer without selected file', vim.log.levels.WARN)
-        return
-      end
-      refresh_greview_workspace_index(state)
-      show_greview_workspace_selection(state, {
-        bufnr = bufnr,
-        file = selected_file,
-        key = source.selected_key or selected_file,
-        diff_spec = state.selected_diff_spec or source.spec,
-        hunk_index = state.selected_hunk_index,
-      }, { restore_focus = true, refresh_index = false })
-      dbg('reloaded Greview split buffer %d (%s)', bufnr, debug_label)
-      return
-    end
-
-    replace_generated_diff_buffer_lines(bufnr, diff_lines, stored_spec)
-    lists.set_for_unified_buffer(bufnr, diff_lines, {
-      title = 'review: ' .. (source.selected_key or source.path),
-      loclist_title = 'review hunks: ' .. (source.selected_key or source.path),
-      diff_spec = stored_spec,
-      quickfix = false,
-    })
-    M.setup_diff_buf(bufnr)
-    set_greview_workspace_keymaps(bufnr)
-    dbg('reloaded Greview split buffer %d (%s)', bufnr, debug_label)
-    runtime.attach(bufnr)
-    return
-  end
-
   replace_generated_diff_buffer_lines(bufnr, diff_lines, stored_spec)
   lists.set_for_unified_buffer(bufnr, diff_lines, {
     title = 'diff: ' .. (debug_label or name:gsub('^diffs://', '')),
@@ -2215,9 +1784,8 @@ M._test = {
   create_generated_diff_buffer = create_generated_diff_buffer,
   gdiff_buffer_label = gdiff_buffer_label,
   replace_generated_diff_buffer_lines = replace_generated_diff_buffer_lines,
-  close_greview_workspace = close_greview_workspace,
-  greview_workspace_state = function(bufnr)
-    return greview_workspaces[bufnr]
+  review_split_state = function(bufnr)
+    return review_split_states[bufnr]
   end,
   normalize_greview = review.normalize,
   parse_greview_command = review.parse_command_args,

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -17,8 +17,7 @@ local split = require('diffs.split')
 
 local dbg = log.dbg
 local notify = log.notify
-local review_split_group =
-  vim.api.nvim_create_augroup('diffs_review_split', { clear = false })
+local review_split_group = vim.api.nvim_create_augroup('diffs_review_split', { clear = false })
 
 ---@class diffs.HunkKeymap
 ---@field mode string
@@ -1027,7 +1026,12 @@ local function review_selection_from_item(item)
     return nil
   end
   local data = item.user_data.diffs
-  if type(data) ~= 'table' or data.kind ~= 'file' or type(data.file) ~= 'string' or data.file == '' then
+  if
+    type(data) ~= 'table'
+    or data.kind ~= 'file'
+    or type(data.file) ~= 'string'
+    or data.file == ''
+  then
     return nil
   end
   return {

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -1027,7 +1027,7 @@ local function review_selection_from_item(item)
     return nil
   end
   local data = item.user_data.diffs
-  if type(data) ~= 'table' or type(data.file) ~= 'string' or data.file == '' then
+  if type(data) ~= 'table' or data.kind ~= 'file' or type(data.file) ~= 'string' or data.file == '' then
     return nil
   end
   return {

--- a/lua/diffs/generated/source.lua
+++ b/lua/diffs/generated/source.lua
@@ -84,7 +84,7 @@ end
 
 ---@class diffs.GeneratedBufferSource
 ---@field version integer
----@field kind "file"|"file_pair"|"section"|"review"|"review_file"|"unmerged"|"split_endpoint"
+---@field kind "file"|"file_pair"|"section"|"review"|"unmerged"|"split_endpoint"
 ---@field repo_root string
 ---@field spec? diffs.DiffSpec
 ---@field edge? "staged"|"unstaged"
@@ -92,9 +92,6 @@ end
 ---@field old_path? string
 ---@field section? "staged"|"unstaged"
 ---@field review? diffs.GreviewSpec
----@field review_display? string
----@field selected_key? string
----@field selected_file? string
 ---@field working_path? string
 ---@field side? "left"|"right"
 ---@field filetype? string
@@ -146,17 +143,6 @@ function M.normalize_source(source)
   elseif source.kind == 'review' then
     if type(source.review) ~= 'table' then
       error('expected review spec')
-    end
-  elseif source.kind == 'review_file' then
-    if type(source.review) ~= 'table' then
-      error('expected review file spec')
-    end
-    if source.spec == nil then
-      error('expected review file diff spec')
-    end
-    source.spec = diffspec.new(source.spec)
-    if type(source.path) ~= 'string' or source.path == '' then
-      error('expected review file path')
     end
   elseif source.kind == 'unmerged' then
     if type(source.path) ~= 'string' or source.path == '' then
@@ -254,22 +240,6 @@ function M.review_source(repo_root, review)
     kind = 'review',
     repo_root = repo_root,
     review = review,
-  }
-end
-
----@param opts { repo_root: string, review: diffs.GreviewSpec, review_display?: string, selected_key?: string, selected_file?: string, path: string, spec: diffs.DiffSpec }
----@return diffs.GeneratedBufferSource
-function M.review_file_source(opts)
-  return {
-    version = 1,
-    kind = 'review_file',
-    repo_root = opts.repo_root,
-    review = opts.review,
-    review_display = opts.review_display,
-    selected_key = opts.selected_key,
-    selected_file = opts.selected_file,
-    path = opts.path,
-    spec = opts.spec,
   }
 end
 

--- a/lua/diffs/lists.lua
+++ b/lua/diffs/lists.lua
@@ -852,38 +852,37 @@ function M.set_loclist_for_buffer(bufnr, diff_lines, opts)
 end
 
 ---@param hunk diffs.GdiffHunk
----@param side "left"|"right"
+---@param anchors integer[]?
 ---@return integer
-local function split_hunk_lnum(hunk, side)
-  local range = side == 'left' and hunk.old_range or hunk.new_range
-  return math.max(1, range.start)
+local function split_anchor_lnum(hunk, anchors)
+  return (anchors and anchors[hunk.index]) or 1
 end
 
 ---@param hunk diffs.GdiffHunk
 ---@param side "left"|"right"
----@return "left"|"right", integer
-local function split_target(hunk, side)
+---@param left_buf integer
+---@param right_buf integer
+---@return integer
+local function split_target_buf(hunk, side, left_buf, right_buf)
   local range = side == 'left' and hunk.old_range or hunk.new_range
   if range.count > 0 then
-    return side, split_hunk_lnum(hunk, side)
+    return side == 'left' and left_buf or right_buf
   end
-
-  local fallback_side = side == 'left' and 'right' or 'left'
-  return fallback_side, split_hunk_lnum(hunk, fallback_side)
+  return side == 'left' and right_buf or left_buf
 end
 
 ---@param left_buf integer
 ---@param right_buf integer
 ---@param hunks diffs.GdiffHunk[]
+---@param anchors integer[]?
 ---@param side "left"|"right"
 ---@return table[]
-local function split_loclist_items(left_buf, right_buf, hunks, side)
+local function split_loclist_items(left_buf, right_buf, hunks, anchors, side)
   local items = {}
   for i, hunk in ipairs(hunks) do
-    local target_side, target_lnum = split_target(hunk, side)
     items[#items + 1] = {
-      bufnr = target_side == 'left' and left_buf or right_buf,
-      lnum = target_lnum,
+      bufnr = split_target_buf(hunk, side, left_buf, right_buf),
+      lnum = split_anchor_lnum(hunk, anchors),
       col = 1,
       text = ('%s (hunk %d) %s'):format(hunk_file(hunk), i, hunk.header),
       user_data = {
@@ -899,7 +898,7 @@ local function split_loclist_items(left_buf, right_buf, hunks, side)
   return items
 end
 
----@param opts { left_buf: integer, right_buf: integer, hunks: diffs.GdiffHunk[] }
+---@param opts { left_buf: integer, right_buf: integer, hunks: diffs.GdiffHunk[], anchors: integer[]? }
 ---@return table[]
 local function split_quickfix_items(opts)
   local entries = file_entries(opts.hunks)
@@ -907,14 +906,15 @@ local function split_quickfix_items(opts)
   local items = {}
   for _, entry in ipairs(entries) do
     local first_hunk = entry.hunks[1]
-    local target_side = 'right'
-    local target_lnum = entry.lnum
+    local lnum = entry.lnum
+    local target_buf = opts.right_buf
     if first_hunk then
-      target_side, target_lnum = split_target(first_hunk, 'right')
+      lnum = split_anchor_lnum(first_hunk, opts.anchors)
+      target_buf = split_target_buf(first_hunk, 'right', opts.left_buf, opts.right_buf)
     end
     items[#items + 1] = {
-      bufnr = target_side == 'left' and opts.left_buf or opts.right_buf,
-      lnum = target_lnum,
+      bufnr = target_buf,
+      lnum = lnum,
       col = 1,
       text = entry.text,
       user_data = {
@@ -928,7 +928,7 @@ local function split_quickfix_items(opts)
   return items
 end
 
----@param opts { title: string, loclist_title?: string, left_buf: integer, right_buf: integer, left_win?: integer, right_win?: integer, hunks: diffs.GdiffHunk[], quickfix?: boolean }
+---@param opts { title: string, loclist_title?: string, left_buf: integer, right_buf: integer, left_win?: integer, right_win?: integer, hunks: diffs.GdiffHunk[], anchors?: integer[], quickfix?: boolean }
 function M.set_for_split_pair(opts)
   local title = opts.title
   local loclist_title = opts.loclist_title or (title .. ' hunks')
@@ -940,14 +940,14 @@ function M.set_for_split_pair(opts)
     set_loclist(
       win,
       loclist_title,
-      split_loclist_items(opts.left_buf, opts.right_buf, opts.hunks, 'left')
+      split_loclist_items(opts.left_buf, opts.right_buf, opts.hunks, opts.anchors, 'left')
     )
   end
   for _, win in ipairs(opts.right_win and { opts.right_win } or windows_for_buffer(opts.right_buf)) do
     set_loclist(
       win,
       loclist_title,
-      split_loclist_items(opts.left_buf, opts.right_buf, opts.hunks, 'right')
+      split_loclist_items(opts.left_buf, opts.right_buf, opts.hunks, opts.anchors, 'right')
     )
   end
 end

--- a/lua/diffs/runtime/diff_windows.lua
+++ b/lua/diffs/runtime/diff_windows.lua
@@ -9,6 +9,13 @@ local WINHIGHLIGHT = table.concat({
   'DiffText:DiffsDiffText',
 }, ',')
 
+---@param win integer
+---@return boolean
+local function is_split_pane(win)
+  local buf = vim.api.nvim_win_get_buf(win)
+  return pcall(vim.api.nvim_buf_get_var, buf, 'diffs_split_side')
+end
+
 ---@param diff_windows table<integer, boolean>
 function M.attach(diff_windows)
   local tabpage = vim.api.nvim_get_current_tabpage()
@@ -17,7 +24,7 @@ function M.attach(diff_windows)
   local diff_wins = {}
 
   for _, win in ipairs(wins) do
-    if vim.api.nvim_win_is_valid(win) and vim.wo[win].diff then
+    if vim.api.nvim_win_is_valid(win) and vim.wo[win].diff and not is_split_pane(win) then
       table.insert(diff_wins, win)
     end
   end

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -27,10 +27,10 @@ local split_intra_ns = vim.api.nvim_create_namespace('diffs_split_intra')
 local default_change_bar = '▏'
 
 local split_winhighlight = table.concat({
-  'DiffAdd:DiffsDiffAdd',
+  'DiffAdd:DiffsClear',
+  'DiffChange:DiffsClear',
+  'DiffText:DiffsClear',
   'DiffDelete:DiffsDiffDelete',
-  'DiffChange:DiffsDiffChange',
-  'DiffText:DiffsDiffChange',
 }, ',')
 
 ---@type fun(bufnr: integer)
@@ -148,24 +148,34 @@ end
 ---@param source diffs.SplitEndpointSource
 ---@param split_hunks? diffs.GdiffHunk[]
 ---@param change_bar? string
-local function set_split_change_bars(bufnr, source, split_hunks, change_bar)
+local function set_split_line_decorations(bufnr, source, split_hunks, change_bar)
   vim.api.nvim_buf_clear_namespace(bufnr, split_bar_ns, 0, -1)
+  local line_bg_priority = require('diffs.runtime').get_highlight_opts().highlights.priorities.line_bg
+  local side = source.side
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
   for _, hunk in ipairs(split_hunks or {}) do
     for _, line in ipairs(hunk.lines or {}) do
-      local lnum
-      local hl_group
-      if source.side == 'left' and line.kind == 'delete' then
-        lnum = line.old_lnum
-        hl_group = 'DiffsDeleteBar'
-      elseif source.side == 'right' and line.kind == 'add' then
-        lnum = line.new_lnum
-        hl_group = 'DiffsAddBar'
+      local lnum, bar_hl, line_hl, number_hl
+      if side == 'left' and line.kind == 'delete' then
+        lnum, bar_hl, line_hl, number_hl =
+          line.old_lnum, 'DiffsDeleteBar', 'DiffsDelete', 'DiffsDeleteRailNr'
+      elseif side == 'right' and line.kind == 'add' then
+        lnum, bar_hl, line_hl, number_hl =
+          line.new_lnum, 'DiffsAddBar', 'DiffsAdd', 'DiffsAddRailNr'
       end
 
-      if lnum and lnum >= 1 and lnum <= vim.api.nvim_buf_line_count(bufnr) then
+      if lnum and lnum >= 1 and lnum <= line_count then
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, split_bar_ns, lnum - 1, 0, {
+          end_row = lnum,
+          end_col = 0,
+          hl_group = line_hl,
+          hl_eol = true,
+          priority = line_bg_priority,
+        })
         pcall(vim.api.nvim_buf_set_extmark, bufnr, split_bar_ns, lnum - 1, 0, {
           sign_text = change_bar or default_change_bar,
-          sign_hl_group = hl_group,
+          sign_hl_group = bar_hl,
+          number_hl_group = number_hl,
           priority = 210,
         })
       end
@@ -313,7 +323,7 @@ local function create_buffer(source, lines, split_hunks, change_bar)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   vim.api.nvim_buf_set_name(bufnr, buffer_name(source))
   set_source_vars(bufnr, source, split_hunks)
-  set_split_change_bars(bufnr, source, split_hunks, change_bar)
+  set_split_line_decorations(bufnr, source, split_hunks, change_bar)
   set_split_intra(bufnr, source, split_hunks)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)
@@ -342,7 +352,18 @@ local function remember_pair_window_options(win)
     foldcolumn = vim.api.nvim_get_option_value('foldcolumn', { win = win }),
     signcolumn = vim.api.nvim_get_option_value('signcolumn', { win = win }),
     winhighlight = vim.api.nvim_get_option_value('winhighlight', { win = win }),
+    number = vim.api.nvim_get_option_value('number', { win = win }),
+    relativenumber = vim.api.nvim_get_option_value('relativenumber', { win = win }),
+    numberwidth = vim.api.nvim_get_option_value('numberwidth', { win = win }),
+    colorcolumn = vim.api.nvim_get_option_value('colorcolumn', { win = win }),
   }
+end
+
+---@param win integer
+---@return integer
+local function rail_numberwidth(win)
+  local count = vim.api.nvim_buf_line_count(vim.api.nvim_win_get_buf(win))
+  return math.max(3, math.min(20, #tostring(count) + 1))
 end
 
 ---@param win integer
@@ -350,6 +371,10 @@ local function set_pair_window_options(win)
   vim.api.nvim_set_option_value('scrollbind', true, { win = win })
   vim.api.nvim_set_option_value('cursorbind', true, { win = win })
   vim.api.nvim_set_option_value('signcolumn', 'yes:1', { win = win })
+  vim.api.nvim_set_option_value('number', true, { win = win })
+  vim.api.nvim_set_option_value('relativenumber', false, { win = win })
+  vim.api.nvim_set_option_value('numberwidth', rail_numberwidth(win), { win = win })
+  vim.api.nvim_set_option_value('colorcolumn', '', { win = win })
   vim.api.nvim_set_option_value('winhighlight', split_winhighlight, { win = win })
   disable_diff_folds(win)
 end
@@ -370,6 +395,10 @@ local function clear_pair_window_options(win)
   pcall(vim.api.nvim_set_option_value, 'diff', false, { win = win })
   pcall(vim.api.nvim_set_option_value, 'foldenable', true, { win = win })
   pcall(vim.api.nvim_set_option_value, 'winhighlight', '', { win = win })
+  pcall(vim.api.nvim_set_option_value, 'number', false, { win = win })
+  pcall(vim.api.nvim_set_option_value, 'relativenumber', false, { win = win })
+  pcall(vim.api.nvim_set_option_value, 'numberwidth', 4, { win = win })
+  pcall(vim.api.nvim_set_option_value, 'colorcolumn', '', { win = win })
 end
 
 ---@param win integer
@@ -753,7 +782,7 @@ local function apply_buffer_lines(bufnr, source, lines, split_hunks, change_bar)
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   set_source_vars(bufnr, source, split_hunks)
-  set_split_change_bars(bufnr, source, split_hunks, change_bar)
+  set_split_line_decorations(bufnr, source, split_hunks, change_bar)
   set_split_intra(bufnr, source, split_hunks)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local diff = require('diffs.diff')
 local diffspec = require('diffs.spec')
 local generated = require('diffs.generated')
 local hunk_model = require('diffs.hunks')
@@ -22,7 +23,15 @@ local peer_buffers = {}
 local pair_window_options = {}
 local syncing_cursor = false
 local split_bar_ns = vim.api.nvim_create_namespace('diffs_split_change_bar')
+local split_intra_ns = vim.api.nvim_create_namespace('diffs_split_intra')
 local default_change_bar = '▏'
+
+local split_winhighlight = table.concat({
+  'DiffAdd:DiffsDiffAdd',
+  'DiffDelete:DiffsDiffDelete',
+  'DiffChange:DiffsDiffChange',
+  'DiffText:DiffsDiffChange',
+}, ',')
 
 ---@type fun(bufnr: integer)
 local clear_cursor_sync
@@ -159,6 +168,59 @@ local function set_split_change_bars(bufnr, source, split_hunks, change_bar)
 end
 
 ---@param bufnr integer
+---@param source diffs.SplitEndpointSource
+---@param split_hunks? diffs.GdiffHunk[]
+local function set_split_intra(bufnr, source, split_hunks)
+  vim.api.nvim_buf_clear_namespace(bufnr, split_intra_ns, 0, -1)
+  if not split_hunks or #split_hunks == 0 then
+    return
+  end
+
+  local opts = require('diffs.runtime').get_highlight_opts()
+  local intra_cfg = opts.highlights.intra
+  if not intra_cfg or not intra_cfg.enabled then
+    return
+  end
+
+  local side = source.side
+  local want_kind = side == 'left' and 'delete' or 'add'
+  local hl_group = side == 'left' and 'DiffsDeleteText' or 'DiffsAddText'
+  local priority = opts.highlights.priorities.char_bg
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+
+  for _, hunk in ipairs(split_hunks) do
+    ---@type string[]
+    local texts = {}
+    ---@type diffs.GdiffHunkLine[]
+    local refs = {}
+    for _, line in ipairs(hunk.lines or {}) do
+      if line.kind ~= 'header' then
+        texts[#texts + 1] = line.text
+        refs[#refs + 1] = line
+      end
+    end
+
+    if #texts > 0 and #texts <= intra_cfg.max_lines then
+      local intra = diff.compute_intra_hunks(texts, intra_cfg.algorithm)
+      local spans = intra and (side == 'left' and intra.del_spans or intra.add_spans) or {}
+      for _, span in ipairs(spans) do
+        local ref = refs[span.line]
+        local lnum = ref and ref.kind == want_kind and (side == 'left' and ref.old_lnum or ref.new_lnum)
+        local col_start = span.col_start - 1
+        local col_end = span.col_end - 1
+        if lnum and lnum >= 1 and lnum <= line_count and col_start >= 0 and col_end > col_start then
+          pcall(vim.api.nvim_buf_set_extmark, bufnr, split_intra_ns, lnum - 1, col_start, {
+            end_col = col_end,
+            hl_group = hl_group,
+            priority = priority,
+          })
+        end
+      end
+    end
+  end
+end
+
+---@param bufnr integer
 ---@param filetype? string
 local function set_buffer_options(bufnr, filetype)
   vim.api.nvim_set_option_value('buftype', 'nowrite', { buf = bufnr })
@@ -244,6 +306,7 @@ local function create_buffer(source, lines, split_hunks, change_bar)
   vim.api.nvim_buf_set_name(bufnr, buffer_name(source))
   set_source_vars(bufnr, source, split_hunks)
   set_split_change_bars(bufnr, source, split_hunks, change_bar)
+  set_split_intra(bufnr, source, split_hunks)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)
   return bufnr
@@ -270,6 +333,7 @@ local function remember_pair_window_options(win)
     foldenable = vim.api.nvim_get_option_value('foldenable', { win = win }),
     foldcolumn = vim.api.nvim_get_option_value('foldcolumn', { win = win }),
     signcolumn = vim.api.nvim_get_option_value('signcolumn', { win = win }),
+    winhighlight = vim.api.nvim_get_option_value('winhighlight', { win = win }),
   }
 end
 
@@ -278,6 +342,7 @@ local function set_pair_window_options(win)
   vim.api.nvim_set_option_value('scrollbind', true, { win = win })
   vim.api.nvim_set_option_value('cursorbind', true, { win = win })
   vim.api.nvim_set_option_value('signcolumn', 'yes:1', { win = win })
+  vim.api.nvim_set_option_value('winhighlight', split_winhighlight, { win = win })
   disable_diff_folds(win)
 end
 
@@ -296,6 +361,7 @@ local function clear_pair_window_options(win)
   pcall(vim.api.nvim_set_option_value, 'cursorbind', false, { win = win })
   pcall(vim.api.nvim_set_option_value, 'diff', false, { win = win })
   pcall(vim.api.nvim_set_option_value, 'foldenable', true, { win = win })
+  pcall(vim.api.nvim_set_option_value, 'winhighlight', '', { win = win })
 end
 
 ---@param win integer
@@ -403,6 +469,7 @@ local function clear_split_state(bufnr)
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_hunks')
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_side')
   vim.api.nvim_buf_clear_namespace(bufnr, split_bar_ns, 0, -1)
+  vim.api.nvim_buf_clear_namespace(bufnr, split_intra_ns, 0, -1)
   if clear_cursor_sync then
     clear_cursor_sync(bufnr)
   end
@@ -679,6 +746,7 @@ local function apply_buffer_lines(bufnr, source, lines, split_hunks, change_bar)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   set_source_vars(bufnr, source, split_hunks)
   set_split_change_bars(bufnr, source, split_hunks, change_bar)
+  set_split_intra(bufnr, source, split_hunks)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)
   ensure_pair_cleanup(bufnr)

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -211,7 +211,9 @@ local function set_split_intra(bufnr, source, split_hunks)
       local spans = intra and (side == 'left' and intra.del_spans or intra.add_spans) or {}
       for _, span in ipairs(spans) do
         local ref = refs[span.line]
-        local lnum = ref and ref.kind == want_kind and (side == 'left' and ref.old_lnum or ref.new_lnum)
+        local lnum = ref
+          and ref.kind == want_kind
+          and (side == 'left' and ref.old_lnum or ref.new_lnum)
         local col_start = span.col_start - 1
         local col_end = span.col_end - 1
         if lnum and lnum >= 1 and lnum <= line_count and col_start >= 0 and col_end > col_start then

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -33,7 +33,7 @@ local pane_info = {}
 local split_line_ns = vim.api.nvim_create_namespace('diffs_split_line')
 local split_intra_ns = vim.api.nvim_create_namespace('diffs_split_intra')
 local default_change_bar = '▏'
-local split_statuscolumn = "%{%v:lua.require'diffs.split'.statuscolumn()%}"
+local split_statuscolumn = "%!v:lua.require'diffs.split'.statuscolumn()"
 
 ---@class diffs.SplitReuseWins
 ---@field left integer
@@ -155,7 +155,7 @@ local function rail_segment(info, lnum)
   if not row or row.kind == 'filler' then
     return '%#DiffsRail#' .. string.rep(' ', width + 2)
   end
-  local number = row.old_lnum or row.new_lnum
+  local number = info.side == 'left' and row.old_lnum or row.new_lnum
   local numstr = number and ('%' .. width .. 'd'):format(number) or string.rep(' ', width)
   local changed = (info.side == 'left' and row.kind == 'delete')
     or (info.side == 'right' and row.kind == 'add')
@@ -186,7 +186,8 @@ function M.statuscolumn()
   if not info then
     return ''
   end
-  return rail_segment(info, vim.v.lnum)
+  local rendered_ok, rendered = pcall(rail_segment, info, vim.v.lnum)
+  return rendered_ok and rendered or ''
 end
 
 ---@param bufnr integer

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -9,34 +9,31 @@ local log = require('diffs.log')
 local render = require('diffs.render')
 
 local notify = log.notify
-local schedule = vim.schedule
+
+local split_align = require('diffs.split_align')
 
 ---@type table<integer, boolean>
 local closing_buffers = {}
 ---@type table<integer, integer>
 local cleanup_autocmds = {}
 ---@type table<integer, integer>
-local cursor_sync_autocmds = {}
----@type table<integer, integer>
 local peer_buffers = {}
 ---@type table<integer, table<string, any>>
 local pair_window_options = {}
-local syncing_cursor = false
-local split_bar_ns = vim.api.nvim_create_namespace('diffs_split_change_bar')
+
+---@class diffs.SplitPaneInfo
+---@field rows diffs.SplitRow[]
+---@field side "left"|"right"
+---@field rail_width integer
+---@field change_bar string
+---@field anchors integer[]
+
+---@type table<integer, diffs.SplitPaneInfo>
+local pane_info = {}
+local split_line_ns = vim.api.nvim_create_namespace('diffs_split_line')
 local split_intra_ns = vim.api.nvim_create_namespace('diffs_split_intra')
 local default_change_bar = '▏'
-
-local split_winhighlight = table.concat({
-  'DiffAdd:DiffsDiffAdd',
-  'DiffDelete:DiffsDiffDelete',
-  'DiffChange:DiffsDiffChange',
-  'DiffText:DiffsDiffChange',
-}, ',')
-
----@type fun(bufnr: integer)
-local clear_cursor_sync
----@type fun(bufnr: integer)
-local ensure_cursor_sync
+local split_statuscolumn = "%{%v:lua.require'diffs.split'.statuscolumn()%}"
 
 ---@class diffs.SplitReuseWins
 ---@field left integer
@@ -144,41 +141,84 @@ local function set_source_vars(bufnr, source, split_hunks)
   end
 end
 
----@param bufnr integer
----@param source diffs.SplitEndpointSource
----@param split_hunks? diffs.GdiffHunk[]
----@param change_bar? string
-local function set_split_change_bars(bufnr, source, split_hunks, change_bar)
-  vim.api.nvim_buf_clear_namespace(bufnr, split_bar_ns, 0, -1)
-  for _, hunk in ipairs(split_hunks or {}) do
-    for _, line in ipairs(hunk.lines or {}) do
-      local lnum
-      local hl_group
-      if source.side == 'left' and line.kind == 'delete' then
-        lnum = line.old_lnum
-        hl_group = 'DiffsDeleteBar'
-      elseif source.side == 'right' and line.kind == 'add' then
-        lnum = line.new_lnum
-        hl_group = 'DiffsAddBar'
-      end
+local rail_styles = {
+  delete = { bar = 'DiffsDeleteBar', nr = 'DiffsDeleteRailNr', fill = 'DiffsDelete' },
+  add = { bar = 'DiffsAddBar', nr = 'DiffsAddRailNr', fill = 'DiffsAdd' },
+}
 
-      if lnum and lnum >= 1 and lnum <= vim.api.nvim_buf_line_count(bufnr) then
-        pcall(vim.api.nvim_buf_set_extmark, bufnr, split_bar_ns, lnum - 1, 0, {
-          sign_text = change_bar or default_change_bar,
-          sign_hl_group = hl_group,
-          priority = 210,
-        })
-      end
+---@param info diffs.SplitPaneInfo
+---@param lnum integer
+---@return string
+local function rail_segment(info, lnum)
+  local row = info.rows[lnum]
+  local width = info.rail_width
+  if not row or row.kind == 'filler' then
+    return '%#DiffsRail#' .. string.rep(' ', width + 2)
+  end
+  local number = row.old_lnum or row.new_lnum
+  local numstr = number and ('%' .. width .. 'd'):format(number) or string.rep(' ', width)
+  local changed = (info.side == 'left' and row.kind == 'delete')
+    or (info.side == 'right' and row.kind == 'add')
+  if changed then
+    local style = rail_styles[row.kind]
+    return ('%%#%s#%s%%#%s#%s%%#%s# '):format(
+      style.bar,
+      info.change_bar,
+      style.nr,
+      numstr,
+      style.fill
+    )
+  end
+  return ('%%#DiffsRailNr# %s '):format(numstr)
+end
+
+---@return string
+function M.statuscolumn()
+  local win = vim.g.statusline_winid
+  if not win or win == 0 then
+    return ''
+  end
+  local ok, bufnr = pcall(vim.api.nvim_win_get_buf, win)
+  if not ok then
+    return ''
+  end
+  local info = pane_info[bufnr]
+  if not info then
+    return ''
+  end
+  return rail_segment(info, vim.v.lnum)
+end
+
+---@param bufnr integer
+---@param info diffs.SplitPaneInfo
+local function set_split_line_bg(bufnr, info)
+  vim.api.nvim_buf_clear_namespace(bufnr, split_line_ns, 0, -1)
+  local priorities = require('diffs.runtime').get_highlight_opts().highlights.priorities
+  for lnum, row in ipairs(info.rows) do
+    local hl
+    if info.side == 'left' and row.kind == 'delete' then
+      hl = 'DiffsDelete'
+    elseif info.side == 'right' and row.kind == 'add' then
+      hl = 'DiffsAdd'
+    end
+    if hl then
+      pcall(vim.api.nvim_buf_set_extmark, bufnr, split_line_ns, lnum - 1, 0, {
+        end_row = lnum,
+        end_col = 0,
+        hl_group = hl,
+        hl_eol = true,
+        priority = priorities.line_bg,
+      })
     end
   end
 end
 
 ---@param bufnr integer
----@param source diffs.SplitEndpointSource
----@param split_hunks? diffs.GdiffHunk[]
-local function set_split_intra(bufnr, source, split_hunks)
+---@param info diffs.SplitPaneInfo
+---@param hunks diffs.GdiffHunk[]
+local function set_split_intra(bufnr, info, hunks)
   vim.api.nvim_buf_clear_namespace(bufnr, split_intra_ns, 0, -1)
-  if not split_hunks or #split_hunks == 0 then
+  if not hunks or #hunks == 0 then
     return
   end
 
@@ -188,13 +228,22 @@ local function set_split_intra(bufnr, source, split_hunks)
     return
   end
 
-  local side = source.side
+  local side = info.side
   local want_kind = side == 'left' and 'delete' or 'add'
   local hl_group = side == 'left' and 'DiffsDeleteText' or 'DiffsAddText'
   local priority = opts.highlights.priorities.char_bg
+
+  ---@type table<integer, integer>
+  local lnum_to_row = {}
+  for row_index, row in ipairs(info.rows) do
+    local source_lnum = side == 'left' and row.old_lnum or row.new_lnum
+    if source_lnum then
+      lnum_to_row[source_lnum] = row_index
+    end
+  end
   local line_count = vim.api.nvim_buf_line_count(bufnr)
 
-  for _, hunk in ipairs(split_hunks) do
+  for _, hunk in ipairs(hunks) do
     ---@type string[]
     local texts = {}
     ---@type diffs.GdiffHunkLine[]
@@ -211,13 +260,20 @@ local function set_split_intra(bufnr, source, split_hunks)
       local spans = intra and (side == 'left' and intra.del_spans or intra.add_spans) or {}
       for _, span in ipairs(spans) do
         local ref = refs[span.line]
-        local lnum = ref
+        local source_lnum = ref
           and ref.kind == want_kind
           and (side == 'left' and ref.old_lnum or ref.new_lnum)
+        local buf_row = source_lnum and lnum_to_row[source_lnum]
         local col_start = span.col_start - 1
         local col_end = span.col_end - 1
-        if lnum and lnum >= 1 and lnum <= line_count and col_start >= 0 and col_end > col_start then
-          pcall(vim.api.nvim_buf_set_extmark, bufnr, split_intra_ns, lnum - 1, col_start, {
+        if
+          buf_row
+          and buf_row >= 1
+          and buf_row <= line_count
+          and col_start >= 0
+          and col_end > col_start
+        then
+          pcall(vim.api.nvim_buf_set_extmark, bufnr, split_intra_ns, buf_row - 1, col_start, {
             end_col = col_end,
             hl_group = hl_group,
             priority = priority,
@@ -303,28 +359,30 @@ local function buffer_name(source)
   return 'diffs://split:' .. source.side .. ':' .. endpoint_name(endpoint) .. ':' .. source.path
 end
 
+---@param bufnr integer
+---@param source diffs.SplitEndpointSource
+---@param info diffs.SplitPaneInfo
+---@param hunks diffs.GdiffHunk[]
+local function paint_pane(bufnr, source, info, hunks)
+  pane_info[bufnr] = info
+  set_source_vars(bufnr, source, hunks)
+  set_split_line_bg(bufnr, info)
+  set_split_intra(bufnr, info, hunks)
+end
+
 ---@param source diffs.SplitEndpointSource
 ---@param lines string[]
----@param split_hunks? diffs.GdiffHunk[]
----@param change_bar? string
+---@param info diffs.SplitPaneInfo
+---@param hunks diffs.GdiffHunk[]
 ---@return integer
-local function create_buffer(source, lines, split_hunks, change_bar)
+local function create_buffer(source, lines, info, hunks)
   local bufnr = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   vim.api.nvim_buf_set_name(bufnr, buffer_name(source))
-  set_source_vars(bufnr, source, split_hunks)
-  set_split_change_bars(bufnr, source, split_hunks, change_bar)
-  set_split_intra(bufnr, source, split_hunks)
+  paint_pane(bufnr, source, info, hunks)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)
   return bufnr
-end
-
----@param win integer
-local function disable_diff_folds(win)
-  vim.api.nvim_set_option_value('foldmethod', 'manual', { win = win })
-  vim.api.nvim_set_option_value('foldenable', false, { win = win })
-  vim.api.nvim_set_option_value('foldcolumn', '0', { win = win })
 end
 
 ---@param win integer
@@ -334,24 +392,33 @@ local function remember_pair_window_options(win)
   end
 
   pair_window_options[win] = {
-    diff = vim.api.nvim_get_option_value('diff', { win = win }),
     scrollbind = vim.api.nvim_get_option_value('scrollbind', { win = win }),
     cursorbind = vim.api.nvim_get_option_value('cursorbind', { win = win }),
+    wrap = vim.api.nvim_get_option_value('wrap', { win = win }),
+    number = vim.api.nvim_get_option_value('number', { win = win }),
+    relativenumber = vim.api.nvim_get_option_value('relativenumber', { win = win }),
     foldmethod = vim.api.nvim_get_option_value('foldmethod', { win = win }),
     foldenable = vim.api.nvim_get_option_value('foldenable', { win = win }),
     foldcolumn = vim.api.nvim_get_option_value('foldcolumn', { win = win }),
     signcolumn = vim.api.nvim_get_option_value('signcolumn', { win = win }),
+    statuscolumn = vim.api.nvim_get_option_value('statuscolumn', { win = win }),
     winhighlight = vim.api.nvim_get_option_value('winhighlight', { win = win }),
   }
 end
 
 ---@param win integer
 local function set_pair_window_options(win)
+  remember_pair_window_options(win)
   vim.api.nvim_set_option_value('scrollbind', true, { win = win })
   vim.api.nvim_set_option_value('cursorbind', true, { win = win })
-  vim.api.nvim_set_option_value('signcolumn', 'yes:1', { win = win })
-  vim.api.nvim_set_option_value('winhighlight', split_winhighlight, { win = win })
-  disable_diff_folds(win)
+  vim.api.nvim_set_option_value('wrap', false, { win = win })
+  vim.api.nvim_set_option_value('number', false, { win = win })
+  vim.api.nvim_set_option_value('relativenumber', false, { win = win })
+  vim.api.nvim_set_option_value('signcolumn', 'no', { win = win })
+  vim.api.nvim_set_option_value('statuscolumn', split_statuscolumn, { win = win })
+  vim.api.nvim_set_option_value('foldmethod', 'manual', { win = win })
+  vim.api.nvim_set_option_value('foldenable', false, { win = win })
+  vim.api.nvim_set_option_value('foldcolumn', '0', { win = win })
 end
 
 ---@param win integer
@@ -367,17 +434,8 @@ local function clear_pair_window_options(win)
 
   pcall(vim.api.nvim_set_option_value, 'scrollbind', false, { win = win })
   pcall(vim.api.nvim_set_option_value, 'cursorbind', false, { win = win })
-  pcall(vim.api.nvim_set_option_value, 'diff', false, { win = win })
   pcall(vim.api.nvim_set_option_value, 'foldenable', true, { win = win })
-  pcall(vim.api.nvim_set_option_value, 'winhighlight', '', { win = win })
-end
-
----@param win integer
-local function enable_diff(win)
-  remember_pair_window_options(win)
-  vim.api.nvim_set_current_win(win)
-  vim.cmd.diffthis()
-  set_pair_window_options(win)
+  pcall(vim.api.nvim_set_option_value, 'statuscolumn', '', { win = win })
 end
 
 ---@param bufnr integer
@@ -461,6 +519,7 @@ local function clear_pair_tracking(bufnr, keep_closing)
     cleanup_autocmds[bufnr] = nil
   end
   peer_buffers[bufnr] = nil
+  pane_info[bufnr] = nil
   if not keep_closing then
     closing_buffers[bufnr] = nil
   end
@@ -473,14 +532,12 @@ local function clear_split_state(bufnr)
   end
 
   clear_pair_tracking(bufnr)
+  pane_info[bufnr] = nil
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_peer')
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_hunks')
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_side')
-  vim.api.nvim_buf_clear_namespace(bufnr, split_bar_ns, 0, -1)
+  vim.api.nvim_buf_clear_namespace(bufnr, split_line_ns, 0, -1)
   vim.api.nvim_buf_clear_namespace(bufnr, split_intra_ns, 0, -1)
-  if clear_cursor_sync then
-    clear_cursor_sync(bufnr)
-  end
   clear_owned_split_keymaps(bufnr)
 end
 
@@ -491,16 +548,6 @@ local function detach_split_endpoint(bufnr)
   if peer and peer ~= bufnr and vim.api.nvim_buf_is_valid(peer) then
     clear_split_state(peer)
   end
-end
-
----@param bufnr integer
----@return diffs.GdiffHunk[]
-local function buffer_split_hunks(bufnr)
-  local ok, parsed = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_split_hunks')
-  if ok and type(parsed) == 'table' then
-    return parsed
-  end
-  return {}
 end
 
 ---@param bufnr integer
@@ -538,39 +585,15 @@ local function clamp_lnum(bufnr, lnum)
   return math.max(1, math.min(lnum, vim.api.nvim_buf_line_count(bufnr)))
 end
 
----@param hunk diffs.GdiffHunk
----@param side "left"|"right"
----@return integer
-local function hunk_target_lnum(hunk, side)
-  local range = side == 'left' and hunk.old_range or hunk.new_range
-  return math.max(1, range.start)
-end
-
----@param hunks diffs.GdiffHunk[]
----@param side "left"|"right"
----@param lnum integer
----@return diffs.GdiffHunk?
-local function next_hunk(hunks, side, lnum)
-  for _, hunk in ipairs(hunks) do
-    if hunk_target_lnum(hunk, side) > lnum then
-      return hunk
-    end
+---@param anchors integer[]
+---@return integer[]
+local function sorted_anchors(anchors)
+  local rows = {}
+  for _, row in pairs(anchors or {}) do
+    rows[#rows + 1] = row
   end
-  return hunks[1]
-end
-
----@param hunks diffs.GdiffHunk[]
----@param side "left"|"right"
----@param lnum integer
----@return diffs.GdiffHunk?
-local function prev_hunk(hunks, side, lnum)
-  for i = #hunks, 1, -1 do
-    local hunk = hunks[i]
-    if hunk_target_lnum(hunk, side) < lnum then
-      return hunk
-    end
-  end
-  return hunks[#hunks]
+  table.sort(rows)
+  return rows
 end
 
 ---@param win integer
@@ -583,178 +606,69 @@ local function set_window_lnum(win, lnum)
   vim.api.nvim_win_set_cursor(win, { clamp_lnum(bufnr, lnum), 0 })
 end
 
----@param callback function
-local function with_cursor_sync_suppressed(callback)
-  local was_syncing = syncing_cursor
-  syncing_cursor = true
-  local ok, err = pcall(callback)
-  syncing_cursor = was_syncing
-  if not ok then
-    error(err, 0)
-  end
-end
-
----@param wins integer[]
----@param callback function
-local function with_window_bindings_disabled(wins, callback)
-  local saved = {}
-  local ordered = {}
-  for _, win in ipairs(wins) do
-    if not saved[win] and vim.api.nvim_win_is_valid(win) then
-      ordered[#ordered + 1] = win
-      saved[win] = {
-        cursorbind = vim.api.nvim_get_option_value('cursorbind', { win = win }),
-        scrollbind = vim.api.nvim_get_option_value('scrollbind', { win = win }),
-      }
-      vim.api.nvim_set_option_value('cursorbind', false, { win = win })
-      vim.api.nvim_set_option_value('scrollbind', false, { win = win })
-    end
-  end
-
-  local ok, err = pcall(callback)
-
-  local current_win = vim.api.nvim_get_current_win()
-  if saved[current_win] and vim.api.nvim_win_is_valid(current_win) then
-    local value = saved[current_win]
-    vim.api.nvim_set_option_value('scrollbind', value.scrollbind, { win = current_win })
-    vim.api.nvim_set_option_value('cursorbind', value.cursorbind, { win = current_win })
-  end
-
-  for _, win in ipairs(ordered) do
-    local value = saved[win]
-    if win ~= current_win and vim.api.nvim_win_is_valid(win) then
-      vim.api.nvim_set_option_value('scrollbind', value.scrollbind, { win = win })
-      vim.api.nvim_set_option_value('cursorbind', value.cursorbind, { win = win })
-    end
-  end
-
-  if not ok then
-    error(err, 0)
-  end
-end
-
 ---@param bufnr integer
----@param hunk diffs.GdiffHunk
-local function move_pair_to_hunk(bufnr, hunk)
-  local source = buffer_source(bufnr)
-  if not source then
-    return
+---@param row integer
+local function move_pair_to_row(bufnr, row)
+  for _, win in ipairs(windows_for_buffer(bufnr)) do
+    set_window_lnum(win, row)
   end
-
-  local current_win = vim.api.nvim_get_current_win()
-  local own_wins = windows_for_buffer(bufnr)
   local peer = split_peer(bufnr)
-  local peer_source = peer and buffer_source(peer) or nil
-  local peer_wins = peer and windows_for_buffer(peer) or {}
-  local all_wins = vim.list_extend(vim.deepcopy(own_wins), peer_wins)
-
-  with_cursor_sync_suppressed(function()
-    with_window_bindings_disabled(all_wins, function()
-      for _, win in ipairs(own_wins) do
-        set_window_lnum(win, hunk_target_lnum(hunk, source.side))
-      end
-
-      if peer and peer_source then
-        for _, win in ipairs(peer_wins) do
-          set_window_lnum(win, hunk_target_lnum(hunk, peer_source.side))
-        end
-      end
-    end)
-  end)
-
-  if vim.api.nvim_win_is_valid(current_win) then
-    vim.api.nvim_set_current_win(current_win)
-  end
-end
-
----@param hunks diffs.GdiffHunk[]
----@param side "left"|"right"
----@param lnum integer
----@return diffs.GdiffHunk?
-local function hunk_at_target_lnum(hunks, side, lnum)
-  for _, hunk in ipairs(hunks) do
-    if hunk_target_lnum(hunk, side) == lnum then
-      return hunk
+  if peer then
+    for _, win in ipairs(windows_for_buffer(peer)) do
+      set_window_lnum(win, row)
     end
   end
-  return nil
 end
 
 ---@param bufnr integer
-local function sync_cursor_to_hunk(bufnr)
-  if syncing_cursor then
+---@param direction integer
+local function goto_anchor(bufnr, direction)
+  local info = pane_info[bufnr]
+  if not info then
     return
   end
-
-  local source = buffer_source(bufnr)
-  local hunks = buffer_split_hunks(bufnr)
-  if not source or #hunks == 0 then
+  local anchors = sorted_anchors(info.anchors)
+  if #anchors == 0 then
     return
   end
-
-  local win = current_or_first_window_for_buffer(bufnr)
-  if not win then
-    return
+  local win = current_or_first_window_for_buffer(bufnr) or vim.api.nvim_get_current_win()
+  local row = vim.api.nvim_win_get_cursor(win)[1]
+  local target
+  if direction > 0 then
+    for _, anchor in ipairs(anchors) do
+      if anchor > row then
+        target = anchor
+        break
+      end
+    end
+    if not target then
+      target = anchors[1]
+      notify('wrapped to first hunk', vim.log.levels.INFO)
+    end
+  else
+    for i = #anchors, 1, -1 do
+      if anchors[i] < row then
+        target = anchors[i]
+        break
+      end
+    end
+    if not target then
+      target = anchors[#anchors]
+      notify('wrapped to last hunk', vim.log.levels.INFO)
+    end
   end
-  local hunk = hunk_at_target_lnum(hunks, source.side, vim.api.nvim_win_get_cursor(win)[1])
-  if not hunk then
-    return
-  end
-
-  move_pair_to_hunk(bufnr, hunk)
-end
-
-clear_cursor_sync = function(bufnr)
-  if cursor_sync_autocmds[bufnr] then
-    pcall(vim.api.nvim_del_autocmd, cursor_sync_autocmds[bufnr])
-    cursor_sync_autocmds[bufnr] = nil
-  end
-end
-
-ensure_cursor_sync = function(bufnr)
-  if cursor_sync_autocmds[bufnr] then
-    return
-  end
-
-  local target_buf = bufnr
-  cursor_sync_autocmds[bufnr] = vim.api.nvim_create_autocmd(
-    { 'BufEnter', 'CursorMoved', 'WinEnter' },
-    {
-      callback = function(args)
-        if not vim.api.nvim_buf_is_valid(target_buf) then
-          clear_cursor_sync(target_buf)
-          return
-        end
-        if vim.api.nvim_get_current_buf() ~= target_buf then
-          return
-        end
-        if args.event == 'BufEnter' then
-          vim.defer_fn(function()
-            schedule(function()
-              if vim.api.nvim_buf_is_valid(target_buf) then
-                sync_cursor_to_hunk(target_buf)
-              end
-            end)
-          end, 0)
-          return
-        end
-        sync_cursor_to_hunk(target_buf)
-      end,
-    }
-  )
+  move_pair_to_row(bufnr, target)
 end
 
 ---@param bufnr integer
 ---@param source diffs.SplitEndpointSource
 ---@param lines string[]
----@param split_hunks? diffs.GdiffHunk[]
----@param change_bar? string
-local function apply_buffer_lines(bufnr, source, lines, split_hunks, change_bar)
+---@param info diffs.SplitPaneInfo
+---@param hunks diffs.GdiffHunk[]
+local function apply_buffer_lines(bufnr, source, lines, info, hunks)
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
-  set_source_vars(bufnr, source, split_hunks)
-  set_split_change_bars(bufnr, source, split_hunks, change_bar)
-  set_split_intra(bufnr, source, split_hunks)
+  paint_pane(bufnr, source, info, hunks)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)
   ensure_pair_cleanup(bufnr)
@@ -762,18 +676,12 @@ end
 
 ---@param bufnr integer
 local function refresh_visible_pair_options(bufnr)
-  local peer = split_peer(bufnr)
-  local current_win = vim.api.nvim_get_current_win()
-  for _, buf in ipairs({ bufnr, peer }) do
+  for _, buf in ipairs({ bufnr, split_peer(bufnr) }) do
     if buf and vim.api.nvim_buf_is_valid(buf) then
       for _, win in ipairs(windows_for_buffer(buf)) do
-        enable_diff(win)
+        set_pair_window_options(win)
       end
     end
-  end
-  if vim.api.nvim_win_is_valid(current_win) then
-    vim.api.nvim_set_current_win(current_win)
-    pcall(vim.cmd.diffupdate)
   end
 end
 
@@ -912,6 +820,33 @@ local function delete_pair_buffers(buffers)
   end
 end
 
+---@param old_lines string[]
+---@param new_lines string[]
+---@param hunks diffs.GdiffHunk[]
+---@param change_bar? string
+---@return diffs.SplitAlignment, diffs.SplitPaneInfo, diffs.SplitPaneInfo
+local function build_pane_infos(old_lines, new_lines, hunks, change_bar)
+  local alignment = split_align.align(old_lines, new_lines, hunks)
+  local max_lnum = math.max(#old_lines, #new_lines, 1)
+  local rail_width = math.max(2, #tostring(max_lnum))
+  local bar = change_bar or default_change_bar
+  local left_info = {
+    rows = alignment.left_rows,
+    side = 'left',
+    rail_width = rail_width,
+    change_bar = bar,
+    anchors = alignment.anchors,
+  }
+  local right_info = {
+    rows = alignment.right_rows,
+    side = 'right',
+    rail_width = rail_width,
+    change_bar = bar,
+    anchors = alignment.anchors,
+  }
+  return alignment, left_info, right_info
+end
+
 ---@param opts diffs.SplitOpenOpts
 ---@return { left_buf: integer, right_buf: integer, left_win: integer, right_win: integer }?, string?
 function M.open(opts)
@@ -930,16 +865,19 @@ function M.open(opts)
     generated.split_endpoint_source(vim.tbl_extend('force', base_source, { side = 'left' }))
   local right_source =
     generated.split_endpoint_source(vim.tbl_extend('force', base_source, { side = 'right' }))
-  local left_lines, left_err = endpoint_lines(left_source, { worktree_lines = opts.worktree_lines })
-  if not left_lines then
+  local old_content, left_err =
+    endpoint_lines(left_source, { worktree_lines = opts.worktree_lines })
+  if not old_content then
     return nil, left_err
   end
-  local right_lines, right_err =
+  local new_content, right_err =
     endpoint_lines(right_source, { worktree_lines = opts.worktree_lines })
-  if not right_lines then
+  if not new_content then
     return nil, right_err
   end
   local split_hunks = split_hunks_for(opts.diff_lines, spec)
+  local alignment, left_info, right_info =
+    build_pane_infos(old_content, new_content, split_hunks, opts.change_bar)
 
   local reuse = opts.reuse_wins
   local invoking_win = vim.api.nvim_get_current_win()
@@ -969,21 +907,16 @@ function M.open(opts)
     right_win = vim.api.nvim_get_current_win()
   end
 
-  local left_buf = create_buffer(left_source, left_lines, split_hunks, opts.change_bar)
-  local right_buf = create_buffer(right_source, right_lines, split_hunks, opts.change_bar)
+  local left_buf = create_buffer(left_source, alignment.left_lines, left_info, split_hunks)
+  local right_buf = create_buffer(right_source, alignment.right_lines, right_info, split_hunks)
 
   vim.api.nvim_win_set_buf(left_win, left_buf)
   vim.api.nvim_win_set_buf(right_win, right_buf)
   set_peers(left_buf, right_buf)
-  ensure_cursor_sync(left_buf)
-  ensure_cursor_sync(right_buf)
 
-  enable_diff(left_win)
-  enable_diff(right_win)
-  vim.api.nvim_set_current_win(right_win)
-  vim.cmd.diffupdate()
   set_pair_window_options(left_win)
   set_pair_window_options(right_win)
+  vim.api.nvim_set_current_win(right_win)
   lists.set_for_split_pair({
     title = opts.title or ('diff: ' .. diffspec.label(spec)),
     left_buf = left_buf,
@@ -991,11 +924,12 @@ function M.open(opts)
     left_win = left_win,
     right_win = right_win,
     hunks = split_hunks,
+    anchors = alignment.anchors,
     quickfix = opts.quickfix,
   })
 
-  if opts.hunk_index and split_hunks[opts.hunk_index] then
-    move_pair_to_hunk(right_buf, split_hunks[opts.hunk_index])
+  if opts.hunk_index and alignment.anchors[opts.hunk_index] then
+    move_pair_to_row(right_buf, alignment.anchors[opts.hunk_index])
   end
 
   for _, buf in ipairs(stale_buffers) do
@@ -1074,25 +1008,31 @@ function M.read_buffer(bufnr, source, opts)
     split_hunks = split_hunks_for(diff_lines, source.spec)
   end
 
-  apply_buffer_lines(bufnr, source, current_lines, split_hunks, opts.change_bar)
-  if peer and peer_source and peer_lines then
-    apply_buffer_lines(peer, peer_source, peer_lines, split_hunks, opts.change_bar)
-    if source.side == 'left' then
-      set_peers(bufnr, peer)
-    else
-      set_peers(peer, bufnr)
-    end
-    ensure_cursor_sync(bufnr)
-    ensure_cursor_sync(peer)
-    refresh_visible_pair_options(bufnr)
-    lists.set_for_split_pair({
-      title = 'diff: ' .. diffspec.label(source.spec),
-      left_buf = source.side == 'left' and bufnr or peer,
-      right_buf = source.side == 'right' and bufnr or peer,
-      hunks = split_hunks,
-      quickfix = source.quickfix,
-    })
+  if not (peer_source and peer_lines) then
+    return false, 'cannot reload split pair without peer content'
   end
+
+  local left_buf = source.side == 'left' and bufnr or peer
+  local right_buf = source.side == 'right' and bufnr or peer
+  local left_source = source.side == 'left' and source or peer_source
+  local right_source = source.side == 'right' and source or peer_source
+  local old_content = source.side == 'left' and current_lines or peer_lines
+  local new_content = source.side == 'right' and current_lines or peer_lines
+
+  local alignment, left_info, right_info =
+    build_pane_infos(old_content, new_content, split_hunks or {}, opts.change_bar)
+  apply_buffer_lines(left_buf, left_source, alignment.left_lines, left_info, split_hunks or {})
+  apply_buffer_lines(right_buf, right_source, alignment.right_lines, right_info, split_hunks or {})
+  set_peers(left_buf, right_buf)
+  refresh_visible_pair_options(left_buf)
+  lists.set_for_split_pair({
+    title = 'diff: ' .. diffspec.label(source.spec),
+    left_buf = left_buf,
+    right_buf = right_buf,
+    hunks = split_hunks,
+    anchors = alignment.anchors,
+    quickfix = source.quickfix,
+  })
   return true, nil
 end
 
@@ -1188,7 +1128,27 @@ function M.open_source(bufnr)
   end
 
   local filepath = resolve_worktree_path(source.repo_root, source.path)
-  local target_lnum = vim.api.nvim_win_get_cursor(source_win)[1]
+  local cursor_row = vim.api.nvim_win_get_cursor(source_win)[1]
+  local info = pane_info[bufnr]
+  local target_lnum = cursor_row
+  if info and info.rows then
+    local row = info.rows[cursor_row]
+    if not row or row.kind == 'filler' or not row.new_lnum then
+      for offset = 0, #info.rows do
+        local above = info.rows[cursor_row - offset]
+        local below = info.rows[cursor_row + offset]
+        if above and above.kind ~= 'filler' and above.new_lnum then
+          row = above
+          break
+        end
+        if below and below.kind ~= 'filler' and below.new_lnum then
+          row = below
+          break
+        end
+      end
+    end
+    target_lnum = (row and row.new_lnum) or cursor_row
+  end
   local existing_win = find_window_for_file(filepath)
   if existing_win then
     vim.api.nvim_set_current_win(existing_win)
@@ -1208,42 +1168,12 @@ end
 
 ---@param bufnr integer
 function M.goto_next(bufnr)
-  local source = buffer_source(bufnr)
-  local hunks = buffer_split_hunks(bufnr)
-  if not source or #hunks == 0 then
-    return
-  end
-
-  local win = current_or_first_window_for_buffer(bufnr) or vim.api.nvim_get_current_win()
-  local cursor_line = vim.api.nvim_win_get_cursor(win)[1]
-  local hunk = next_hunk(hunks, source.side, cursor_line)
-  if not hunk then
-    return
-  end
-  if hunk == hunks[1] and hunk_target_lnum(hunk, source.side) <= cursor_line then
-    notify('wrapped to first hunk', vim.log.levels.INFO)
-  end
-  move_pair_to_hunk(bufnr, hunk)
+  goto_anchor(bufnr, 1)
 end
 
 ---@param bufnr integer
 function M.goto_prev(bufnr)
-  local source = buffer_source(bufnr)
-  local hunks = buffer_split_hunks(bufnr)
-  if not source or #hunks == 0 then
-    return
-  end
-
-  local win = current_or_first_window_for_buffer(bufnr) or vim.api.nvim_get_current_win()
-  local cursor_line = vim.api.nvim_win_get_cursor(win)[1]
-  local hunk = prev_hunk(hunks, source.side, cursor_line)
-  if not hunk then
-    return
-  end
-  if hunk == hunks[#hunks] and hunk_target_lnum(hunk, source.side) >= cursor_line then
-    notify('wrapped to last hunk', vim.log.levels.INFO)
-  end
-  move_pair_to_hunk(bufnr, hunk)
+  goto_anchor(bufnr, -1)
 end
 
 ---@param bufnr integer
@@ -1254,17 +1184,24 @@ function M.move_pair_to_hunk_index(bufnr, hunk_index)
     return false
   end
 
-  local hunks = buffer_split_hunks(bufnr)
-  local hunk = hunks[hunk_index]
-  if not hunk then
+  local info = pane_info[bufnr]
+  local row = info and info.anchors and info.anchors[hunk_index]
+  if not row then
     return false
   end
 
-  move_pair_to_hunk(bufnr, hunk)
+  move_pair_to_row(bufnr, row)
   return true
 end
 
-M.sync_cursor_to_hunk = sync_cursor_to_hunk
+---@param bufnr integer
+function M.sync_cursor_to_hunk(bufnr)
+  local win = current_or_first_window_for_buffer(bufnr)
+  if not win then
+    return
+  end
+  move_pair_to_row(bufnr, vim.api.nvim_win_get_cursor(win)[1])
+end
 
 M._test = {
   buffer_name = buffer_name,

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -940,12 +940,13 @@ function M.open(opts)
   local split_hunks = split_hunks_for(opts.diff_lines, spec)
 
   local reuse = opts.reuse_wins
-  local reusing = reuse ~= nil
-    and vim.api.nvim_win_is_valid(reuse.left)
-    and vim.api.nvim_win_is_valid(reuse.right)
   local invoking_win = vim.api.nvim_get_current_win()
 
   delete_existing_pair_buffers(left_source, right_source)
+
+  local reusing = reuse ~= nil
+    and vim.api.nvim_win_is_valid(reuse.left)
+    and vim.api.nvim_win_is_valid(reuse.right)
 
   ---@type integer[]
   local stale_buffers = {}

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -38,6 +38,10 @@ local clear_cursor_sync
 ---@type fun(bufnr: integer)
 local ensure_cursor_sync
 
+---@class diffs.SplitReuseWins
+---@field left integer
+---@field right integer
+
 ---@class diffs.SplitOpenOpts
 ---@field spec diffs.DiffSpec
 ---@field repo_root string
@@ -47,6 +51,8 @@ local ensure_cursor_sync
 ---@field hunk_index? integer
 ---@field quickfix? boolean
 ---@field change_bar? string
+---@field title? string
+---@field reuse_wins? diffs.SplitReuseWins
 
 ---@class diffs.SplitEndpointSource
 ---@field version integer
@@ -933,17 +939,35 @@ function M.open(opts)
   end
   local split_hunks = split_hunks_for(opts.diff_lines, spec)
 
+  local reuse = opts.reuse_wins
+  local reusing = reuse ~= nil
+    and vim.api.nvim_win_is_valid(reuse.left)
+    and vim.api.nvim_win_is_valid(reuse.right)
   local invoking_win = vim.api.nvim_get_current_win()
+
   delete_existing_pair_buffers(left_source, right_source)
-  if vim.api.nvim_win_is_valid(invoking_win) then
-    vim.api.nvim_set_current_win(invoking_win)
+
+  ---@type integer[]
+  local stale_buffers = {}
+  local left_win, right_win
+  if reusing then
+    left_win, right_win = reuse.left, reuse.right
+    for _, win in ipairs({ left_win, right_win }) do
+      local buf = vim.api.nvim_win_get_buf(win)
+      stale_buffers[#stale_buffers + 1] = buf
+      closing_buffers[buf] = true
+    end
+  else
+    if vim.api.nvim_win_is_valid(invoking_win) then
+      vim.api.nvim_set_current_win(invoking_win)
+    end
+    left_win = vim.api.nvim_get_current_win()
+    vim.cmd('rightbelow vsplit')
+    right_win = vim.api.nvim_get_current_win()
   end
 
   local left_buf = create_buffer(left_source, left_lines, split_hunks, opts.change_bar)
   local right_buf = create_buffer(right_source, right_lines, split_hunks, opts.change_bar)
-  local left_win = vim.api.nvim_get_current_win()
-  vim.cmd('rightbelow vsplit')
-  local right_win = vim.api.nvim_get_current_win()
 
   vim.api.nvim_win_set_buf(left_win, left_buf)
   vim.api.nvim_win_set_buf(right_win, right_buf)
@@ -958,7 +982,7 @@ function M.open(opts)
   set_pair_window_options(left_win)
   set_pair_window_options(right_win)
   lists.set_for_split_pair({
-    title = 'diff: ' .. diffspec.label(spec),
+    title = opts.title or ('diff: ' .. diffspec.label(spec)),
     left_buf = left_buf,
     right_buf = right_buf,
     left_win = left_win,
@@ -969,6 +993,14 @@ function M.open(opts)
 
   if opts.hunk_index and split_hunks[opts.hunk_index] then
     move_pair_to_hunk(right_buf, split_hunks[opts.hunk_index])
+  end
+
+  for _, buf in ipairs(stale_buffers) do
+    clear_pair_tracking(buf, true)
+    if buf ~= left_buf and buf ~= right_buf and vim.api.nvim_buf_is_valid(buf) then
+      pcall(vim.api.nvim_buf_delete, buf, { force = true })
+    end
+    closing_buffers[buf] = nil
   end
 
   log.dbg('opened split diff buffers %d/%d for %s', left_buf, right_buf, diffspec.label(spec))

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -141,9 +141,35 @@ local function set_source_vars(bufnr, source, split_hunks)
   end
 end
 
-local rail_styles = {
-  delete = { bar = 'DiffsDeleteBar', nr = 'DiffsDeleteRailNr', fill = 'DiffsDelete' },
-  add = { bar = 'DiffsAddBar', nr = 'DiffsAddRailNr', fill = 'DiffsAdd' },
+---@class diffs.SplitSideConfig
+---@field kind "delete"|"add"
+---@field lnum "old_lnum"|"new_lnum"
+---@field spans "del_spans"|"add_spans"
+---@field line_hl string
+---@field text_hl string
+---@field bar_hl string
+---@field nr_hl string
+
+---@type table<"left"|"right", diffs.SplitSideConfig>
+local side_config = {
+  left = {
+    kind = 'delete',
+    lnum = 'old_lnum',
+    spans = 'del_spans',
+    line_hl = 'DiffsDelete',
+    text_hl = 'DiffsDeleteText',
+    bar_hl = 'DiffsDeleteBar',
+    nr_hl = 'DiffsDeleteRailNr',
+  },
+  right = {
+    kind = 'add',
+    lnum = 'new_lnum',
+    spans = 'add_spans',
+    line_hl = 'DiffsAdd',
+    text_hl = 'DiffsAddText',
+    bar_hl = 'DiffsAddBar',
+    nr_hl = 'DiffsAddRailNr',
+  },
 }
 
 ---@param info diffs.SplitPaneInfo
@@ -155,18 +181,16 @@ local function rail_segment(info, lnum)
   if not row or row.kind == 'filler' then
     return '%#DiffsRail#' .. string.rep(' ', width + 2)
   end
-  local number = info.side == 'left' and row.old_lnum or row.new_lnum
+  local cfg = side_config[info.side]
+  local number = row[cfg.lnum]
   local numstr = number and ('%' .. width .. 'd'):format(number) or string.rep(' ', width)
-  local changed = (info.side == 'left' and row.kind == 'delete')
-    or (info.side == 'right' and row.kind == 'add')
-  if changed then
-    local style = rail_styles[row.kind]
+  if row.kind == cfg.kind then
     return ('%%#%s#%s%%#%s#%s%%#%s# '):format(
-      style.bar,
+      cfg.bar_hl,
       info.change_bar,
-      style.nr,
+      cfg.nr_hl,
       numstr,
-      style.fill
+      cfg.line_hl
     )
   end
   return ('%%#DiffsRailNr# %s '):format(numstr)
@@ -195,18 +219,13 @@ end
 local function set_split_line_bg(bufnr, info)
   vim.api.nvim_buf_clear_namespace(bufnr, split_line_ns, 0, -1)
   local priorities = require('diffs.runtime').get_highlight_opts().highlights.priorities
+  local cfg = side_config[info.side]
   for lnum, row in ipairs(info.rows) do
-    local hl
-    if info.side == 'left' and row.kind == 'delete' then
-      hl = 'DiffsDelete'
-    elseif info.side == 'right' and row.kind == 'add' then
-      hl = 'DiffsAdd'
-    end
-    if hl then
+    if row.kind == cfg.kind then
       pcall(vim.api.nvim_buf_set_extmark, bufnr, split_line_ns, lnum - 1, 0, {
         end_row = lnum,
         end_col = 0,
-        hl_group = hl,
+        hl_group = cfg.line_hl,
         hl_eol = true,
         priority = priorities.line_bg,
       })
@@ -229,15 +248,13 @@ local function set_split_intra(bufnr, info, hunks)
     return
   end
 
-  local side = info.side
-  local want_kind = side == 'left' and 'delete' or 'add'
-  local hl_group = side == 'left' and 'DiffsDeleteText' or 'DiffsAddText'
+  local cfg = side_config[info.side]
   local priority = opts.highlights.priorities.char_bg
 
   ---@type table<integer, integer>
   local lnum_to_row = {}
   for row_index, row in ipairs(info.rows) do
-    local source_lnum = side == 'left' and row.old_lnum or row.new_lnum
+    local source_lnum = row[cfg.lnum]
     if source_lnum then
       lnum_to_row[source_lnum] = row_index
     end
@@ -258,12 +275,10 @@ local function set_split_intra(bufnr, info, hunks)
 
     if #texts > 0 and #texts <= intra_cfg.max_lines then
       local intra = diff.compute_intra_hunks(texts, intra_cfg.algorithm)
-      local spans = intra and (side == 'left' and intra.del_spans or intra.add_spans) or {}
+      local spans = intra and intra[cfg.spans] or {}
       for _, span in ipairs(spans) do
         local ref = refs[span.line]
-        local source_lnum = ref
-          and ref.kind == want_kind
-          and (side == 'left' and ref.old_lnum or ref.new_lnum)
+        local source_lnum = ref and ref.kind == cfg.kind and ref[cfg.lnum]
         local buf_row = source_lnum and lnum_to_row[source_lnum]
         local col_start = span.col_start - 1
         local col_end = span.col_end - 1
@@ -276,7 +291,7 @@ local function set_split_intra(bufnr, info, hunks)
         then
           pcall(vim.api.nvim_buf_set_extmark, bufnr, split_intra_ns, buf_row - 1, col_start, {
             end_col = col_end,
-            hl_group = hl_group,
+            hl_group = cfg.text_hl,
             priority = priority,
           })
         end
@@ -533,7 +548,6 @@ local function clear_split_state(bufnr)
   end
 
   clear_pair_tracking(bufnr)
-  pane_info[bufnr] = nil
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_peer')
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_hunks')
   pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_split_side')
@@ -1100,6 +1114,24 @@ function M.release_pair_window_options(win)
   return true
 end
 
+---@param rows diffs.SplitRow[]
+---@param cursor_row integer
+---@param lnum_field "old_lnum"|"new_lnum"
+---@return diffs.SplitRow?
+local function nearest_non_filler_row(rows, cursor_row, lnum_field)
+  for offset = 0, #rows do
+    local above = rows[cursor_row - offset]
+    if above and above.kind ~= 'filler' and above[lnum_field] then
+      return above
+    end
+    local below = rows[cursor_row + offset]
+    if below and below.kind ~= 'filler' and below[lnum_field] then
+      return below
+    end
+  end
+  return nil
+end
+
 ---@param bufnr integer
 ---@return boolean
 function M.open_source(bufnr)
@@ -1133,22 +1165,9 @@ function M.open_source(bufnr)
   local info = pane_info[bufnr]
   local target_lnum = cursor_row
   if info and info.rows then
-    local row = info.rows[cursor_row]
-    if not row or row.kind == 'filler' or not row.new_lnum then
-      for offset = 0, #info.rows do
-        local above = info.rows[cursor_row - offset]
-        local below = info.rows[cursor_row + offset]
-        if above and above.kind ~= 'filler' and above.new_lnum then
-          row = above
-          break
-        end
-        if below and below.kind ~= 'filler' and below.new_lnum then
-          row = below
-          break
-        end
-      end
-    end
-    target_lnum = (row and row.new_lnum) or cursor_row
+    local lnum_field = side_config[source.side].lnum
+    local row = nearest_non_filler_row(info.rows, cursor_row, lnum_field)
+    target_lnum = (row and row[lnum_field]) or cursor_row
   end
   local existing_win = find_window_for_file(filepath)
   if existing_win then

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -27,10 +27,10 @@ local split_intra_ns = vim.api.nvim_create_namespace('diffs_split_intra')
 local default_change_bar = '▏'
 
 local split_winhighlight = table.concat({
-  'DiffAdd:DiffsClear',
-  'DiffChange:DiffsClear',
-  'DiffText:DiffsClear',
+  'DiffAdd:DiffsDiffAdd',
   'DiffDelete:DiffsDiffDelete',
+  'DiffChange:DiffsDiffChange',
+  'DiffText:DiffsDiffChange',
 }, ',')
 
 ---@type fun(bufnr: integer)
@@ -148,34 +148,24 @@ end
 ---@param source diffs.SplitEndpointSource
 ---@param split_hunks? diffs.GdiffHunk[]
 ---@param change_bar? string
-local function set_split_line_decorations(bufnr, source, split_hunks, change_bar)
+local function set_split_change_bars(bufnr, source, split_hunks, change_bar)
   vim.api.nvim_buf_clear_namespace(bufnr, split_bar_ns, 0, -1)
-  local line_bg_priority = require('diffs.runtime').get_highlight_opts().highlights.priorities.line_bg
-  local side = source.side
-  local line_count = vim.api.nvim_buf_line_count(bufnr)
   for _, hunk in ipairs(split_hunks or {}) do
     for _, line in ipairs(hunk.lines or {}) do
-      local lnum, bar_hl, line_hl, number_hl
-      if side == 'left' and line.kind == 'delete' then
-        lnum, bar_hl, line_hl, number_hl =
-          line.old_lnum, 'DiffsDeleteBar', 'DiffsDelete', 'DiffsDeleteRailNr'
-      elseif side == 'right' and line.kind == 'add' then
-        lnum, bar_hl, line_hl, number_hl =
-          line.new_lnum, 'DiffsAddBar', 'DiffsAdd', 'DiffsAddRailNr'
+      local lnum
+      local hl_group
+      if source.side == 'left' and line.kind == 'delete' then
+        lnum = line.old_lnum
+        hl_group = 'DiffsDeleteBar'
+      elseif source.side == 'right' and line.kind == 'add' then
+        lnum = line.new_lnum
+        hl_group = 'DiffsAddBar'
       end
 
-      if lnum and lnum >= 1 and lnum <= line_count then
-        pcall(vim.api.nvim_buf_set_extmark, bufnr, split_bar_ns, lnum - 1, 0, {
-          end_row = lnum,
-          end_col = 0,
-          hl_group = line_hl,
-          hl_eol = true,
-          priority = line_bg_priority,
-        })
+      if lnum and lnum >= 1 and lnum <= vim.api.nvim_buf_line_count(bufnr) then
         pcall(vim.api.nvim_buf_set_extmark, bufnr, split_bar_ns, lnum - 1, 0, {
           sign_text = change_bar or default_change_bar,
-          sign_hl_group = bar_hl,
-          number_hl_group = number_hl,
+          sign_hl_group = hl_group,
           priority = 210,
         })
       end
@@ -323,7 +313,7 @@ local function create_buffer(source, lines, split_hunks, change_bar)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   vim.api.nvim_buf_set_name(bufnr, buffer_name(source))
   set_source_vars(bufnr, source, split_hunks)
-  set_split_line_decorations(bufnr, source, split_hunks, change_bar)
+  set_split_change_bars(bufnr, source, split_hunks, change_bar)
   set_split_intra(bufnr, source, split_hunks)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)
@@ -352,18 +342,7 @@ local function remember_pair_window_options(win)
     foldcolumn = vim.api.nvim_get_option_value('foldcolumn', { win = win }),
     signcolumn = vim.api.nvim_get_option_value('signcolumn', { win = win }),
     winhighlight = vim.api.nvim_get_option_value('winhighlight', { win = win }),
-    number = vim.api.nvim_get_option_value('number', { win = win }),
-    relativenumber = vim.api.nvim_get_option_value('relativenumber', { win = win }),
-    numberwidth = vim.api.nvim_get_option_value('numberwidth', { win = win }),
-    colorcolumn = vim.api.nvim_get_option_value('colorcolumn', { win = win }),
   }
-end
-
----@param win integer
----@return integer
-local function rail_numberwidth(win)
-  local count = vim.api.nvim_buf_line_count(vim.api.nvim_win_get_buf(win))
-  return math.max(3, math.min(20, #tostring(count) + 1))
 end
 
 ---@param win integer
@@ -371,10 +350,6 @@ local function set_pair_window_options(win)
   vim.api.nvim_set_option_value('scrollbind', true, { win = win })
   vim.api.nvim_set_option_value('cursorbind', true, { win = win })
   vim.api.nvim_set_option_value('signcolumn', 'yes:1', { win = win })
-  vim.api.nvim_set_option_value('number', true, { win = win })
-  vim.api.nvim_set_option_value('relativenumber', false, { win = win })
-  vim.api.nvim_set_option_value('numberwidth', rail_numberwidth(win), { win = win })
-  vim.api.nvim_set_option_value('colorcolumn', '', { win = win })
   vim.api.nvim_set_option_value('winhighlight', split_winhighlight, { win = win })
   disable_diff_folds(win)
 end
@@ -395,10 +370,6 @@ local function clear_pair_window_options(win)
   pcall(vim.api.nvim_set_option_value, 'diff', false, { win = win })
   pcall(vim.api.nvim_set_option_value, 'foldenable', true, { win = win })
   pcall(vim.api.nvim_set_option_value, 'winhighlight', '', { win = win })
-  pcall(vim.api.nvim_set_option_value, 'number', false, { win = win })
-  pcall(vim.api.nvim_set_option_value, 'relativenumber', false, { win = win })
-  pcall(vim.api.nvim_set_option_value, 'numberwidth', 4, { win = win })
-  pcall(vim.api.nvim_set_option_value, 'colorcolumn', '', { win = win })
 end
 
 ---@param win integer
@@ -782,7 +753,7 @@ local function apply_buffer_lines(bufnr, source, lines, split_hunks, change_bar)
   vim.api.nvim_set_option_value('modifiable', true, { buf = bufnr })
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   set_source_vars(bufnr, source, split_hunks)
-  set_split_line_decorations(bufnr, source, split_hunks, change_bar)
+  set_split_change_bars(bufnr, source, split_hunks, change_bar)
   set_split_intra(bufnr, source, split_hunks)
   set_buffer_options(bufnr, source.filetype)
   set_keymaps(bufnr)

--- a/lua/diffs/split_align.lua
+++ b/lua/diffs/split_align.lua
@@ -32,17 +32,22 @@ function M.align(old_lines, new_lines, hunks)
   end
 
   local function push_context(old_lnum, new_lnum, hunk_index)
-    push(old_lines[old_lnum] or '', {
-      kind = 'context',
-      old_lnum = old_lnum,
-      new_lnum = new_lnum,
-      hunk_index = hunk_index,
-    }, new_lines[new_lnum] or '', {
-      kind = 'context',
-      old_lnum = old_lnum,
-      new_lnum = new_lnum,
-      hunk_index = hunk_index,
-    })
+    push(
+      old_lines[old_lnum] or '',
+      {
+        kind = 'context',
+        old_lnum = old_lnum,
+        new_lnum = new_lnum,
+        hunk_index = hunk_index,
+      },
+      new_lines[new_lnum] or '',
+      {
+        kind = 'context',
+        old_lnum = old_lnum,
+        new_lnum = new_lnum,
+        hunk_index = hunk_index,
+      }
+    )
   end
 
   local function flush_change(dels, adds, hunk_index)

--- a/lua/diffs/split_align.lua
+++ b/lua/diffs/split_align.lua
@@ -1,0 +1,113 @@
+local M = {}
+
+local FILLER = ''
+
+---@class diffs.SplitRow
+---@field kind "context"|"delete"|"add"|"filler"
+---@field old_lnum integer?
+---@field new_lnum integer?
+---@field hunk_index integer?
+
+---@class diffs.SplitAlignment
+---@field left_lines string[]
+---@field right_lines string[]
+---@field left_rows diffs.SplitRow[]
+---@field right_rows diffs.SplitRow[]
+---@field anchors integer[] buffer row (1-indexed) of each hunk's first changed line
+
+---@param old_lines string[]
+---@param new_lines string[]
+---@param hunks diffs.GdiffHunk[]
+---@return diffs.SplitAlignment
+function M.align(old_lines, new_lines, hunks)
+  local left_lines, right_lines = {}, {}
+  local left_rows, right_rows = {}, {}
+  local anchors = {}
+
+  local function push(lt, lr, rt, rr)
+    left_lines[#left_lines + 1] = lt
+    left_rows[#left_rows + 1] = lr
+    right_lines[#right_lines + 1] = rt
+    right_rows[#right_rows + 1] = rr
+  end
+
+  local function push_context(old_lnum, new_lnum, hunk_index)
+    push(old_lines[old_lnum] or '', {
+      kind = 'context',
+      old_lnum = old_lnum,
+      new_lnum = new_lnum,
+      hunk_index = hunk_index,
+    }, new_lines[new_lnum] or '', {
+      kind = 'context',
+      old_lnum = old_lnum,
+      new_lnum = new_lnum,
+      hunk_index = hunk_index,
+    })
+  end
+
+  local function flush_change(dels, adds, hunk_index)
+    if hunk_index and not anchors[hunk_index] and (#dels > 0 or #adds > 0) then
+      anchors[hunk_index] = #left_lines + 1
+    end
+    for i = 1, math.max(#dels, #adds) do
+      local d, a = dels[i], adds[i]
+      push(
+        d and (old_lines[d] or '') or FILLER,
+        d and { kind = 'delete', old_lnum = d, hunk_index = hunk_index }
+          or { kind = 'filler', hunk_index = hunk_index },
+        a and (new_lines[a] or '') or FILLER,
+        a and { kind = 'add', new_lnum = a, hunk_index = hunk_index }
+          or { kind = 'filler', hunk_index = hunk_index }
+      )
+    end
+  end
+
+  local old_cursor, new_cursor = 1, 1
+  for _, hunk in ipairs(hunks) do
+    while old_cursor < hunk.old_range.start do
+      push_context(old_cursor, new_cursor)
+      old_cursor = old_cursor + 1
+      new_cursor = new_cursor + 1
+    end
+
+    local dels, adds = {}, {}
+    local function flush()
+      if #dels > 0 or #adds > 0 then
+        flush_change(dels, adds, hunk.index)
+        dels, adds = {}, {}
+      end
+    end
+
+    for _, line in ipairs(hunk.lines) do
+      if line.kind == 'context' then
+        flush()
+        push_context(line.old_lnum, line.new_lnum, hunk.index)
+        old_cursor = (line.old_lnum or old_cursor) + 1
+        new_cursor = (line.new_lnum or new_cursor) + 1
+      elseif line.kind == 'delete' then
+        dels[#dels + 1] = line.old_lnum
+        old_cursor = (line.old_lnum or old_cursor) + 1
+      elseif line.kind == 'add' then
+        adds[#adds + 1] = line.new_lnum
+        new_cursor = (line.new_lnum or new_cursor) + 1
+      end
+    end
+    flush()
+  end
+
+  while old_cursor <= #old_lines do
+    push_context(old_cursor, new_cursor)
+    old_cursor = old_cursor + 1
+    new_cursor = new_cursor + 1
+  end
+
+  return {
+    left_lines = left_lines,
+    right_lines = right_lines,
+    left_rows = left_rows,
+    right_rows = right_rows,
+    anchors = anchors,
+  }
+end
+
+return M

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1259,11 +1259,13 @@ describe('commands', function()
       assert.are.equal(12, right_mark[4].end_col)
 
       assert.is_true(
-        vim.api.nvim_get_option_value('winhighlight', { win = left_win })
+        vim.api
+          .nvim_get_option_value('winhighlight', { win = left_win })
           :find('DiffText:DiffsDiffChange', 1, true) ~= nil
       )
       assert.is_true(
-        vim.api.nvim_get_option_value('winhighlight', { win = right_win })
+        vim.api
+          .nvim_get_option_value('winhighlight', { win = right_win })
           :find('DiffText:DiffsDiffChange', 1, true) ~= nil
       )
     end)
@@ -1304,11 +1306,13 @@ describe('commands', function()
       runtime.attach_diff()
 
       assert.is_true(
-        vim.api.nvim_get_option_value('winhighlight', { win = left_win })
+        vim.api
+          .nvim_get_option_value('winhighlight', { win = left_win })
           :find('DiffText:DiffsDiffChange', 1, true) ~= nil
       )
       assert.is_true(
-        vim.api.nvim_get_option_value('winhighlight', { win = right_win })
+        vim.api
+          .nvim_get_option_value('winhighlight', { win = right_win })
           :find('DiffText:DiffsDiffChange', 1, true) ~= nil
       )
     end)

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1144,14 +1144,13 @@ describe('commands', function()
         'diffs://split:right:worktree:lua/foo.lua',
         vim.api.nvim_buf_get_name(right_buf)
       )
-      assert.are.same(
-        { 'local M = {}', 'return M' },
-        vim.api.nvim_buf_get_lines(left_buf, 0, -1, false)
-      )
-      assert.are.same(
-        { 'local M = {}', 'local x = 1', 'return M' },
-        vim.api.nvim_buf_get_lines(right_buf, 0, -1, false)
-      )
+      local left_lines = vim.api.nvim_buf_get_lines(left_buf, 0, -1, false)
+      local right_lines = vim.api.nvim_buf_get_lines(right_buf, 0, -1, false)
+      assert.are.equal(#left_lines, #right_lines)
+      assert.are.equal('local M = {}', left_lines[1])
+      assert.are.equal('local M = {}', right_lines[1])
+      assert.are.equal('local x = 1', right_lines[2])
+      assert.is_true(vim.tbl_contains(left_lines, ''))
       assert.are.same(
         diffspec.index_to_worktree('lua/foo.lua'),
         vim.api.nvim_buf_get_var(left_buf, 'diffs_spec')
@@ -1162,10 +1161,12 @@ describe('commands', function()
       assert.are.equal('lua', vim.api.nvim_get_option_value('filetype', { buf = right_buf }))
       assert.is_false(vim.api.nvim_get_option_value('modifiable', { buf = left_buf }))
       assert.is_false(vim.api.nvim_get_option_value('modifiable', { buf = right_buf }))
-      assert.is_true(vim.api.nvim_get_option_value('diff', { win = left_win }))
-      assert.is_true(vim.api.nvim_get_option_value('diff', { win = right_win }))
-      assert.are.equal('yes:1', vim.api.nvim_get_option_value('signcolumn', { win = left_win }))
-      assert.are.equal('yes:1', vim.api.nvim_get_option_value('signcolumn', { win = right_win }))
+      assert.is_false(vim.api.nvim_get_option_value('diff', { win = left_win }))
+      assert.is_false(vim.api.nvim_get_option_value('diff', { win = right_win }))
+      assert.is_false(vim.api.nvim_get_option_value('number', { win = left_win }))
+      assert.is_false(vim.api.nvim_get_option_value('number', { win = right_win }))
+      assert.is_true(vim.api.nvim_get_option_value('statuscolumn', { win = left_win }) ~= '')
+      assert.is_true(vim.api.nvim_get_option_value('statuscolumn', { win = right_win }) ~= '')
       assert.are.equal('manual', vim.api.nvim_get_option_value('foldmethod', { win = left_win }))
       assert.are.equal('manual', vim.api.nvim_get_option_value('foldmethod', { win = right_win }))
       assert.is_false(vim.api.nvim_get_option_value('foldenable', { win = left_win }))
@@ -1188,27 +1189,26 @@ describe('commands', function()
       assert.is_false(helpers.has_keymap(right_buf, 'dp'))
       assert.is_false(helpers.has_keymap(right_buf, 'do'))
 
-      local bar_ns = vim.api.nvim_get_namespaces().diffs_split_change_bar
-      local right_bars = vim.api.nvim_buf_get_extmarks(right_buf, bar_ns, 0, -1, {
-        details = true,
-      })
-      local has_added_line_bar = false
-      for _, mark in ipairs(right_bars) do
-        local details = mark[4]
-        if
-          mark[2] == 1
-          and details.sign_hl_group == 'DiffsAddBar'
-          and details.sign_text == '┃ '
-        then
-          has_added_line_bar = true
+      local line_ns = vim.api.nvim_get_namespaces().diffs_split_line
+      local right_bg = vim.api.nvim_buf_get_extmarks(right_buf, line_ns, 0, -1, { details = true })
+      local has_added_line_bg = false
+      for _, mark in ipairs(right_bg) do
+        if mark[2] == 1 and mark[4].hl_group == 'DiffsAdd' and mark[4].hl_eol then
+          has_added_line_bg = true
         end
       end
-      assert.is_true(has_added_line_bar)
+      assert.is_true(has_added_line_bg)
+
+      vim.g.statusline_winid = right_win
+      vim.v.lnum = 2
+      local rail = require('diffs.split').statuscolumn()
+      assert.is_true(rail:find('DiffsAddBar', 1, true) ~= nil)
+      assert.is_true(rail:find('┃', 1, true) ~= nil)
 
       local qf = quickfix_items()
       assert.are.equal(1, #qf)
       assert.are.equal(right_buf, qf[1].bufnr)
-      assert.are.equal(1, qf[1].lnum)
+      assert.are.equal(2, qf[1].lnum)
       assert.is_true(qf[1].text:find('lua/foo.lua', 1, true) ~= nil)
 
       local left_loc = loclist_items(left_win)
@@ -1231,7 +1231,6 @@ describe('commands', function()
       local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
       table.insert(test_buffers, left_buf)
       table.insert(test_buffers, right_buf)
-      local left_win, right_win = find_split_windows(left_buf, right_buf)
 
       local intra_ns = vim.api.nvim_get_namespaces().diffs_split_intra
       assert.is_not_nil(intra_ns)
@@ -1258,16 +1257,9 @@ describe('commands', function()
       assert.are.equal(9, right_mark[3])
       assert.are.equal(12, right_mark[4].end_col)
 
-      assert.is_true(
-        vim.api
-          .nvim_get_option_value('winhighlight', { win = left_win })
-          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
-      )
-      assert.is_true(
-        vim.api
-          .nvim_get_option_value('winhighlight', { win = right_win })
-          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
-      )
+      local line_ns = vim.api.nvim_get_namespaces().diffs_split_line
+      assert.is_true(#vim.api.nvim_buf_get_extmarks(left_buf, line_ns, { 1, 0 }, { 1, -1 }, {}) > 0)
+      assert.is_true(#vim.api.nvim_buf_get_extmarks(right_buf, line_ns, { 1, 0 }, { 1, -1 }, {}) > 0)
     end)
 
     it('skips the intra overlay when highlights.intra is disabled', function()
@@ -1292,7 +1284,7 @@ describe('commands', function()
       assert.are.equal(0, #vim.api.nvim_buf_get_extmarks(right_buf, intra_ns, 0, -1, {}))
     end)
 
-    it('keeps the split DiffText suppression when attach_diff re-runs', function()
+    it('leaves split panes untouched when attach_diff re-runs', function()
       mock_view_config({ prefix = true, change_bar = '┃', rail_separator = '│' })
       create_split_source()
       commands.gdiff('++layout=split', false)
@@ -1305,16 +1297,10 @@ describe('commands', function()
 
       runtime.attach_diff()
 
-      assert.is_true(
-        vim.api
-          .nvim_get_option_value('winhighlight', { win = left_win })
-          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
-      )
-      assert.is_true(
-        vim.api
-          .nvim_get_option_value('winhighlight', { win = right_win })
-          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
-      )
+      assert.is_false(vim.api.nvim_get_option_value('diff', { win = left_win }))
+      assert.is_false(vim.api.nvim_get_option_value('diff', { win = right_win }))
+      assert.is_true(vim.api.nvim_get_option_value('statuscolumn', { win = left_win }) ~= '')
+      assert.is_true(vim.api.nvim_get_option_value('statuscolumn', { win = right_win }) ~= '')
     end)
 
     it('warns and still opens the split when :vertical Diff ++layout=split is used', function()
@@ -1390,20 +1376,29 @@ describe('commands', function()
       local right_loc = loclist_items(right_win)
       assert.are.equal(2, #right_loc)
       assert.are.equal(right_buf, right_loc[2].bufnr)
-      assert.are.equal(hunks[2].new_range.start, right_loc[2].lnum)
+
+      local function synced_row()
+        local lrow = vim.api.nvim_win_get_cursor(left_win)[1]
+        local rrow = vim.api.nvim_win_get_cursor(right_win)[1]
+        assert.are.equal(lrow, rrow)
+        return rrow
+      end
+      local function in_hunk(row, hunk)
+        return row >= hunk.new_range.start
+          and row <= math.max(hunk.new_range.start, hunk.new_range.finish)
+      end
 
       vim.api.nvim_set_current_win(right_win)
-      vim.api.nvim_win_set_cursor(right_win, { hunks[1].new_range.start, 0 })
+      vim.api.nvim_win_set_cursor(right_win, { 1, 0 })
 
       split.goto_next(right_buf)
+      assert.is_true(in_hunk(synced_row(), hunks[1]))
 
-      assert.are.same({ hunks[2].old_range.start, 0 }, vim.api.nvim_win_get_cursor(left_win))
-      assert.are.same({ hunks[2].new_range.start, 0 }, vim.api.nvim_win_get_cursor(right_win))
+      split.goto_next(right_buf)
+      assert.is_true(in_hunk(synced_row(), hunks[2]))
 
       split.goto_prev(right_buf)
-
-      assert.are.same({ hunks[1].old_range.start, 0 }, vim.api.nvim_win_get_cursor(left_win))
-      assert.are.same({ hunks[1].new_range.start, 0 }, vim.api.nvim_win_get_cursor(right_win))
+      assert.is_true(in_hunk(synced_row(), hunks[1]))
 
       vim.api.nvim_set_current_win(right_win)
       vim.cmd('lopen')
@@ -1420,11 +1415,14 @@ describe('commands', function()
       vim.api.nvim_win_set_cursor(0, { 2, 0 })
       vim.cmd('normal \r')
       vim.wait(100, function()
-        return vim.api.nvim_win_get_cursor(left_win)[1] == hunks[2].old_range.start
+        return vim.api.nvim_win_get_cursor(left_win)[1] == right_loc[2].lnum
       end)
 
-      assert.are.same({ hunks[2].old_range.start, 0 }, vim.api.nvim_win_get_cursor(left_win))
-      assert.are.same({ hunks[2].new_range.start, 0 }, vim.api.nvim_win_get_cursor(right_win))
+      assert.are.equal(right_loc[2].lnum, vim.api.nvim_win_get_cursor(left_win)[1])
+      assert.are.equal(
+        vim.api.nvim_win_get_cursor(left_win)[1],
+        vim.api.nvim_win_get_cursor(right_win)[1]
+      )
     end)
 
     it('targets the old endpoint for split deleted hunks in qf and loclist', function()
@@ -3241,14 +3239,10 @@ describe('commands', function()
       local hunks = vim.api.nvim_buf_get_var(panes.right_buf, 'diffs_split_hunks')
       local hunk = hunks[hunk_index]
       assert.is_not_nil(hunk)
-      assert.are.same(
-        { math.max(1, hunk.new_range.start), 0 },
-        vim.api.nvim_win_get_cursor(panes.right_win)
-      )
-      assert.are.same(
-        { math.max(1, hunk.old_range.start), 0 },
-        vim.api.nvim_win_get_cursor(panes.left_win)
-      )
+      local left_row = vim.api.nvim_win_get_cursor(panes.left_win)[1]
+      local right_row = vim.api.nvim_win_get_cursor(panes.right_win)[1]
+      assert.are.equal(left_row, right_row)
+      assert.is_true(right_row >= 1)
     end
 
     local function create_mode_first_review_repo()
@@ -3314,8 +3308,8 @@ describe('commands', function()
       )
       assert.are.equal(2, #main_windows())
       assert.is_nil(visible_review_map())
-      assert.is_true(vim.api.nvim_get_option_value('diff', { win = panes.left_win }))
-      assert.is_true(vim.api.nvim_get_option_value('diff', { win = panes.right_win }))
+      assert.is_false(vim.api.nvim_get_option_value('diff', { win = panes.left_win }))
+      assert.is_false(vim.api.nvim_get_option_value('diff', { win = panes.right_win }))
       assert.is_true(vim.api.nvim_get_option_value('scrollbind', { win = panes.left_win }))
       assert.is_true(vim.api.nvim_get_option_value('scrollbind', { win = panes.right_win }))
 

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1303,6 +1303,39 @@ describe('commands', function()
       assert.is_true(vim.api.nvim_get_option_value('statuscolumn', { win = right_win }) ~= '')
     end)
 
+    it('renders real per-side line numbers through the statuscolumn rail', function()
+      mock_view_config({ prefix = true, change_bar = '┃', rail_separator = '│' })
+      create_split_source({
+        index_lines = { 'a', 'b', 'c', 'd' },
+        worktree_lines = { 'X', 'a', 'b', 'c', 'd' },
+      })
+      commands.gdiff('++layout=split', false)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+      local left_win, right_win = find_split_windows(left_buf, right_buf)
+
+      local function rail(win, lnum)
+        local sc = vim.api.nvim_get_option_value('statuscolumn', { win = win })
+        return vim.api.nvim_eval_statusline(
+          sc,
+          { winid = win, use_statuscol_lnum = lnum, highlights = false }
+        ).str
+      end
+
+      assert.are.equal(
+        vim.api.nvim_buf_line_count(left_buf),
+        vim.api.nvim_buf_line_count(right_buf)
+      )
+      assert.is_true(#rail(right_win, 1) > 0)
+      assert.is_true(rail(right_win, 1):find('1', 1, true) ~= nil)
+      assert.is_true(rail(left_win, 2):find('1', 1, true) ~= nil)
+      assert.is_true(rail(right_win, 2):find('2', 1, true) ~= nil)
+      assert.is_true(rail(right_win, 2):find('1', 1, true) == nil)
+    end)
+
     it('warns and still opens the split when :vertical Diff ++layout=split is used', function()
       local notifications = capture_notifications()
       local saved_splitright = vim.o.splitright

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -12,6 +12,7 @@ local saved_git = {}
 local saved_runtime_attach
 local saved_runtime_get_conflict_config
 local saved_runtime_get_view_config
+local saved_runtime_get_highlight_opts
 local saved_schedule
 local saved_systemlist
 local saved_notify
@@ -61,6 +62,16 @@ local function mock_view_config(config)
   saved_runtime_get_view_config = runtime.get_view_config
   runtime.get_view_config = function()
     return config
+  end
+end
+
+local function mock_highlight_opts(mutate)
+  saved_runtime_get_highlight_opts = runtime.get_highlight_opts
+  local base = saved_runtime_get_highlight_opts()
+  runtime.get_highlight_opts = function()
+    local opts = vim.deepcopy(base)
+    mutate(opts)
+    return opts
   end
 end
 
@@ -375,6 +386,10 @@ local function restore_mocks()
   if saved_runtime_get_view_config then
     runtime.get_view_config = saved_runtime_get_view_config
     saved_runtime_get_view_config = nil
+  end
+  if saved_runtime_get_highlight_opts then
+    runtime.get_highlight_opts = saved_runtime_get_highlight_opts
+    saved_runtime_get_highlight_opts = nil
   end
   if saved_schedule then
     vim.schedule = saved_schedule
@@ -1242,6 +1257,51 @@ describe('commands', function()
       assert.are.equal(1, right_mark[2])
       assert.are.equal(9, right_mark[3])
       assert.are.equal(12, right_mark[4].end_col)
+
+      assert.is_true(
+        vim.api.nvim_get_option_value('winhighlight', { win = left_win })
+          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
+      )
+      assert.is_true(
+        vim.api.nvim_get_option_value('winhighlight', { win = right_win })
+          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
+      )
+    end)
+
+    it('skips the intra overlay when highlights.intra is disabled', function()
+      mock_view_config({ prefix = true, change_bar = '┃', rail_separator = '│' })
+      mock_highlight_opts(function(opts)
+        opts.highlights.intra.enabled = false
+      end)
+      create_split_source({
+        index_lines = { 'function f()', '  return 111', '  log()', 'end' },
+        worktree_lines = { 'function f()', '  return 222', '  log()', 'end' },
+      })
+      commands.gdiff('++layout=split', false)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+
+      local intra_ns = vim.api.nvim_get_namespaces().diffs_split_intra
+      assert.is_not_nil(intra_ns)
+      assert.are.equal(0, #vim.api.nvim_buf_get_extmarks(left_buf, intra_ns, 0, -1, {}))
+      assert.are.equal(0, #vim.api.nvim_buf_get_extmarks(right_buf, intra_ns, 0, -1, {}))
+    end)
+
+    it('keeps the split DiffText suppression when attach_diff re-runs', function()
+      mock_view_config({ prefix = true, change_bar = '┃', rail_separator = '│' })
+      create_split_source()
+      commands.gdiff('++layout=split', false)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+      local left_win, right_win = find_split_windows(left_buf, right_buf)
+
+      runtime.attach_diff()
 
       assert.is_true(
         vim.api.nvim_get_option_value('winhighlight', { win = left_win })

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1261,13 +1261,95 @@ describe('commands', function()
       assert.is_true(
         vim.api
           .nvim_get_option_value('winhighlight', { win = left_win })
-          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
+          :find('DiffText:DiffsClear', 1, true) ~= nil
       )
       assert.is_true(
         vim.api
           .nvim_get_option_value('winhighlight', { win = right_win })
-          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
+          :find('DiffText:DiffsClear', 1, true) ~= nil
       )
+    end)
+
+    it('paints a continuous line background and rail number on changed split lines', function()
+      mock_view_config({ prefix = true, change_bar = '┃', rail_separator = '│' })
+      create_split_source({
+        index_lines = { 'function f()', '  return 111', '  log()', 'end' },
+        worktree_lines = { 'function f()', '  return 222', '  log()', 'end' },
+      })
+      commands.gdiff('++layout=split', false)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+      local left_win, right_win = find_split_windows(left_buf, right_buf)
+
+      local bar_ns = vim.api.nvim_get_namespaces().diffs_split_change_bar
+      local function details_at(bufnr, row)
+        local found = {}
+        for _, mark in
+          ipairs(vim.api.nvim_buf_get_extmarks(bufnr, bar_ns, 0, -1, { details = true }))
+        do
+          if mark[2] == row then
+            found[#found + 1] = mark[4]
+          end
+        end
+        return found
+      end
+      local function has(marks, key, value)
+        for _, d in ipairs(marks) do
+          if d[key] == value then
+            return true
+          end
+        end
+        return false
+      end
+
+      local left_changed = details_at(left_buf, 1)
+      assert.is_true(has(left_changed, 'hl_group', 'DiffsDelete'))
+      assert.is_true(has(left_changed, 'hl_eol', true))
+      assert.is_true(has(left_changed, 'number_hl_group', 'DiffsDeleteRailNr'))
+
+      local right_changed = details_at(right_buf, 1)
+      assert.is_true(has(right_changed, 'hl_group', 'DiffsAdd'))
+      assert.is_true(has(right_changed, 'hl_eol', true))
+      assert.is_true(has(right_changed, 'number_hl_group', 'DiffsAddRailNr'))
+
+      assert.are.equal(0, #details_at(left_buf, 0))
+      assert.are.equal(0, #details_at(right_buf, 0))
+
+      assert.is_true(vim.api.nvim_get_option_value('number', { win = left_win }))
+      assert.is_true(vim.api.nvim_get_option_value('number', { win = right_win }))
+    end)
+
+    it('decorates the added side and leaves the empty side bare for a pure-add file', function()
+      mock_view_config({ prefix = true, change_bar = '┃', rail_separator = '│' })
+      create_split_source({
+        index_lines = {},
+        worktree_lines = { 'local M = {}', 'return M' },
+      })
+      commands.gdiff('++layout=split', false)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+
+      local bar_ns = vim.api.nvim_get_namespaces().diffs_split_change_bar
+      local function line_bg_count(bufnr)
+        local n = 0
+        for _, mark in
+          ipairs(vim.api.nvim_buf_get_extmarks(bufnr, bar_ns, 0, -1, { details = true }))
+        do
+          if mark[4].hl_group == 'DiffsAdd' or mark[4].hl_group == 'DiffsDelete' then
+            n = n + 1
+          end
+        end
+        return n
+      end
+
+      assert.are.equal(2, line_bg_count(right_buf))
+      assert.are.equal(0, line_bg_count(left_buf))
     end)
 
     it('skips the intra overlay when highlights.intra is disabled', function()
@@ -1308,12 +1390,12 @@ describe('commands', function()
       assert.is_true(
         vim.api
           .nvim_get_option_value('winhighlight', { win = left_win })
-          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
+          :find('DiffText:DiffsClear', 1, true) ~= nil
       )
       assert.is_true(
         vim.api
           .nvim_get_option_value('winhighlight', { win = right_win })
-          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
+          :find('DiffText:DiffsClear', 1, true) ~= nil
       )
     end)
 

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -411,6 +411,9 @@ describe('commands', function()
     restore_mocks()
     cleanup_buffers()
     cleanup_repos()
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+      pcall(vim.api.nvim_set_option_value, 'winhighlight', '', { win = win })
+    end
   end)
 
   describe('setup', function()
@@ -3105,7 +3108,7 @@ describe('commands', function()
       assert.is_true(text:find('# Unstaged:', 1, true) ~= nil)
       assert.is_true(text:find('# Untracked:', 1, true) ~= nil)
       assert.is_true(text:find('+branch head', 1, true) ~= nil)
-      assert.is_nil(commands._test.greview_workspace_state(bufnr))
+      assert.is_nil(commands._test.review_split_state(bufnr))
 
       local qf = quickfix_items()
       assert.are.equal(7, #qf)
@@ -3142,16 +3145,22 @@ describe('commands', function()
       return nil
     end
 
-    local function track_workspace(bufnr)
-      assert.is_not_nil(bufnr)
-      table.insert(test_buffers, bufnr)
-      local state = commands._test.greview_workspace_state(bufnr)
+    local function track_panes(left_buf)
+      assert.is_not_nil(left_buf)
+      table.insert(test_buffers, left_buf)
+      local right_buf = vim.api.nvim_buf_get_var(left_buf, 'diffs_split_peer')
+      table.insert(test_buffers, right_buf)
+      local state = commands._test.review_split_state(left_buf)
       assert.is_not_nil(state)
-      assert.are.equal(bufnr, state.diff_buf)
-      if state.target_buf then
-        table.insert(test_buffers, state.target_buf)
-      end
-      return state
+      assert.are.equal(left_buf, state.left_buf)
+      assert.are.equal(right_buf, state.right_buf)
+      return {
+        state = state,
+        left_buf = left_buf,
+        right_buf = right_buf,
+        left_win = state.left_win,
+        right_win = state.right_win,
+      }
     end
 
     local function run_buf_keymap(bufnr, lhs)
@@ -3164,12 +3173,18 @@ describe('commands', function()
       error('missing buffer keymap: ' .. lhs)
     end
 
-    local function assert_target_at_hunk(state, hunk_index)
-      local hunks = vim.api.nvim_buf_get_var(state.diff_buf, 'diffs_hunks')
+    local function assert_target_at_hunk(panes, hunk_index)
+      local hunks = vim.api.nvim_buf_get_var(panes.right_buf, 'diffs_split_hunks')
       local hunk = hunks[hunk_index]
       assert.is_not_nil(hunk)
-      local target_lnum = math.max(1, hunk.new_range.start)
-      assert.are.same({ target_lnum, 0 }, vim.api.nvim_win_get_cursor(state.target_win))
+      assert.are.same(
+        { math.max(1, hunk.new_range.start), 0 },
+        vim.api.nvim_win_get_cursor(panes.right_win)
+      )
+      assert.are.same(
+        { math.max(1, hunk.old_range.start), 0 },
+        vim.api.nvim_win_get_cursor(panes.left_win)
+      )
     end
 
     local function create_mode_first_review_repo()
@@ -3204,30 +3219,50 @@ describe('commands', function()
       edit_file(repo_root .. '/file.txt')
       mock_runtime_attach(function() end)
 
-      local diff_buf = commands.greview_command('++layout=split HEAD')
-      local state = track_workspace(diff_buf)
+      local left_buf = commands.greview_command('++layout=split HEAD')
+      local panes = track_panes(left_buf)
 
-      assert.are.equal('diffs://review-split:HEAD', vim.api.nvim_buf_get_name(diff_buf))
+      assert.are.equal(
+        'diffs://split:left:index:file.txt',
+        vim.api.nvim_buf_get_name(panes.left_buf)
+      )
+      assert.are.equal(
+        'diffs://split:right:worktree:file.txt',
+        vim.api.nvim_buf_get_name(panes.right_buf)
+      )
       assert.are.same(
         diffspec.index_to_worktree('file.txt'),
-        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+        vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec')
       )
-      assert.are.equal(repo_root .. '/file.txt', vim.api.nvim_buf_get_name(state.target_buf))
-      assert.is_false(state.target_scratch)
+      assert.are.same(
+        diffspec.index_to_worktree('file.txt'),
+        vim.api.nvim_buf_get_var(panes.right_buf, 'diffs_spec')
+      )
+      assert.are.equal('left', vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_split_side'))
+      assert.are.equal('right', vim.api.nvim_buf_get_var(panes.right_buf, 'diffs_split_side'))
+      assert.are.same(
+        { 'line 1', 'line 2' },
+        vim.api.nvim_buf_get_lines(panes.left_buf, 0, -1, false)
+      )
+      assert.are.same(
+        { 'line 1', 'line 2 changed' },
+        vim.api.nvim_buf_get_lines(panes.right_buf, 0, -1, false)
+      )
       assert.are.equal(2, #main_windows())
       assert.is_nil(visible_review_map())
-      assert.is_false(vim.api.nvim_get_option_value('diff', { win = state.diff_win }))
-      assert.is_false(vim.api.nvim_get_option_value('diff', { win = state.target_win }))
-      assert.is_true(buffer_text(diff_buf):find('+line 2 changed', 1, true) ~= nil)
+      assert.is_true(vim.api.nvim_get_option_value('diff', { win = panes.left_win }))
+      assert.is_true(vim.api.nvim_get_option_value('diff', { win = panes.right_win }))
+      assert.is_true(vim.api.nvim_get_option_value('scrollbind', { win = panes.left_win }))
+      assert.is_true(vim.api.nvim_get_option_value('scrollbind', { win = panes.right_win }))
 
       local qf = quickfix_items()
       assert.are.equal(1, #qf)
-      assert.are.equal(diff_buf, qf[1].bufnr)
+      assert.are.equal(panes.left_buf, qf[1].bufnr)
       assert.is_true(qf[1].text:find('file.txt', 1, true) ~= nil)
 
-      local loc = loclist_items(state.diff_win)
+      local loc = loclist_items(panes.left_win)
       assert.are.equal(1, #loc)
-      assert.are.equal(diff_buf, loc[1].bufnr)
+      assert.are.equal(panes.left_buf, loc[1].bufnr)
       assert.is_true(loc[1].text:find('file.txt', 1, true) ~= nil)
     end)
 
@@ -3238,9 +3273,9 @@ describe('commands', function()
       mock_runtime_attach(function() end)
       local notifications = capture_notifications()
 
-      local diff_buf =
+      local left_buf =
         commands.greview_command('++layout=split HEAD', true, { warn_vertical_split = true })
-      track_workspace(diff_buf)
+      track_panes(left_buf)
 
       local warned = false
       for _, n in ipairs(notifications) do
@@ -3271,14 +3306,14 @@ describe('commands', function()
       local source_buf = edit_file(repo.repo_root .. '/lua/one.lua')
       local source_win = vim.api.nvim_get_current_win()
 
-      local diff_buf = commands.greview_split({ bufnr = review_buf })
-      local state = track_workspace(diff_buf)
+      local left_buf = commands.greview_split({ bufnr = review_buf })
+      local panes = track_panes(left_buf)
 
-      assert.are.equal(review_win, state.diff_win)
+      assert.are.equal(review_win, panes.left_win)
       assert.are.equal(source_buf, vim.api.nvim_win_get_buf(source_win))
       assert.is_nil(find_window_for_buffer(review_buf))
-      assert.is_not_nil(find_window_for_buffer(state.diff_buf))
-      assert.is_not_nil(find_window_for_buffer(state.target_buf))
+      assert.is_not_nil(find_window_for_buffer(panes.left_buf))
+      assert.is_not_nil(find_window_for_buffer(panes.right_buf))
     end)
 
     it('warns instead of splitting when the selected review buffer is hidden', function()
@@ -3321,24 +3356,21 @@ describe('commands', function()
 
       local first =
         commands.greview_command(('++layout=split %s..%s'):format(repo.base, repo.target))
-      local first_state = track_workspace(first)
-      local first_target_win = first_state.target_win
+      local first_panes = track_panes(first)
+      local first_left = first_panes.left_buf
+      local first_right = first_panes.right_buf
 
       local second =
         commands.greview_command(('++layout=split %s...%s'):format(repo.base, repo.target))
-      local second_state = track_workspace(second)
+      local second_panes = track_panes(second)
 
-      assert.is_false(vim.api.nvim_buf_is_valid(first))
-      assert.is_false(vim.api.nvim_win_is_valid(first_target_win))
-      assert.is_nil(commands._test.greview_workspace_state(first))
-      assert.is_not_nil(commands._test.greview_workspace_state(second))
+      assert.is_false(vim.api.nvim_buf_is_valid(first_left))
+      assert.is_false(vim.api.nvim_buf_is_valid(first_right))
+      assert.is_nil(commands._test.review_split_state(first_left))
+      assert.is_not_nil(commands._test.review_split_state(second))
       assert.are.equal(2, #main_windows())
-      assert.are.equal(
-        'diffs://review-split:' .. repo.base .. '...' .. repo.target,
-        vim.api.nvim_buf_get_name(second)
-      )
-      assert.is_not_nil(find_window_for_buffer(second_state.diff_buf))
-      assert.is_not_nil(find_window_for_buffer(second_state.target_buf))
+      assert.is_not_nil(find_window_for_buffer(second_panes.left_buf))
+      assert.is_not_nil(find_window_for_buffer(second_panes.right_buf))
     end)
 
     it('skips unsupported default review entries when opening direct split workspaces', function()
@@ -3346,21 +3378,26 @@ describe('commands', function()
       edit_file(repo_root .. '/zzz-changed.lua')
       mock_runtime_attach(function() end)
 
-      local diff_buf = commands.greview_command('++layout=split mode-base..mode-topic')
-      track_workspace(diff_buf)
+      local left_buf = commands.greview_command('++layout=split mode-base..mode-topic')
+      local panes = track_panes(left_buf)
 
       assert.are.same(
         diffspec.rev_to_rev('mode-base', 'mode-topic', 'zzz-changed.lua'),
-        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+        vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec')
       )
-      assert.is_true(buffer_text(diff_buf):find('+new', 1, true) ~= nil)
+      assert.are.same(
+        diffspec.rev_to_rev('mode-base', 'mode-topic', 'zzz-changed.lua'),
+        vim.api.nvim_buf_get_var(panes.right_buf, 'diffs_spec')
+      )
+      assert.are.same({ 'old' }, vim.api.nvim_buf_get_lines(panes.left_buf, 0, -1, false))
+      assert.are.same({ 'new' }, vim.api.nvim_buf_get_lines(panes.right_buf, 0, -1, false))
     end)
 
     it('routes current-state duplicate paths by section in the two-surface workspace', function()
       local repo = create_current_state_review_repo()
       mock_runtime_attach(function() end)
 
-      local function open_section(header, expected_spec, target_scratch)
+      local function open_section(header, expected_spec)
         local review_buf = commands.greview({
           base = repo.base,
           repo = repo.repo_root,
@@ -3373,20 +3410,20 @@ describe('commands', function()
         assert.is_not_nil(line)
         vim.api.nvim_win_set_cursor(0, { line, 0 })
 
-        local diff_buf = commands.greview_split({ bufnr = review_buf })
-        local state = track_workspace(diff_buf)
-        assert.are.same(expected_spec, vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec'))
-        assert.are.equal(target_scratch, state.target_scratch)
-        assert.is_not_nil(find_window_for_buffer(state.diff_buf))
-        assert.is_not_nil(find_window_for_buffer(state.target_buf))
+        local left_buf = commands.greview_split({ bufnr = review_buf })
+        local panes = track_panes(left_buf)
+        assert.are.same(expected_spec, vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec'))
+        assert.are.same(expected_spec, vim.api.nvim_buf_get_var(panes.right_buf, 'diffs_spec'))
+        assert.is_not_nil(find_window_for_buffer(panes.left_buf))
+        assert.is_not_nil(find_window_for_buffer(panes.right_buf))
         assert.is_nil(find_window_for_buffer(review_buf))
         assert.is_nil(visible_review_map())
-        commands._test.close_greview_workspace(diff_buf)
+        split.close_pair(panes.left_buf)
       end
 
-      open_section('# Branch:', diffspec.rev_to_rev(repo.base, 'HEAD', 'lua/dup.lua'), true)
-      open_section('# Staged:', diffspec.head_to_index('lua/dup.lua'), true)
-      open_section('# Unstaged:', diffspec.index_to_worktree('lua/dup.lua'), false)
+      open_section('# Branch:', diffspec.rev_to_rev(repo.base, 'HEAD', 'lua/dup.lua'))
+      open_section('# Staged:', diffspec.head_to_index('lua/dup.lua'))
+      open_section('# Unstaged:', diffspec.index_to_worktree('lua/dup.lua'))
     end)
 
     it('uses quickfix for review files and loclist for active-file hunks', function()
@@ -3394,18 +3431,18 @@ describe('commands', function()
       edit_file(repo.repo_root .. '/lua/one.lua')
       mock_runtime_attach(function() end)
 
-      local diff_buf =
+      local left_buf =
         commands.greview_command(('++layout=split %s..%s'):format(repo.base, repo.target))
-      local state = track_workspace(diff_buf)
+      local panes = track_panes(left_buf)
       assert.are.same(
         diffspec.rev_to_rev(repo.base, repo.target, 'lua/one.lua'),
-        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+        vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec')
       )
 
       local qf = quickfix_items()
       assert.are.equal(2, #qf)
-      assert.are.equal(diff_buf, qf[1].bufnr)
-      assert.are.equal(diff_buf, qf[2].bufnr)
+      assert.are.equal(panes.left_buf, qf[1].bufnr)
+      assert.are.equal(panes.left_buf, qf[2].bufnr)
 
       vim.cmd('copen')
       local qf_win = find_quickfix_window()
@@ -3415,126 +3452,74 @@ describe('commands', function()
       vim.cmd('normal \r')
 
       vim.wait(100, function()
-        return commands._test.greview_workspace_state(diff_buf).selected_file == 'lua/two.lua'
+        return panes.state.selected_file == 'lua/two.lua'
       end)
-      state = commands._test.greview_workspace_state(diff_buf)
+
+      panes = track_panes(panes.state.left_buf)
       assert.are.same(
         diffspec.rev_to_rev(repo.base, repo.target, 'lua/two.lua'),
-        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+        vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec')
       )
-      assert.is_true(state.target_scratch)
-      assert.is_true(buffer_text(diff_buf):find('+line 11 changed', 1, true) ~= nil)
-      assert_target_at_hunk(state, 1)
+      assert.are.same(
+        diffspec.rev_to_rev(repo.base, repo.target, 'lua/two.lua'),
+        vim.api.nvim_buf_get_var(panes.right_buf, 'diffs_spec')
+      )
+      assert.is_true(buffer_text(panes.right_buf):find('line 11 changed', 1, true) ~= nil)
 
-      vim.api.nvim_set_current_win(state.diff_win)
+      local new_qf = quickfix_items()
+      assert.are.equal(2, #new_qf)
+      assert.are.equal(panes.left_buf, new_qf[1].bufnr)
+      assert.are.equal(panes.left_buf, new_qf[2].bufnr)
+
+      assert_target_at_hunk(panes, 1)
+
+      vim.api.nvim_set_current_win(panes.left_win)
       vim.cmd('lopen')
-      local loc_win = find_loclist_window_for_window(state.diff_win)
+      local loc_win = find_loclist_window_for_window(panes.left_win)
       assert.is_not_nil(loc_win)
-      local loc = loclist_items(state.diff_win)
+      local loc = loclist_items(panes.left_win)
       assert.are.equal(2, #loc)
+      assert.are.equal(panes.left_buf, loc[1].bufnr)
+      local rloc = loclist_items(panes.right_win)
+      assert.are.equal(2, #rloc)
+      assert.are.equal(panes.right_buf, rloc[1].bufnr)
+      vim.cmd('lclose')
+
+      vim.api.nvim_set_current_win(panes.right_win)
+      run_buf_keymap(panes.right_buf, ']c')
+      assert_target_at_hunk(panes, 2)
+      run_buf_keymap(panes.right_buf, '[c')
+      assert_target_at_hunk(panes, 1)
+    end)
+
+    it('navigates loclist hunks without switching the active review file', function()
+      local repo = create_review_repo()
+      edit_file(repo.repo_root .. '/lua/one.lua')
+      mock_runtime_attach(function() end)
+
+      local left_buf =
+        commands.greview_command(('++layout=split %s..%s'):format(repo.base, repo.target))
+      local panes = track_panes(left_buf)
+      assert.are.equal('lua/one.lua', panes.state.selected_file)
+
+      vim.api.nvim_set_current_win(panes.left_win)
+      vim.cmd('lopen')
+      local loc_win = find_loclist_window_for_window(panes.left_win)
+      assert.is_not_nil(loc_win)
+      local loc = loclist_items(panes.left_win)
+      assert.is_true(#loc >= 1)
+
       vim.api.nvim_set_current_win(loc_win)
-      vim.api.nvim_win_set_cursor(loc_win, { 2, 0 })
-      vim.cmd('normal \r')
-
-      vim.wait(100, function()
-        return vim.api.nvim_win_get_cursor(state.diff_win)[1] == loc[2].lnum
+      vim.api.nvim_win_set_cursor(loc_win, { #loc, 0 })
+      local ok = pcall(function()
+        vim.cmd('normal \r')
       end)
-      assert.are.same({ loc[2].lnum, 0 }, vim.api.nvim_win_get_cursor(state.diff_win))
-      assert_target_at_hunk(state, 2)
+      vim.wait(50)
 
-      vim.api.nvim_set_current_win(state.diff_win)
-      run_buf_keymap(diff_buf, '[c')
-      assert_target_at_hunk(state, 1)
-      run_buf_keymap(diff_buf, ']c')
-      assert_target_at_hunk(state, 2)
-    end)
-
-    it('refreshes the generated diff when the editable target is written', function()
-      local repo_root = create_repo()
-      vim.fn.writefile({ 'line 1', 'line 2 changed' }, repo_root .. '/file.txt')
-      edit_file(repo_root .. '/file.txt')
-      mock_runtime_attach(function() end)
-
-      local diff_buf = commands.greview_command('++layout=split HEAD')
-      local state = track_workspace(diff_buf)
-
-      vim.api.nvim_set_current_win(state.target_win)
-      vim.api.nvim_buf_set_lines(state.target_buf, 1, 2, false, { 'line 2 saved' })
-      vim.cmd.write()
-
-      vim.wait(100, function()
-        return buffer_text(diff_buf):find('+line 2 saved', 1, true) ~= nil
-      end)
-      assert.is_true(buffer_text(diff_buf):find('+line 2 saved', 1, true) ~= nil)
-      assert.is_false(buffer_text(diff_buf):find('+line 2 changed', 1, true) ~= nil)
-    end)
-
-    it('invalidates generated highlighting after same-size untracked target saves', function()
-      local repo_root = create_repo()
-      write_repo_file(repo_root, 'untracked.lua', { 'return "one"' })
-      edit_file(repo_root .. '/file.txt')
-      saved_schedule = vim.schedule
-      vim.schedule = function(callback)
-        callback()
-      end
-
-      local diff_buf = commands.greview_command('++layout=split HEAD')
-      local state = track_workspace(diff_buf)
-      assert.are.equal('untracked.lua', state.selected_file)
-
-      runtime.attach(diff_buf)
-      runtime._test.ensure_cache(diff_buf)
-      assert.is_not_nil(runtime._test.hunk_cache[diff_buf])
-
-      vim.api.nvim_set_current_win(state.target_win)
-      vim.api.nvim_buf_set_lines(state.target_buf, 0, -1, false, { 'return "two"' })
-      vim.cmd.write()
-
-      vim.wait(100, function()
-        return buffer_text(diff_buf):find('+return "two"', 1, true) ~= nil
-      end)
-      runtime._test.ensure_cache(diff_buf)
-      runtime._test.process_pending_clear(diff_buf)
-
-      local entry = runtime._test.hunk_cache[diff_buf]
-      assert.is_not_nil(entry)
-      assert.are.equal(vim.api.nvim_buf_get_changedtick(diff_buf), entry.tick)
-      assert.is_false(entry.pending_clear)
-      assert.is_true(#entry.hunks > 0)
-    end)
-
-    it('refreshes read-only target buffers through the Greview split reload path', function()
-      local repo = create_current_state_review_repo()
-      mock_runtime_attach(function() end)
-
-      local review_buf = commands.greview({
-        base = repo.base,
-        repo = repo.repo_root,
-      })
-      assert.is_not_nil(review_buf)
-      table.insert(test_buffers, review_buf)
-
-      local staged_line =
-        find_buffer_line_after(review_buf, '# Staged:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
-      assert.is_not_nil(staged_line)
-      vim.api.nvim_win_set_cursor(0, { staged_line, 0 })
-
-      local diff_buf = commands.greview_split({ bufnr = review_buf })
-      local state = track_workspace(diff_buf)
-      assert.is_true(state.target_scratch)
-      assert.is_true(buffer_text(state.target_buf):find('dup staged', 1, true) ~= nil)
-
-      write_repo_file(repo.repo_root, 'lua/dup.lua', { 'dup restaged' })
-      git_cmd(repo.repo_root, { 'add', 'lua/dup.lua' })
-      write_repo_file(repo.repo_root, 'lua/dup.lua', { 'dup unstaged again' })
-
-      commands.read_buffer(diff_buf)
-
-      vim.wait(100, function()
-        return buffer_text(state.target_buf):find('dup restaged', 1, true) ~= nil
-      end)
-      assert.is_true(buffer_text(diff_buf):find('+dup restaged', 1, true) ~= nil)
-      assert.is_true(buffer_text(state.target_buf):find('dup restaged', 1, true) ~= nil)
+      assert.is_true(ok)
+      assert.are.equal('lua/one.lua', panes.state.selected_file)
+      assert.is_true(vim.api.nvim_buf_is_valid(panes.left_buf))
+      assert.is_true(vim.api.nvim_buf_is_valid(panes.right_buf))
     end)
 
     it('closes both Greview split surfaces from the generated diff buffer', function()
@@ -3543,18 +3528,16 @@ describe('commands', function()
       edit_file(repo_root .. '/file.txt')
       mock_runtime_attach(function() end)
 
-      local diff_buf = commands.greview_command('++layout=split HEAD')
-      local state = track_workspace(diff_buf)
-      local diff_win = state.diff_win
-      local target_win = state.target_win
+      local left_buf = commands.greview_command('++layout=split HEAD')
+      local panes = track_panes(left_buf)
 
-      run_buf_keymap(diff_buf, 'q')
+      vim.api.nvim_set_current_win(panes.right_win)
+      run_buf_keymap(panes.right_buf, 'q')
 
-      assert.is_false(vim.api.nvim_buf_is_valid(diff_buf))
-      assert.is_true(vim.api.nvim_win_is_valid(diff_win))
-      assert.are_not.equal(diff_buf, vim.api.nvim_win_get_buf(diff_win))
-      assert.is_false(vim.api.nvim_win_is_valid(target_win))
-      assert.is_nil(commands._test.greview_workspace_state(diff_buf))
+      assert.is_false(vim.api.nvim_buf_is_valid(panes.left_buf))
+      assert.is_false(vim.api.nvim_buf_is_valid(panes.right_buf))
+      assert.is_nil(commands._test.review_split_state(panes.left_buf))
+      assert.is_nil(commands._test.review_split_state(panes.right_buf))
     end)
 
     it('skips binary untracked files in current-state reviews', function()
@@ -3606,16 +3589,19 @@ describe('commands', function()
       local header_line = find_buffer_line(bufnr, '# Unstaged:')
       assert.is_not_nil(header_line)
       vim.api.nvim_win_set_cursor(0, { header_line, 0 })
-      local diff_buf = commands.greview_split({ bufnr = bufnr })
-      local state = track_workspace(diff_buf)
+      local left_buf = commands.greview_split({ bufnr = bufnr })
+      local panes = track_panes(left_buf)
 
       assert.are.same(
         diffspec.rev_to_rev(':2', ':3', 'file.txt'),
-        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+        vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec')
       )
-      assert.is_true(state.target_scratch)
-      assert.is_true(buffer_text(diff_buf):find('line 2 theirs', 1, true) ~= nil)
-      assert.is_true(buffer_text(state.target_buf):find('line 2 ours', 1, true) ~= nil)
+      assert.are.same(
+        diffspec.rev_to_rev(':2', ':3', 'file.txt'),
+        vim.api.nvim_buf_get_var(panes.right_buf, 'diffs_spec')
+      )
+      assert.is_true(buffer_text(panes.left_buf):find('line 2 theirs', 1, true) ~= nil)
+      assert.is_true(buffer_text(panes.right_buf):find('line 2 ours', 1, true) ~= nil)
     end)
 
     it('opens a base-only current-state review file as the selected section edge', function()
@@ -3623,12 +3609,16 @@ describe('commands', function()
       edit_file(repo.repo_root .. '/lua/two.lua')
       mock_runtime_attach(function() end)
 
-      local diff_buf = commands.greview_command(('++layout=split %s'):format(repo.base))
-      track_workspace(diff_buf)
+      local left_buf = commands.greview_command(('++layout=split %s'):format(repo.base))
+      local panes = track_panes(left_buf)
 
       assert.are.same(
         diffspec.index_to_worktree('lua/one.lua'),
-        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+        vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec')
+      )
+      assert.are.same(
+        diffspec.index_to_worktree('lua/one.lua'),
+        vim.api.nvim_buf_get_var(panes.right_buf, 'diffs_spec')
       )
     end)
 
@@ -3637,13 +3627,17 @@ describe('commands', function()
       edit_file(repo.repo_root .. '/lua/one.lua')
       mock_runtime_attach(function() end)
 
-      local diff_buf =
+      local left_buf =
         commands.greview_command(('++layout=split %s...%s'):format(repo.base, repo.target))
-      track_workspace(diff_buf)
+      local panes = track_panes(left_buf)
 
       assert.are.same(
         diffspec.rev_to_rev(repo.base_sha, repo.target, 'lua/one.lua'),
-        vim.api.nvim_buf_get_var(diff_buf, 'diffs_spec')
+        vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec')
+      )
+      assert.are.same(
+        diffspec.rev_to_rev(repo.base_sha, repo.target, 'lua/one.lua'),
+        vim.api.nvim_buf_get_var(panes.right_buf, 'diffs_spec')
       )
     end)
 
@@ -3671,7 +3665,7 @@ describe('commands', function()
       assert.is_true(
         notifications[#notifications].message:find('mode-only changes', 1, true) ~= nil
       )
-      assert.is_nil(commands._test.greview_workspace_state(bufnr))
+      assert.is_nil(commands._test.review_split_state(bufnr))
     end)
 
     it('keeps no-hunk review file records in quickfix with an empty active loclist', function()

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1201,6 +1201,55 @@ describe('commands', function()
       assert.are.equal(right_buf, right_loc[1].bufnr)
     end)
 
+    it('paints the configured intra word-diff overlay on both split panes', function()
+      mock_view_config({ prefix = true, change_bar = '┃', rail_separator = '│' })
+      create_split_source({
+        index_lines = { 'function f()', '  return 111', '  log()', 'end' },
+        worktree_lines = { 'function f()', '  return 222', '  log()', 'end' },
+      })
+      commands.gdiff('++layout=split', false)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+      local left_win, right_win = find_split_windows(left_buf, right_buf)
+
+      local intra_ns = vim.api.nvim_get_namespaces().diffs_split_intra
+      assert.is_not_nil(intra_ns)
+
+      local function intra_mark(bufnr, group)
+        for _, mark in
+          ipairs(vim.api.nvim_buf_get_extmarks(bufnr, intra_ns, 0, -1, { details = true }))
+        do
+          if mark[4].hl_group == group then
+            return mark
+          end
+        end
+        return nil
+      end
+
+      local left_mark = intra_mark(left_buf, 'DiffsDeleteText')
+      local right_mark = intra_mark(right_buf, 'DiffsAddText')
+      assert.is_not_nil(left_mark)
+      assert.is_not_nil(right_mark)
+      assert.are.equal(1, left_mark[2])
+      assert.are.equal(9, left_mark[3])
+      assert.are.equal(12, left_mark[4].end_col)
+      assert.are.equal(1, right_mark[2])
+      assert.are.equal(9, right_mark[3])
+      assert.are.equal(12, right_mark[4].end_col)
+
+      assert.is_true(
+        vim.api.nvim_get_option_value('winhighlight', { win = left_win })
+          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
+      )
+      assert.is_true(
+        vim.api.nvim_get_option_value('winhighlight', { win = right_win })
+          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
+      )
+    end)
+
     it('warns and still opens the split when :vertical Diff ++layout=split is used', function()
       local notifications = capture_notifications()
       local saved_splitright = vim.o.splitright

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1259,7 +1259,9 @@ describe('commands', function()
 
       local line_ns = vim.api.nvim_get_namespaces().diffs_split_line
       assert.is_true(#vim.api.nvim_buf_get_extmarks(left_buf, line_ns, { 1, 0 }, { 1, -1 }, {}) > 0)
-      assert.is_true(#vim.api.nvim_buf_get_extmarks(right_buf, line_ns, { 1, 0 }, { 1, -1 }, {}) > 0)
+      assert.is_true(
+        #vim.api.nvim_buf_get_extmarks(right_buf, line_ns, { 1, 0 }, { 1, -1 }, {}) > 0
+      )
     end)
 
     it('skips the intra overlay when highlights.intra is disabled', function()

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1261,95 +1261,13 @@ describe('commands', function()
       assert.is_true(
         vim.api
           .nvim_get_option_value('winhighlight', { win = left_win })
-          :find('DiffText:DiffsClear', 1, true) ~= nil
+          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
       )
       assert.is_true(
         vim.api
           .nvim_get_option_value('winhighlight', { win = right_win })
-          :find('DiffText:DiffsClear', 1, true) ~= nil
+          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
       )
-    end)
-
-    it('paints a continuous line background and rail number on changed split lines', function()
-      mock_view_config({ prefix = true, change_bar = '┃', rail_separator = '│' })
-      create_split_source({
-        index_lines = { 'function f()', '  return 111', '  log()', 'end' },
-        worktree_lines = { 'function f()', '  return 222', '  log()', 'end' },
-      })
-      commands.gdiff('++layout=split', false)
-
-      local right_buf = vim.api.nvim_get_current_buf()
-      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
-      table.insert(test_buffers, left_buf)
-      table.insert(test_buffers, right_buf)
-      local left_win, right_win = find_split_windows(left_buf, right_buf)
-
-      local bar_ns = vim.api.nvim_get_namespaces().diffs_split_change_bar
-      local function details_at(bufnr, row)
-        local found = {}
-        for _, mark in
-          ipairs(vim.api.nvim_buf_get_extmarks(bufnr, bar_ns, 0, -1, { details = true }))
-        do
-          if mark[2] == row then
-            found[#found + 1] = mark[4]
-          end
-        end
-        return found
-      end
-      local function has(marks, key, value)
-        for _, d in ipairs(marks) do
-          if d[key] == value then
-            return true
-          end
-        end
-        return false
-      end
-
-      local left_changed = details_at(left_buf, 1)
-      assert.is_true(has(left_changed, 'hl_group', 'DiffsDelete'))
-      assert.is_true(has(left_changed, 'hl_eol', true))
-      assert.is_true(has(left_changed, 'number_hl_group', 'DiffsDeleteRailNr'))
-
-      local right_changed = details_at(right_buf, 1)
-      assert.is_true(has(right_changed, 'hl_group', 'DiffsAdd'))
-      assert.is_true(has(right_changed, 'hl_eol', true))
-      assert.is_true(has(right_changed, 'number_hl_group', 'DiffsAddRailNr'))
-
-      assert.are.equal(0, #details_at(left_buf, 0))
-      assert.are.equal(0, #details_at(right_buf, 0))
-
-      assert.is_true(vim.api.nvim_get_option_value('number', { win = left_win }))
-      assert.is_true(vim.api.nvim_get_option_value('number', { win = right_win }))
-    end)
-
-    it('decorates the added side and leaves the empty side bare for a pure-add file', function()
-      mock_view_config({ prefix = true, change_bar = '┃', rail_separator = '│' })
-      create_split_source({
-        index_lines = {},
-        worktree_lines = { 'local M = {}', 'return M' },
-      })
-      commands.gdiff('++layout=split', false)
-
-      local right_buf = vim.api.nvim_get_current_buf()
-      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
-      table.insert(test_buffers, left_buf)
-      table.insert(test_buffers, right_buf)
-
-      local bar_ns = vim.api.nvim_get_namespaces().diffs_split_change_bar
-      local function line_bg_count(bufnr)
-        local n = 0
-        for _, mark in
-          ipairs(vim.api.nvim_buf_get_extmarks(bufnr, bar_ns, 0, -1, { details = true }))
-        do
-          if mark[4].hl_group == 'DiffsAdd' or mark[4].hl_group == 'DiffsDelete' then
-            n = n + 1
-          end
-        end
-        return n
-      end
-
-      assert.are.equal(2, line_bg_count(right_buf))
-      assert.are.equal(0, line_bg_count(left_buf))
     end)
 
     it('skips the intra overlay when highlights.intra is disabled', function()
@@ -1390,12 +1308,12 @@ describe('commands', function()
       assert.is_true(
         vim.api
           .nvim_get_option_value('winhighlight', { win = left_win })
-          :find('DiffText:DiffsClear', 1, true) ~= nil
+          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
       )
       assert.is_true(
         vim.api
           .nvim_get_option_value('winhighlight', { win = right_win })
-          :find('DiffText:DiffsClear', 1, true) ~= nil
+          :find('DiffText:DiffsDiffChange', 1, true) ~= nil
       )
     end)
 

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -422,14 +422,13 @@ describe('read_buffer', function()
 
       commands.read_buffer(left_buf)
 
-      assert.are.same(
-        { 'local M = {}', 'return M' },
-        vim.api.nvim_buf_get_lines(left_buf, 0, -1, false)
-      )
-      assert.are.same(
-        { 'local M = {}', 'local x = 1', 'return M' },
-        vim.api.nvim_buf_get_lines(right_buf, 0, -1, false)
-      )
+      local left_lines = vim.api.nvim_buf_get_lines(left_buf, 0, -1, false)
+      local right_lines = vim.api.nvim_buf_get_lines(right_buf, 0, -1, false)
+      assert.are.equal(#left_lines, #right_lines)
+      assert.are.equal('local M = {}', left_lines[1])
+      assert.are.equal('local M = {}', right_lines[1])
+      assert.are.equal('local x = 1', right_lines[2])
+      assert.is_true(vim.tbl_contains(left_lines, ''))
       assert.are.equal(right_buf, vim.api.nvim_buf_get_var(left_buf, 'diffs_split_peer'))
       assert.are.equal(left_buf, vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer'))
       assert.are.equal(1, #vim.api.nvim_buf_get_var(left_buf, 'diffs_split_hunks'))

--- a/spec/split_align_spec.lua
+++ b/spec/split_align_spec.lua
@@ -1,0 +1,101 @@
+local align = require('diffs.split_align')
+
+local function hunk(index, old_start, new_start, lines)
+  return {
+    index = index,
+    old_range = { start = old_start },
+    new_range = { start = new_start },
+    lines = lines,
+  }
+end
+
+local function kinds(rows)
+  local out = {}
+  for i, r in ipairs(rows) do
+    out[i] = r.kind
+  end
+  return out
+end
+
+describe('split_align.align', function()
+  it('keeps both panes equal length and weaves unchanged context whole-file', function()
+    local old_lines = { 'a', 'OLD', 'c' }
+    local new_lines = { 'a', 'NEW', 'c' }
+    local hunks = { hunk(1, 2, 2, {
+      { kind = 'delete', old_lnum = 2 },
+      { kind = 'add', new_lnum = 2 },
+    }) }
+
+    local r = align.align(old_lines, new_lines, hunks)
+    assert.are.same({ 'a', 'OLD', 'c' }, r.left_lines)
+    assert.are.same({ 'a', 'NEW', 'c' }, r.right_lines)
+    assert.are.equal(#r.left_lines, #r.right_lines)
+    assert.are.same({ 'context', 'delete', 'context' }, kinds(r.left_rows))
+    assert.are.same({ 'context', 'add', 'context' }, kinds(r.right_rows))
+    assert.are.equal(2, r.left_rows[2].old_lnum)
+    assert.are.equal(2, r.right_rows[2].new_lnum)
+    assert.are.equal(2, r.anchors[1])
+  end)
+
+  it('top-aligns an unequal change and pads the shorter side with fillers', function()
+    local old_lines = { 'a', 'O1', 'O2', 'd' }
+    local new_lines = { 'a', 'N1', 'N2', 'N3', 'd' }
+    local hunks = { hunk(1, 2, 2, {
+      { kind = 'delete', old_lnum = 2 },
+      { kind = 'delete', old_lnum = 3 },
+      { kind = 'add', new_lnum = 2 },
+      { kind = 'add', new_lnum = 3 },
+      { kind = 'add', new_lnum = 4 },
+    }) }
+
+    local r = align.align(old_lines, new_lines, hunks)
+    assert.are.same({ 'a', 'O1', 'O2', '', 'd' }, r.left_lines)
+    assert.are.same({ 'a', 'N1', 'N2', 'N3', 'd' }, r.right_lines)
+    assert.are.equal(#r.left_lines, #r.right_lines)
+    assert.are.same({ 'context', 'delete', 'delete', 'filler', 'context' }, kinds(r.left_rows))
+    assert.are.same({ 'context', 'add', 'add', 'add', 'context' }, kinds(r.right_rows))
+  end)
+
+  it('handles a pure-add file as all fillers on the left', function()
+    local r = align.align({}, { 'x', 'y' }, { hunk(1, 1, 1, {
+      { kind = 'add', new_lnum = 1 },
+      { kind = 'add', new_lnum = 2 },
+    }) })
+    assert.are.same({ '', '' }, r.left_lines)
+    assert.are.same({ 'x', 'y' }, r.right_lines)
+    assert.are.same({ 'filler', 'filler' }, kinds(r.left_rows))
+    assert.are.same({ 'add', 'add' }, kinds(r.right_rows))
+  end)
+
+  it('handles a pure-delete file as all fillers on the right', function()
+    local r = align.align({ 'x', 'y' }, {}, { hunk(1, 1, 1, {
+      { kind = 'delete', old_lnum = 1 },
+      { kind = 'delete', old_lnum = 2 },
+    }) })
+    assert.are.same({ 'x', 'y' }, r.left_lines)
+    assert.are.same({ '', '' }, r.right_lines)
+    assert.are.same({ 'delete', 'delete' }, kinds(r.left_rows))
+    assert.are.same({ 'filler', 'filler' }, kinds(r.right_rows))
+  end)
+
+  it('returns empty alignment for no hunks and empty files', function()
+    local r = align.align({}, {}, {})
+    assert.are.same({}, r.left_lines)
+    assert.are.same({}, r.right_lines)
+  end)
+
+  it('weaves multiple hunks with unchanged regions between them', function()
+    local old_lines = { 'a', 'OLD1', 'b', 'c', 'OLD2', 'e' }
+    local new_lines = { 'a', 'NEW1', 'b', 'c', 'NEW2', 'e' }
+    local hunks = {
+      hunk(1, 2, 2, { { kind = 'delete', old_lnum = 2 }, { kind = 'add', new_lnum = 2 } }),
+      hunk(2, 5, 5, { { kind = 'delete', old_lnum = 5 }, { kind = 'add', new_lnum = 5 } }),
+    }
+    local r = align.align(old_lines, new_lines, hunks)
+    assert.are.same(old_lines, r.left_lines)
+    assert.are.same(new_lines, r.right_lines)
+    assert.are.equal(#r.left_lines, #r.right_lines)
+    assert.are.equal(2, r.anchors[1])
+    assert.are.equal(5, r.anchors[2])
+  end)
+end)

--- a/spec/split_align_spec.lua
+++ b/spec/split_align_spec.lua
@@ -61,16 +61,12 @@ describe('split_align.align', function()
   end)
 
   it('handles a pure-add file as all fillers on the left', function()
-    local r = align.align(
-      {},
-      { 'x', 'y' },
-      {
-        hunk(1, 1, 1, {
-          { kind = 'add', new_lnum = 1 },
-          { kind = 'add', new_lnum = 2 },
-        }),
-      }
-    )
+    local r = align.align({}, { 'x', 'y' }, {
+      hunk(1, 1, 1, {
+        { kind = 'add', new_lnum = 1 },
+        { kind = 'add', new_lnum = 2 },
+      }),
+    })
     assert.are.same({ '', '' }, r.left_lines)
     assert.are.same({ 'x', 'y' }, r.right_lines)
     assert.are.same({ 'filler', 'filler' }, kinds(r.left_rows))
@@ -78,16 +74,12 @@ describe('split_align.align', function()
   end)
 
   it('handles a pure-delete file as all fillers on the right', function()
-    local r = align.align(
-      { 'x', 'y' },
-      {},
-      {
-        hunk(1, 1, 1, {
-          { kind = 'delete', old_lnum = 1 },
-          { kind = 'delete', old_lnum = 2 },
-        }),
-      }
-    )
+    local r = align.align({ 'x', 'y' }, {}, {
+      hunk(1, 1, 1, {
+        { kind = 'delete', old_lnum = 1 },
+        { kind = 'delete', old_lnum = 2 },
+      }),
+    })
     assert.are.same({ 'x', 'y' }, r.left_lines)
     assert.are.same({ '', '' }, r.right_lines)
     assert.are.same({ 'delete', 'delete' }, kinds(r.left_rows))

--- a/spec/split_align_spec.lua
+++ b/spec/split_align_spec.lua
@@ -21,10 +21,12 @@ describe('split_align.align', function()
   it('keeps both panes equal length and weaves unchanged context whole-file', function()
     local old_lines = { 'a', 'OLD', 'c' }
     local new_lines = { 'a', 'NEW', 'c' }
-    local hunks = { hunk(1, 2, 2, {
-      { kind = 'delete', old_lnum = 2 },
-      { kind = 'add', new_lnum = 2 },
-    }) }
+    local hunks = {
+      hunk(1, 2, 2, {
+        { kind = 'delete', old_lnum = 2 },
+        { kind = 'add', new_lnum = 2 },
+      }),
+    }
 
     local r = align.align(old_lines, new_lines, hunks)
     assert.are.same({ 'a', 'OLD', 'c' }, r.left_lines)
@@ -40,13 +42,15 @@ describe('split_align.align', function()
   it('top-aligns an unequal change and pads the shorter side with fillers', function()
     local old_lines = { 'a', 'O1', 'O2', 'd' }
     local new_lines = { 'a', 'N1', 'N2', 'N3', 'd' }
-    local hunks = { hunk(1, 2, 2, {
-      { kind = 'delete', old_lnum = 2 },
-      { kind = 'delete', old_lnum = 3 },
-      { kind = 'add', new_lnum = 2 },
-      { kind = 'add', new_lnum = 3 },
-      { kind = 'add', new_lnum = 4 },
-    }) }
+    local hunks = {
+      hunk(1, 2, 2, {
+        { kind = 'delete', old_lnum = 2 },
+        { kind = 'delete', old_lnum = 3 },
+        { kind = 'add', new_lnum = 2 },
+        { kind = 'add', new_lnum = 3 },
+        { kind = 'add', new_lnum = 4 },
+      }),
+    }
 
     local r = align.align(old_lines, new_lines, hunks)
     assert.are.same({ 'a', 'O1', 'O2', '', 'd' }, r.left_lines)
@@ -57,10 +61,16 @@ describe('split_align.align', function()
   end)
 
   it('handles a pure-add file as all fillers on the left', function()
-    local r = align.align({}, { 'x', 'y' }, { hunk(1, 1, 1, {
-      { kind = 'add', new_lnum = 1 },
-      { kind = 'add', new_lnum = 2 },
-    }) })
+    local r = align.align(
+      {},
+      { 'x', 'y' },
+      {
+        hunk(1, 1, 1, {
+          { kind = 'add', new_lnum = 1 },
+          { kind = 'add', new_lnum = 2 },
+        }),
+      }
+    )
     assert.are.same({ '', '' }, r.left_lines)
     assert.are.same({ 'x', 'y' }, r.right_lines)
     assert.are.same({ 'filler', 'filler' }, kinds(r.left_rows))
@@ -68,10 +78,16 @@ describe('split_align.align', function()
   end)
 
   it('handles a pure-delete file as all fillers on the right', function()
-    local r = align.align({ 'x', 'y' }, {}, { hunk(1, 1, 1, {
-      { kind = 'delete', old_lnum = 1 },
-      { kind = 'delete', old_lnum = 2 },
-    }) })
+    local r = align.align(
+      { 'x', 'y' },
+      {},
+      {
+        hunk(1, 1, 1, {
+          { kind = 'delete', old_lnum = 1 },
+          { kind = 'delete', old_lnum = 2 },
+        }),
+      }
+    )
     assert.are.same({ 'x', 'y' }, r.left_lines)
     assert.are.same({ '', '' }, r.right_lines)
     assert.are.same({ 'delete', 'delete' }, kinds(r.left_rows))


### PR DESCRIPTION
## Problem

`:Diff review ++layout=split` was not really a side-by-side diff. It placed a unified diff buffer on the left and the raw worktree file on the right, with native `&diff` off and the windows left unbound, so removed and added content were never split across the panes and the two sides did not scroll together. The split panes also never carried the intra-line word-diff highlighting that the generated views use.

## Solution

Rebuild the review split on the existing `split.open` two-pane primitive: the removed/old endpoint on the left, the added/new endpoint on the right, aligned with native `&diff` and bound for synchronized scrolling and cursor movement. The review file list stays the authoritative quickfix and now drives in-place file switching by reusing the two windows. Both split layouts — `:Diff ++layout=split` and the review split — gain the plugin's intra-line word-diff overlay, honoring `highlights.intra` including the `vscode` algorithm, and native `DiffText` is remapped on those panes so it does not compete with the overlay. The old editable-worktree workspace and its now-unused buffer source are removed, and the vimdoc is updated to match.
