### PR TITLE
fix(split): tear down the pane pair on any window close

### DIFF
--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -20,6 +20,9 @@ local cleanup_autocmds = {}
 local peer_buffers = {}
 ---@type table<integer, table<string, any>>
 local pair_window_options = {}
+---@type table<integer, integer>
+local split_windows = {}
+local win_closed_registered = false
 
 ---@class diffs.SplitPaneInfo
 ---@field rows diffs.SplitRow[]
@@ -504,7 +507,7 @@ local function ensure_pair_cleanup(bufnr)
       local peer = peer_buffers[bufnr] or split_peer(bufnr)
       cleanup_autocmds[bufnr] = nil
       peer_buffers[bufnr] = nil
-      if closing_buffers[bufnr] or not peer then
+      if closing_buffers[bufnr] or not peer or vim.v.exiting ~= vim.NIL then
         return
       end
       vim.schedule(function()
@@ -514,6 +517,41 @@ local function ensure_pair_cleanup(bufnr)
       end)
     end,
   })
+end
+
+local function register_win_closed()
+  if win_closed_registered then
+    return
+  end
+  win_closed_registered = true
+  vim.api.nvim_create_autocmd('WinClosed', {
+    callback = function(args)
+      local win = tonumber(args.match)
+      if not win then
+        return
+      end
+      local bufnr = split_windows[win]
+      split_windows[win] = nil
+      if not bufnr or vim.v.exiting ~= vim.NIL then
+        return
+      end
+      if closing_buffers[bufnr] or not vim.api.nvim_buf_is_valid(bufnr) then
+        return
+      end
+      vim.schedule(function()
+        if vim.api.nvim_buf_is_valid(bufnr) and not closing_buffers[bufnr] then
+          M.close_pair(bufnr)
+        end
+      end)
+    end,
+  })
+end
+
+---@param win integer
+---@param bufnr integer
+local function track_split_window(win, bufnr)
+  register_win_closed()
+  split_windows[win] = bufnr
 end
 
 ---@param left_buf integer
@@ -536,6 +574,11 @@ local function clear_pair_tracking(bufnr, keep_closing)
   end
   peer_buffers[bufnr] = nil
   pane_info[bufnr] = nil
+  for win, win_buf in pairs(split_windows) do
+    if win_buf == bufnr then
+      split_windows[win] = nil
+    end
+  end
   if not keep_closing then
     closing_buffers[bufnr] = nil
   end
@@ -928,6 +971,8 @@ function M.open(opts)
   vim.api.nvim_win_set_buf(left_win, left_buf)
   vim.api.nvim_win_set_buf(right_win, right_buf)
   set_peers(left_buf, right_buf)
+  track_split_window(left_win, left_buf)
+  track_split_window(right_win, right_buf)
 
   set_pair_window_options(left_win)
   set_pair_window_options(right_win)
@@ -1061,8 +1106,17 @@ function M.close_pair(bufnr)
     return false
   end
 
+  for buf in pairs(buffers) do
+    if closing_buffers[buf] then
+      return false
+    end
+  end
+
   local pair_wins, non_pair_wins = tab_windows_for_buffers(buffers)
 
+  for _, win in ipairs(pair_wins) do
+    split_windows[win] = nil
+  end
   for buf in pairs(buffers) do
     closing_buffers[buf] = true
   end

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1595,6 +1595,52 @@ describe('commands', function()
       assert.is_false(vim.api.nvim_buf_is_valid(right_buf))
     end)
 
+    it('tears down the pair when a pane window is closed', function()
+      create_split_source()
+      vim.cmd('split')
+      commands.gdiff('++layout=split', false)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+      local _, right_win = find_split_windows(left_buf, right_buf)
+
+      vim.api.nvim_win_close(right_win, false)
+      vim.wait(200, function()
+        return not vim.api.nvim_buf_is_valid(left_buf)
+      end)
+
+      assert.is_false(vim.api.nvim_buf_is_valid(left_buf))
+      assert.is_false(vim.api.nvim_buf_is_valid(right_buf))
+      for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+        if vim.api.nvim_buf_is_valid(buf) then
+          assert.is_nil(vim.api.nvim_buf_get_name(buf):match('diffs://split:'))
+        end
+      end
+    end)
+
+    it('tears down the pair when :only is run on a pane', function()
+      create_split_source()
+      commands.gdiff('++layout=split', false)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      table.insert(test_buffers, left_buf)
+      table.insert(test_buffers, right_buf)
+      local left_win = find_split_windows(left_buf, right_buf)
+
+      vim.api.nvim_set_current_win(left_win)
+      vim.cmd('only')
+      vim.wait(200, function()
+        return not vim.api.nvim_buf_is_valid(right_buf)
+      end)
+
+      assert.is_false(vim.api.nvim_buf_is_valid(left_buf))
+      assert.is_false(vim.api.nvim_buf_is_valid(right_buf))
+      assert.is_true(#vim.api.nvim_tabpage_list_wins(0) >= 1)
+    end)
+
     it('closes paired split endpoint buffers with q and can reopen the same split', function()
       local source_buf = create_split_source()
 


### PR DESCRIPTION
## Problem

The `++layout=split` pane pair only collapsed cleanly when it was closed through the `q` mapping or an explicit buffer wipe. The coupling that closes the peer when one pane goes away was hung off a `BufWipeout` autocmd, but the panes are `bufhidden=delete`, so closing a pane window with `:q`, `:close`, `:only`, `<C-w>c`, or the mouse runs a `:bdelete` and fires `BufDelete`/`BufUnload` rather than `BufWipeout`. The peer was therefore left behind as an orphaned read-only half-diff: a lone `diffs://split:…` buffer with `scrollbind` bound to nothing and a stale line-number rail. Native `&diff` never strands you like this, because its surviving window is a real, editable file that simply drops out of diff mode.

## Solution

Each pane window is recorded in a window-id to buffer registry, and a single `WinClosed` handler collapses the pair through the existing `close_pair` path whenever a tracked pane window goes away by any means. Because these panes are read-only generated views with no useful standalone state, collapsing the pair and returning to a normal buffer is the faithful adaptation of native's contract of never leaving a half-broken diff behind. The handler self-clears its registry entry on every window close, stays inert while Neovim is exiting and while a teardown is already in flight, and only acts on a still-valid pane buffer, so closing an unrelated window or reusing a window id can never collapse a pair. `close_pair` clears the registry for its own windows up front and refuses re-entry, the per-buffer teardown drops any registry entries that point at a buffer that is going away, and the existing `BufWipeout` cleanup gained the same exiting guard for symmetry.
