### PR TITLE
feat(commands): add :Diff files to diff two arbitrary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ highlighting driven by treesitter.
 - Word-level diff highlighting
 - `:Diff` for [pierre-style](https://diffs.com) unified, stacked, or split diffs against any revision
 - `:Diff review` full-repo review diff with qflist/loclist navigation
+- `:Diff files {a} {b}` to diff two arbitrary files
 - Inline merge conflict detection, highlighting, and resolution
 - Email quoting/patch syntax support (`> diff ...`)
 - Vim syntax fallback

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -395,8 +395,8 @@ highlight-only.
                     |diffs.nvim-diff-objects|. Defaults to the current file in
                     the index.
 
-    Completion covers `++layout=...`, the `review` subcommand, supported object
-    forms, and git refs.
+    Completion covers `++layout=...`, the `review` and `files` subcommands,
+    supported object forms, and git refs.
 
     Examples: >vim
         :Diff           " diff against the index
@@ -406,6 +406,7 @@ highlight-only.
         :Diff abc123    " diff against specific commit
         :Diff ++layout=stacked
         :vertical Diff  " open the generated diff in a vertical split
+        :Diff files old.lua new.lua  " diff two arbitrary files
 <
     Edge cases: ~
     - Untracked and added files render as all-added files.
@@ -456,6 +457,32 @@ Diff objects: ~                                       *diffs.nvim-diff-objects*
         - `{a}..{b}`, `{a}...{b}`     ranges; use |:Diff-review| instead
         - `{rev}:`                    tree objects
         - `-`                         the previous object
+
+Diff files: ~                                            *diffs.nvim-diff-files*
+
+    `:Diff files {left} [{right}]` opens a read-only generated diff of two
+    arbitrary files. Neither file has to be tracked by git, and the command
+    works outside a repository. It is the file-path counterpart to a plain
+    |:Diff| object: the first path names the old (left) side, and the second
+    names the new (right) side. With a single path the new side defaults to the
+    current buffer's file, mirroring |:diffsplit| and `:Diff {rev}`.
+
+    Examples: >vim
+        :Diff files old.lua new.lua   " old.lua (old) vs new.lua (new)
+        :Diff files other.lua         " other.lua (old) vs current file (new)
+        :Diff files ++layout=stacked a.txt b.txt
+<
+    The `++layout=unified` and `++layout=stacked` layouts and the |:vertical|
+    modifier apply as they do for |:Diff|. `++layout=split` is not supported for
+    two arbitrary files; use native diff mode (`nvim -d` or |:diffsplit|) for a
+    side-by-side comparison. The view is read-only, so the hunk-staging maps
+    (`do`/`dp`) are not available.
+
+    Errors: ~
+    - With no path, or more than two, the command reports the expected count.
+    - A path that is a directory, missing, unreadable, or binary is refused and
+      named; directories are intentionally unsupported.
+    - Two identical files report no changes without opening a buffer.
 
 Stacked generated layout: ~                        *diffs.nvim-stacked-layout*
 

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -509,6 +509,21 @@ local function render_source(source)
     return diff_lines, source.spec, diffspec.label(source.spec), nil
   end
 
+  if source.kind == 'files' then
+    local old_lines = git.get_working_content(source.left_path)
+    if not old_lines then
+      return nil, nil, source.left_name .. ': file not readable', nil
+    end
+    local new_lines = git.get_working_content(source.right_path)
+    if not new_lines then
+      return nil, nil, source.right_name .. ': file not readable', nil
+    end
+    return render.unified_lines(old_lines, new_lines, source.left_name, source.right_name),
+      nil,
+      'files:' .. source.left_name .. ' -> ' .. source.right_name,
+      nil
+  end
+
   if source.kind == 'file_pair' then
     local abs_path = source.repo_root .. '/' .. source.path
     local old_abs_path = source.repo_root .. '/' .. source.old_path
@@ -749,6 +764,20 @@ local function complete_review_args(arglead, context)
   return matches
 end
 
+local files_layout_options = {
+  '++layout=unified',
+  '++layout=stacked',
+}
+
+---@param arglead string
+---@return string[]
+local function complete_files_args(arglead)
+  if arglead:match('^%+%+') then
+    return prefix_matches(files_layout_options, arglead)
+  end
+  return vim.fn.getcompletion(arglead, 'file')
+end
+
 ---@param arglead string
 ---@param cmdline? string
 ---@param cursorpos? integer
@@ -758,9 +787,17 @@ local function complete_diff_command(arglead, cmdline, cursorpos)
   if args[1] == 'review' then
     return complete_review_args(arglead, args_context(args, 2))
   end
+  if args[1] == 'files' then
+    return complete_files_args(arglead)
+  end
   local matches = {}
-  if #args == 0 and not arglead:match('^%+%+') and starts_with('review', arglead) then
-    matches[#matches + 1] = 'review'
+  if #args == 0 and not arglead:match('^%+%+') then
+    if starts_with('review', arglead) then
+      matches[#matches + 1] = 'review'
+    end
+    if starts_with('files', arglead) then
+      matches[#matches + 1] = 'files'
+    end
   end
   vim.list_extend(matches, complete_diff_args(arglead, cmdline, cursorpos))
   return matches
@@ -812,8 +849,110 @@ function M.diff_command(args, vertical)
         { warn_vertical_split = vertical }
       )
     end
+    if sub == 'files' then
+      return M.diff_files_command(remainder ~= '' and remainder or nil, vertical)
+    end
   end
   return M.diff(args, vertical, { warn_vertical_split = vertical })
+end
+
+---@param args? string
+---@param vertical? boolean
+---@return integer?
+function M.diff_files_command(args, vertical)
+  local parsed, err = diff_parser.parse_files(args)
+  if not parsed then
+    notify(err, vim.log.levels.ERROR)
+    return nil
+  end
+
+  local layout = parsed.layout
+  if layout == 'split' then
+    notify(
+      'split layout is not supported for :Diff files; use nvim -d or :diffsplit for side-by-side',
+      vim.log.levels.ERROR
+    )
+    return nil
+  end
+
+  return M.diff_files(parsed.left, parsed.right, {
+    layout = layout,
+    vertical = vertical,
+  })
+end
+
+---@class diffs.DiffFilesViewOpts
+---@field layout "unified"|"stacked"|"split"
+---@field vertical? boolean
+
+---@param left string
+---@param right string?
+---@param opts? diffs.DiffFilesViewOpts
+---@return integer?
+function M.diff_files(left, right, opts)
+  opts = opts or {}
+
+  local right_input = right
+  if not right_input then
+    local current = vim.api.nvim_buf_get_name(vim.api.nvim_get_current_buf())
+    if current == '' then
+      notify('cannot diff unnamed buffer', vim.log.levels.ERROR)
+      return nil
+    end
+    right_input = current
+  end
+
+  local left_abs = vim.fn.fnamemodify(vim.fn.expand(left), ':p')
+  local right_abs = vim.fn.fnamemodify(vim.fn.expand(right_input), ':p')
+  local left_name = vim.fn.fnamemodify(left_abs, ':~:.')
+  if left_name == '' then
+    left_name = left_abs
+  end
+  local right_name = vim.fn.fnamemodify(right_abs, ':~:.')
+  if right_name == '' then
+    right_name = right_abs
+  end
+
+  for _, side in ipairs({
+    { abs = left_abs, name = left_name },
+    { abs = right_abs, name = right_name },
+  }) do
+    if vim.fn.isdirectory(side.abs) == 1 then
+      notify(side.name .. ' is a directory; :Diff files compares two files', vim.log.levels.ERROR)
+      return nil
+    end
+    if vim.fn.filereadable(side.abs) ~= 1 then
+      notify(side.name .. ': file not readable', vim.log.levels.ERROR)
+      return nil
+    end
+  end
+
+  local old_lines = git.get_working_content(left_abs) or {}
+  local new_lines = git.get_working_content(right_abs) or {}
+  if render.has_binary_lines(old_lines) or render.has_binary_lines(new_lines) then
+    notify('diff does not support binary files', vim.log.levels.ERROR)
+    return nil
+  end
+
+  local diff_lines = render.unified_lines(old_lines, new_lines, left_name, right_name)
+  if #diff_lines == 0 then
+    notify('no changes between ' .. left_name .. ' and ' .. right_name, vim.log.levels.INFO)
+    return nil
+  end
+
+  local diff_buf = create_generated_diff_buffer({
+    name = 'diffs://files:' .. left_name .. ' -> ' .. right_name,
+    lines = diff_lines,
+    source = generated.files_source(left_abs, right_abs, left_name, right_name),
+    rail_style = rail_style_for_layout(opts.layout),
+  })
+  show_generated_diff_buffer(diff_buf, opts.vertical)
+  lists.set_for_unified_buffer(diff_buf, diff_lines, {
+    title = 'diff: files ' .. left_name .. ' -> ' .. right_name,
+  })
+  attach_generated_diff_buffer(diff_buf)
+  dbg('opened files diff buffer %d (%s -> %s)', diff_buf, left_name, right_name)
+  return diff_buf
 end
 
 ---@param repo_root string
@@ -1571,12 +1710,6 @@ function M.read_buffer(bufnr)
     return
   end
 
-  local repo_root = source and source.repo_root or generated.repo_root(bufnr)
-  if not repo_root then
-    notify('cannot reload diffs:// buffer without diffs_repo_root', vim.log.levels.WARN)
-    return
-  end
-
   if source and source.kind == 'split_endpoint' then
     local ok, err = split.read_buffer(bufnr, source, {
       change_bar = runtime.get_view_config().change_bar,
@@ -1602,6 +1735,11 @@ function M.read_buffer(bufnr)
     end
     debug_label = render_err
   else
+    local repo_root = generated.repo_root(bufnr)
+    if not repo_root then
+      notify('cannot reload diffs:// buffer without diffs_repo_root', vim.log.levels.WARN)
+      return
+    end
     local spec_err
     stored_spec, spec_err = get_diff_spec_var(bufnr)
     if spec_err then
@@ -1771,7 +1909,7 @@ function M.setup()
     nargs = '*',
     bar = true,
     complete = complete_diff_command,
-    desc = 'Show a current-file diff, or a repository review with :Diff review',
+    desc = 'Show a current-file diff, a repository review with :Diff review, or two files with :Diff files',
   })
 end
 

--- a/lua/diffs/diffargs.lua
+++ b/lua/diffs/diffargs.lua
@@ -27,6 +27,30 @@ local function split_args(args)
   return vim.split(args, '%s+', { trimempty = true })
 end
 
+---@param tokens string[]
+---@return ("unified"|"stacked"|"split")?, string?
+local function take_layout(tokens)
+  local layout = 'unified'
+  local has_layout = false
+  while tokens[1] and tokens[1]:match('^%+%+') do
+    if tokens[1]:match('^%+%+layout=') then
+      if has_layout then
+        return nil, 'repeated ++layout option'
+      end
+      local value = tokens[1]:match('^%+%+layout=(.+)$')
+      if value ~= 'unified' and value ~= 'stacked' and value ~= 'split' then
+        return nil, 'unsupported layout ' .. tostring(value)
+      end
+      has_layout = true
+      layout = value
+      table.remove(tokens, 1)
+    else
+      return nil, 'unknown option ' .. tokens[1]
+    end
+  end
+  return layout
+end
+
 ---@param endpoint diffs.Endpoint
 ---@return boolean
 local function is_index(endpoint)
@@ -162,24 +186,9 @@ function M.parse(args, context)
 
   local current = context.current and diffspec.endpoint(context.current) or diffspec.worktree()
   local tokens = split_args(args)
-  local layout = 'unified'
-  local has_layout = false
-
-  while tokens[1] and tokens[1]:match('^%+%+') do
-    if tokens[1]:match('^%+%+layout=') then
-      if has_layout then
-        return nil, 'repeated ++layout option'
-      end
-      local value = tokens[1]:match('^%+%+layout=(.+)$')
-      if value ~= 'unified' and value ~= 'stacked' and value ~= 'split' then
-        return nil, 'unsupported layout ' .. tostring(value)
-      end
-      has_layout = true
-      layout = value
-      table.remove(tokens, 1)
-    else
-      return nil, 'unknown option ' .. tokens[1]
-    end
+  local layout, layout_err = take_layout(tokens)
+  if not layout then
+    return nil, layout_err
   end
 
   if tokens[1] and tokens[1]:match('^%-%-') then
@@ -206,6 +215,34 @@ function M.parse(args, context)
   local right = object.right_worktree and diffspec.worktree() or current
   return {
     spec = diffspec.file(object.left, right, scope_path),
+    layout = layout,
+  }, nil
+end
+
+---@class diffs.DiffFilesParseResult
+---@field left string # old/left side path, as typed
+---@field right? string # new/right side path, as typed; nil means the current buffer
+---@field layout "unified"|"stacked"|"split"
+
+---@param args? string
+---@return diffs.DiffFilesParseResult?, string?
+function M.parse_files(args)
+  local tokens = split_args(args)
+  local layout, layout_err = take_layout(tokens)
+  if not layout then
+    return nil, layout_err
+  end
+
+  if #tokens == 0 then
+    return nil, ':Diff files expects one or two file paths'
+  end
+  if #tokens > 2 then
+    return nil, 'expected at most two file paths'
+  end
+
+  return {
+    left = tokens[1],
+    right = tokens[2],
     layout = layout,
   }, nil
 end

--- a/lua/diffs/generated/source.lua
+++ b/lua/diffs/generated/source.lua
@@ -84,8 +84,8 @@ end
 
 ---@class diffs.GeneratedBufferSource
 ---@field version integer
----@field kind "file"|"file_pair"|"section"|"review"|"unmerged"|"split_endpoint"
----@field repo_root string
+---@field kind "file"|"file_pair"|"section"|"review"|"unmerged"|"split_endpoint"|"files"
+---@field repo_root? string
 ---@field spec? diffs.DiffSpec
 ---@field edge? "staged"|"unstaged"
 ---@field path? string
@@ -96,6 +96,10 @@ end
 ---@field side? "left"|"right"
 ---@field filetype? string
 ---@field quickfix? boolean
+---@field left_path? string
+---@field right_path? string
+---@field left_name? string
+---@field right_name? string
 
 ---@param source table
 ---@return diffs.GeneratedBufferSource?
@@ -106,8 +110,10 @@ function M.normalize_source(source)
   if source.version ~= 1 then
     error('expected version 1')
   end
-  if type(source.repo_root) ~= 'string' or source.repo_root == '' then
-    error('expected repo_root')
+  if source.kind ~= 'files' then
+    if type(source.repo_root) ~= 'string' or source.repo_root == '' then
+      error('expected repo_root')
+    end
   end
 
   if source.kind == 'file' then
@@ -147,6 +153,13 @@ function M.normalize_source(source)
   elseif source.kind == 'unmerged' then
     if type(source.path) ~= 'string' or source.path == '' then
       error('expected unmerged path')
+    end
+  elseif source.kind == 'files' then
+    if type(source.left_path) ~= 'string' or source.left_path == '' then
+      error('expected files left_path')
+    end
+    if type(source.right_path) ~= 'string' or source.right_path == '' then
+      error('expected files right_path')
     end
   else
     error('unknown source kind')
@@ -228,6 +241,22 @@ function M.unmerged_source(repo_root, path, working_path)
     repo_root = repo_root,
     path = path,
     working_path = working_path,
+  }
+end
+
+---@param left_path string # absolute path of the old/left side
+---@param right_path string # absolute path of the new/right side
+---@param left_name string # display name for the old/left side
+---@param right_name string # display name for the new/right side
+---@return diffs.GeneratedBufferSource
+function M.files_source(left_path, right_path, left_name, right_name)
+  return {
+    version = 1,
+    kind = 'files',
+    left_path = left_path,
+    right_path = right_path,
+    left_name = left_name,
+    right_name = right_name,
   }
 end
 

--- a/lua/diffs/runtime/attach.lua
+++ b/lua/diffs/runtime/attach.lua
@@ -20,6 +20,10 @@ end
 function M.attach(opts, bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
 
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
   if opts.attached_buffers[bufnr] then
     return
   end

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -620,7 +620,7 @@ describe('commands', function()
   end)
 
   describe('command completion', function()
-    it('completes the Diff review subcommand, layout options, objects, and refs', function()
+    it('completes the Diff subcommands, layout options, objects, and refs', function()
       mock_repo_root(function()
         return '/tmp/repo'
       end)
@@ -630,6 +630,7 @@ describe('commands', function()
 
       assert.are.same({
         'review',
+        'files',
         '++layout=unified',
         '++layout=stacked',
         '++layout=split',
@@ -642,6 +643,13 @@ describe('commands', function()
       }, commands._test.complete_diff('', 'Diff ', #'Diff '))
 
       assert.are.same({ 'review' }, commands._test.complete_diff('rev', 'Diff rev', #'Diff rev'))
+
+      assert.are.same({ 'files' }, commands._test.complete_diff('fil', 'Diff fil', #'Diff fil'))
+
+      assert.are.same({
+        '++layout=unified',
+        '++layout=stacked',
+      }, commands._test.complete_diff('++l', 'Diff files ++l', #'Diff files ++l'))
 
       assert.are.same({
         '++layout=unified',

--- a/spec/diff_files_spec.lua
+++ b/spec/diff_files_spec.lua
@@ -1,0 +1,154 @@
+require('spec.helpers')
+
+local commands = require('diffs.commands')
+local generated = require('diffs.generated')
+
+local saved_notify
+local notifications = {}
+
+local function capture_notify()
+  saved_notify = vim.notify
+  notifications = {}
+  vim.notify = function(msg, level)
+    table.insert(notifications, { msg = msg, level = level })
+  end
+end
+
+local function restore_notify()
+  if saved_notify then
+    vim.notify = saved_notify
+    saved_notify = nil
+  end
+end
+
+---@return string?
+local function last_message()
+  local entry = notifications[#notifications]
+  return entry and entry.msg
+end
+
+---@param needle string
+---@return boolean
+local function last_message_has(needle)
+  local msg = last_message()
+  return msg ~= nil and msg:find(needle, 1, true) ~= nil
+end
+
+local function diff_lines(bufnr)
+  return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+end
+
+local function has_line(bufnr, pattern)
+  for _, line in ipairs(diff_lines(bufnr)) do
+    if line:match(pattern) then
+      return true
+    end
+  end
+  return false
+end
+
+describe('diffs.commands.diff_files', function()
+  local dir
+  local a
+  local b
+
+  before_each(function()
+    dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    a = dir .. '/a.txt'
+    b = dir .. '/b.txt'
+    vim.fn.writefile({ 'alpha', 'beta', 'gamma' }, a)
+    vim.fn.writefile({ 'alpha', 'BETA', 'gamma', 'delta' }, b)
+    capture_notify()
+  end)
+
+  after_each(function()
+    restore_notify()
+    -- Let the scheduled runtime.attach run while the buffers are still valid.
+    vim.wait(20, function()
+      return false
+    end)
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf):match('^diffs://') then
+        pcall(vim.api.nvim_buf_delete, buf, { force = true })
+      end
+    end
+    vim.fn.delete(dir, 'rf')
+  end)
+
+  it('renders a read-only unified diff of two files outside any repo', function()
+    local bufnr = commands.diff_files(a, b, { layout = 'unified' })
+
+    assert.is_number(bufnr)
+    assert.are.equal('diff', vim.bo[bufnr].filetype)
+    assert.is_false(vim.bo[bufnr].modifiable)
+    assert.is_true(has_line(bufnr, 'diff %-%-git a/.*a%.txt b/.*b%.txt'))
+    assert.is_true(has_line(bufnr, '^.*%+BETA'))
+
+    local source = generated.source(bufnr)
+    assert.are.equal('files', source.kind)
+    assert.are.equal(a, source.left_path)
+    assert.are.equal(b, source.right_path)
+  end)
+
+  it('defaults the new side to the current buffer with a single path', function()
+    vim.cmd('edit ' .. vim.fn.fnameescape(a))
+    local bufnr = commands.diff_files(b, nil, { layout = 'unified' })
+
+    assert.is_number(bufnr)
+    local source = generated.source(bufnr)
+    assert.are.equal(b, source.left_path)
+    assert.are.equal(a, source.right_path)
+  end)
+
+  it('reloads from disk through the files source', function()
+    local bufnr = commands.diff_files(a, b, { layout = 'unified' })
+    assert.is_number(bufnr)
+
+    vim.fn.writefile({ 'alpha', 'beta', 'gamma', 'delta', 'epsilon' }, b)
+    commands.read_buffer(bufnr)
+
+    assert.is_true(has_line(bufnr, '^.*%+epsilon'))
+  end)
+
+  it('reports no changes for identical files without opening a buffer', function()
+    local bufnr = commands.diff_files(a, a, { layout = 'unified' })
+
+    assert.is_nil(bufnr)
+    local name = vim.fn.fnamemodify(a, ':~:.')
+    assert.is_true(last_message_has('no changes between ' .. name .. ' and ' .. name))
+  end)
+
+  it('refuses a directory', function()
+    local bufnr = commands.diff_files(dir, b, { layout = 'unified' })
+
+    assert.is_nil(bufnr)
+    assert.is_true(last_message_has('is a directory; :Diff files compares two files'))
+  end)
+
+  it('refuses an unreadable path', function()
+    local bufnr = commands.diff_files(dir .. '/missing.txt', b, { layout = 'unified' })
+
+    assert.is_nil(bufnr)
+    assert.is_true(last_message_has('missing.txt: file not readable'))
+  end)
+end)
+
+describe('diffs.commands.diff_files_command', function()
+  before_each(capture_notify)
+  after_each(restore_notify)
+
+  it('refuses the split layout', function()
+    local result = commands.diff_files_command('++layout=split a.txt b.txt', false)
+
+    assert.is_nil(result)
+    assert.is_true(last_message_has('split layout is not supported for :Diff files'))
+  end)
+
+  it('surfaces parser errors', function()
+    local result = commands.diff_files_command('a b c', false)
+
+    assert.is_nil(result)
+    assert.is_true(last_message_has('expected at most two file paths'))
+  end)
+end)

--- a/spec/diffargs_spec.lua
+++ b/spec/diffargs_spec.lua
@@ -188,3 +188,65 @@ describe('diffs.diffargs', function()
     end)
   end
 end)
+
+describe('diffs.diffargs.parse_files', function()
+  it('parses a single path as the old side with the current buffer as new', function()
+    local result = diffargs.parse_files('old.lua')
+
+    assert.are.equal('old.lua', result.left)
+    assert.is_nil(result.right)
+    assert.are.equal('unified', result.layout)
+  end)
+
+  it('parses two paths as old and new', function()
+    local result = diffargs.parse_files('old.lua new.lua')
+
+    assert.are.equal('old.lua', result.left)
+    assert.are.equal('new.lua', result.right)
+    assert.are.equal('unified', result.layout)
+  end)
+
+  it('parses a leading layout before the paths', function()
+    local result = diffargs.parse_files('++layout=stacked old.lua new.lua')
+
+    assert.are.equal('old.lua', result.left)
+    assert.are.equal('new.lua', result.right)
+    assert.are.equal('stacked', result.layout)
+  end)
+
+  it('accepts ++layout=split at parse time (rejected by the command)', function()
+    local result = diffargs.parse_files('++layout=split old.lua new.lua')
+
+    assert.are.equal('split', result.layout)
+  end)
+
+  it('requires at least one path', function()
+    for _, args in ipairs({ nil, '', '++layout=unified' }) do
+      local result, err = diffargs.parse_files(args)
+
+      assert.is_nil(result)
+      assert.are.equal(':Diff files expects one or two file paths', err)
+    end
+  end)
+
+  it('rejects more than two paths', function()
+    local result, err = diffargs.parse_files('a.lua b.lua c.lua')
+
+    assert.is_nil(result)
+    assert.are.equal('expected at most two file paths', err)
+  end)
+
+  it('rejects repeated and unsupported layouts and unknown options', function()
+    local repeated, repeated_err = diffargs.parse_files('++layout=unified ++layout=split a.lua')
+    assert.is_nil(repeated)
+    assert.are.equal('repeated ++layout option', repeated_err)
+
+    local bad_layout, bad_layout_err = diffargs.parse_files('++layout=tiled a.lua')
+    assert.is_nil(bad_layout)
+    assert.are.equal('unsupported layout tiled', bad_layout_err)
+
+    local unknown, unknown_err = diffargs.parse_files('++bogus a.lua')
+    assert.is_nil(unknown)
+    assert.are.equal('unknown option ++bogus', unknown_err)
+  end)
+end)


### PR DESCRIPTION
## Problem

`:Diff` can render a generated unified or stacked diff of the current file against a git revision, the index, or a merge stage, but there is no way to diff two arbitrary files that are not git versions of the same path. Comparing file A against an unrelated file B has no command: a bare path handed to `:Diff` is parsed as a git revision and fails with a confusing "failed to resolve revision" error, and nothing works outside a repository at all. Native diff mode (`nvim -d`, `:diffsplit`) covers side-by-side comparison, but not the single-buffer generated view that `:Diff` produces.

## Solution

Add a `files` subcommand to `:Diff`. `:Diff files {left} [{right}]` opens a read-only generated diff of two arbitrary paths on disk, mirroring the existing object model: the named or first path is the old side, and the current buffer (one path) or the second path (two paths) is the new side. It needs no repository and no git tracking, and it reuses the unified and stacked layouts along with the `:vertical` modifier.

The split layout is rejected in favor of native diff mode, since a side-by-side view of two real files is what `nvim -d` and `:diffsplit` already provide. Directories, missing, unreadable, and binary paths, as well as too few or too many paths, are refused with specific messages, and two identical files report no changes without opening a buffer. A repo-less `files` generated-buffer source drives reloading, the `++layout=` parsing shared with `:Diff` is factored into a single helper, and the runtime attach path now guards against a buffer that was closed before its scheduled attach runs.
