### PR TITLE
chore(lib): upgrade libvscode_diff to v2.49.2 and sync the FFI interface

### DIFF
--- a/lua/diffs/lib.lua
+++ b/lua/diffs/lib.lua
@@ -54,7 +54,7 @@ local function version_path()
   return lib_dir() .. '/version'
 end
 
-local EXPECTED_VERSION = '2.18.0'
+local EXPECTED_VERSION = '2.49.2'
 
 ---@return boolean
 function M.has_lib()
@@ -146,6 +146,8 @@ function M.load()
     );
 
     void free_lines_diff(DiffsLinesDiff* diff);
+
+    const char* get_version(void);
   ]])
 
   local ok, handle = pcall(ffi.load, path)


### PR DESCRIPTION
## Problem

The optional `vscode` intra-line backend pins `libvscode_diff` to v2.18.0, the version from when the backend was first added in February. Upstream `esmuellert/codediff.nvim` has released frequently since and is now at v2.49.2, so the pinned download is several months and dozens of releases behind. The FFI declaration also omits the library's exported `get_version` symbol, so the `ffi.cdef` is not a faithful description of the library's interface.

## Solution

Bump the pinned `libvscode_diff` version to v2.49.2 and declare its `get_version` export in the FFI `cdef` so the binding matches the library's interface exactly, even though diffs.nvim does not call it. The library's public ABI — the `compute_diff` and `free_lines_diff` signatures along with every struct (line and character ranges, detailed mappings, moved text, options, and the result) — is identical between v2.18.0 and v2.49.2, so the struct declarations are unchanged and the bump carries no ABI change.
