### PR TITLE
refactor(commands): remove the ++novertical :Diff option

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -391,8 +391,6 @@ highlight-only.
                     context-aware line-number rail.
         ++layout=split (optional) Open the current single-file comparison as
                     paired old/new endpoint windows.
-        ++novertical (optional) Force a horizontal split even under |:vertical|.
-                    Useful in command wrappers.
         {object}    (string, optional) The object to diff against; see
                     |diffs.nvim-diff-objects|. Defaults to the current file in
                     the index.

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -1290,10 +1290,6 @@ function M.diff(args, vertical, opts)
     warn_vertical_split_ignored()
   end
 
-  if parsed.novertical then
-    vertical = false
-  end
-
   local rail_style = rail_style_for_layout(parsed.layout)
   local diff_spec = parsed.spec
   local diff_label = diff_buffer_label(diff_spec)

--- a/lua/diffs/diffargs.lua
+++ b/lua/diffs/diffargs.lua
@@ -8,7 +8,6 @@ local diffspec = require('diffs.spec')
 
 ---@class diffs.DiffParseResult
 ---@field spec diffs.DiffSpec
----@field novertical boolean
 ---@field layout "unified"|"stacked"|"split"
 
 local function normalize_rev(rev)
@@ -163,15 +162,11 @@ function M.parse(args, context)
 
   local current = context.current and diffspec.endpoint(context.current) or diffspec.worktree()
   local tokens = split_args(args)
-  local novertical = false
   local layout = 'unified'
   local has_layout = false
 
   while tokens[1] and tokens[1]:match('^%+%+') do
-    if tokens[1] == '++novertical' then
-      novertical = true
-      table.remove(tokens, 1)
-    elseif tokens[1]:match('^%+%+layout=') then
+    if tokens[1]:match('^%+%+layout=') then
       if has_layout then
         return nil, 'repeated ++layout option'
       end
@@ -198,10 +193,8 @@ function M.parse(args, context)
   if #tokens == 0 then
     return {
       spec = default_spec(current, path),
-      novertical = novertical,
       layout = layout,
-    },
-      nil
+    }, nil
   end
 
   local object, err = parse_object(tokens[1])
@@ -213,10 +206,8 @@ function M.parse(args, context)
   local right = object.right_worktree and diffspec.worktree() or current
   return {
     spec = diffspec.file(object.left, right, scope_path),
-    novertical = novertical,
     layout = layout,
-  },
-    nil
+  }, nil
 end
 
 M._test = {

--- a/spec/diffargs_spec.lua
+++ b/spec/diffargs_spec.lua
@@ -19,7 +19,6 @@ describe('diffs.diffargs', function()
     local result = parse(nil)
 
     assert.are.same(diffspec.index_to_worktree(path), result.spec)
-    assert.is_false(result.novertical)
     assert.are.equal('unified', result.layout)
   end)
 
@@ -61,19 +60,10 @@ describe('diffs.diffargs', function()
     assert.are.same(diffspec.head_to_index(path), result.spec)
   end)
 
-  it('keeps ++novertical separate from endpoint parsing', function()
-    local result = parse('++novertical HEAD')
-
-    assert.are.same(diffspec.rev_to_worktree('HEAD', path), result.spec)
-    assert.is_true(result.novertical)
-    assert.are.equal('unified', result.layout)
-  end)
-
   it('parses opt-in split layout separately from endpoint parsing', function()
     local result = parse('++layout=split HEAD')
 
     assert.are.same(diffspec.rev_to_worktree('HEAD', path), result.spec)
-    assert.is_false(result.novertical)
     assert.are.equal('split', result.layout)
   end)
 
@@ -81,7 +71,6 @@ describe('diffs.diffargs', function()
     local result = parse('++layout=stacked HEAD')
 
     assert.are.same(diffspec.rev_to_worktree('HEAD', path), result.spec)
-    assert.is_false(result.novertical)
     assert.are.equal('stacked', result.layout)
   end)
 


### PR DESCRIPTION
## Problem

The `:Diff` command accepted a `++novertical` option whose only effect was to force a horizontal split even when `:vertical` had been applied. Split direction for the generated diff comes solely from the `:vertical` modifier, so the flag only ever undid a modifier the caller had applied themselves. Interactively it was pure redundancy, its sole stated use was escaping a wrapper that hard-coded `:vertical`, and nothing inside the plugin passed it.

## Solution

Remove `++novertical` entirely: drop it from the argument parser and its result type, from the `:Diff` handler, from the help, and from the parser tests. The `:vertical` modifier remains the single way to control split orientation.
