### PR TITLE
fix(lists): reserve the global quickfix for multi-file views

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -410,6 +410,11 @@ highlight-only.
     row with |diffs.nvim-du|/|diffs.nvim-dU| or an explicit supported object
     form such as `:Diff :0:%`. |:Diff| does not provide a `--staged` flag.
 
+    A single-file |:Diff| populates the window's |location-list| with that
+    file's hunks and leaves the global |quickfix| list untouched. The quickfix
+    list is taken over as a repo-wide file index only for multi-file views and
+    |:Diff-review|.
+
     Parameters: ~
         ++layout=unified (optional) Open the default generated `diffs://` view
                     with old and new line-number rails.

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -1711,6 +1711,7 @@ function M.read_buffer(bufnr)
     debug_label = debug_label or ((label or '?') .. ':' .. (path or '?'))
   end
 
+  local is_review = pcall(vim.api.nvim_buf_get_var, bufnr, 'diffs_review_base')
   replace_generated_diff_buffer_lines(bufnr, diff_lines, stored_spec)
   lists.set_for_unified_buffer(bufnr, diff_lines, {
     title = 'diff: ' .. (debug_label or name:gsub('^diffs://', '')),
@@ -1718,6 +1719,7 @@ function M.read_buffer(bufnr)
     metadata_for_line = list_opts and list_opts.metadata_for_line,
     sections = list_opts and list_opts.sections,
     store_hunks = list_opts and list_opts.store_hunks,
+    quickfix = is_review or nil,
   })
   M.setup_diff_buf(bufnr)
 

--- a/lua/diffs/lists.lua
+++ b/lua/diffs/lists.lua
@@ -792,7 +792,11 @@ function M.set_for_unified_buffer(bufnr, diff_lines, opts)
   }
   ensure_generated_autocmds(bufnr)
 
-  if opts.quickfix ~= false then
+  local want_quickfix = opts.quickfix
+  if want_quickfix == nil then
+    want_quickfix = #state.entries > 1
+  end
+  if want_quickfix then
     set_quickfix(title, quickfix_items(bufnr, state.entries))
   end
   for _, win in ipairs(windows_for_buffer(bufnr)) do
@@ -933,8 +937,9 @@ function M.set_for_split_pair(opts)
   local title = opts.title
   local loclist_title = opts.loclist_title or (title .. ' hunks')
 
-  if opts.quickfix ~= false then
-    set_quickfix(title, split_quickfix_items(opts))
+  local quickfix_entries = split_quickfix_items(opts)
+  if opts.quickfix ~= false and #quickfix_entries > 1 then
+    set_quickfix(title, quickfix_entries)
   end
   for _, win in ipairs(opts.left_win and { opts.left_win } or windows_for_buffer(opts.left_buf)) do
     set_loclist(

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -785,6 +785,7 @@ function M.greview(spec, deps)
     metadata_for_line = list_opts and list_opts.metadata_for_line,
     sections = list_opts and list_opts.sections,
     store_hunks = list_opts and list_opts.store_hunks,
+    quickfix = true,
   })
 
   deps.attach_generated_diff_buffer(diff_buf)

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1046,6 +1046,51 @@ describe('commands', function()
       assert.is_true(loc[1].text:find('lua/foo.lua', 1, true) ~= nil)
     end)
 
+    it('leaves an existing user quickfix list untouched for a single-file diff', function()
+      local source_buf = vim.api.nvim_create_buf(false, true)
+      table.insert(test_buffers, source_buf)
+      vim.api.nvim_buf_set_name(source_buf, '/tmp/repo/lua/foo.lua')
+      vim.api.nvim_buf_set_lines(source_buf, 0, -1, false, {
+        'local M = {}',
+        'local x = 1',
+        'return M',
+      })
+      vim.api.nvim_set_current_buf(source_buf)
+
+      mock_git_method('get_relative_path', function()
+        return 'lua/foo.lua'
+      end)
+      mock_git_method('get_index_content', function()
+        return { 'local M = {}', 'return M' }
+      end)
+      mock_repo_root(function()
+        return '/tmp/repo'
+      end)
+      mock_runtime_attach(function() end)
+      mock_view_config({ prefix = true, change_bar = '▏', rail_separator = '|' })
+
+      vim.fn.setqflist({}, ' ', {
+        title = 'user list',
+        items = {
+          { filename = '/tmp/repo/other.lua', lnum = 3, text = 'grep hit' },
+          { filename = '/tmp/repo/more.lua', lnum = 7, text = 'grep hit two' },
+        },
+      })
+
+      commands.gdiff(nil, false)
+
+      local diff_buf = vim.api.nvim_get_current_buf()
+      table.insert(test_buffers, diff_buf)
+
+      local qf = vim.fn.getqflist({ title = 0, items = 0 })
+      assert.are.equal('user list', qf.title)
+      assert.are.equal(2, #qf.items)
+
+      local loc = loclist_items()
+      assert.is_true(#loc >= 1)
+      assert.are.equal(diff_buf, loc[1].bufnr)
+    end)
+
     it('opens stacked :Gdiff as a generated buffer with single rails', function()
       mock_runtime_attach(function() end)
       mock_view_config({ prefix = true, change_bar = '▏', rail_separator = '|' })

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -426,6 +426,7 @@ describe('commands', function()
     restore_mocks()
     cleanup_buffers()
     cleanup_repos()
+    pcall(vim.fn.setqflist, {}, 'f')
     for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
       pcall(vim.api.nvim_set_option_value, 'winhighlight', '', { win = win })
     end
@@ -1036,10 +1037,7 @@ describe('commands', function()
       assert.is_true(table.concat(display_lines, '\n'):find('    2 | +local x = 1', 1, true) ~= nil)
 
       local qf = quickfix_items()
-      assert.are.equal(1, #qf)
-      assert.are.equal(diff_buf, qf[1].bufnr)
-      assert.are.equal(1, qf[1].lnum)
-      assert.is_true(qf[1].text:find('lua/foo.lua', 1, true) ~= nil)
+      assert.are.equal(0, #qf)
 
       local loc = loclist_items()
       assert.are.equal(1, #loc)
@@ -1206,10 +1204,7 @@ describe('commands', function()
       assert.is_true(rail:find('┃', 1, true) ~= nil)
 
       local qf = quickfix_items()
-      assert.are.equal(1, #qf)
-      assert.are.equal(right_buf, qf[1].bufnr)
-      assert.are.equal(2, qf[1].lnum)
-      assert.is_true(qf[1].text:find('lua/foo.lua', 1, true) ~= nil)
+      assert.are.equal(0, #qf)
 
       local left_loc = loclist_items(left_win)
       local right_loc = loclist_items(right_win)
@@ -1460,7 +1455,7 @@ describe('commands', function()
       )
     end)
 
-    it('targets the old endpoint for split deleted hunks in qf and loclist', function()
+    it('targets the old endpoint for split deleted hunks in the loclist', function()
       create_split_source({
         index_lines = {
           'line 1',
@@ -1482,9 +1477,7 @@ describe('commands', function()
       assert.are.equal(0, hunks[1].new_range.count)
 
       local qf = quickfix_items()
-      assert.are.equal(1, #qf)
-      assert.are.equal(left_buf, qf[1].bufnr)
-      assert.are.equal(hunks[1].old_range.start, qf[1].lnum)
+      assert.are.equal(0, #qf)
 
       local right_loc = loclist_items(right_win)
       assert.are.equal(1, #right_loc)
@@ -2002,10 +1995,7 @@ describe('commands', function()
       }, vim.api.nvim_buf_get_var(diff_buf, 'diffs_source'))
 
       local qf = quickfix_items()
-      assert.are.equal(1, #qf)
-      assert.are.equal(diff_buf, qf[1].bufnr)
-      assert.are.equal(1, qf[1].lnum)
-      assert.is_true(qf[1].text:find('renamed.txt', 1, true) ~= nil)
+      assert.are.equal(0, #qf)
 
       local loc = loclist_items()
       assert.are.equal(1, #loc)
@@ -2607,9 +2597,13 @@ describe('commands', function()
       assert.is_false(vim.tbl_contains(lines, 'stale lifecycle content'))
 
       local qf = quickfix_items()
-      assert.is_true(#qf >= 1, case.label)
-      assert.are.equal(bufnr, qf[1].bufnr, case.label)
-      assert.are.equal(1, qf[1].lnum, case.label)
+      if case.review then
+        assert.is_true(#qf >= 1, case.label)
+        assert.are.equal(bufnr, qf[1].bufnr, case.label)
+        assert.are.equal(1, qf[1].lnum, case.label)
+      else
+        assert.are.equal(0, #qf, case.label)
+      end
 
       local loc = loclist_items()
       assert.is_true(#loc >= 1, case.label)


### PR DESCRIPTION
## Problem

A single-file `:Diff` populated the global quickfix list with a one-entry "file index", which displaced whatever list the user had active — a `:grep`, `:make`, or LSP-references result — with no way to get it back short of `:colder`, and it was never restored when the diff closed. The quickfix is a single shared resource, so taking it over for a trivial single-file diff is surprising and intrusive, and it carries no navigational benefit: the window-local location list already holds that file's hunks, which is exactly what a location list is for.

## Solution

Only populate the global quickfix when there is a real file index to browse: a `:Diff` that spans more than one file, and any `:Diff review` workspace, which deliberately owns the quickfix as its cross-file navigator (including the single-file review case and on reload). A plain single-file `:Diff` now leaves the quickfix untouched and continues to populate the window's location list with its hunks. Location-list behavior is unchanged.
