### PR TITLE
feat(difftastic): add optional structural diff engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ highlighting driven by treesitter.
 - Inline merge conflict detection, highlighting, and resolution
 - Email quoting/patch syntax support (`> diff ...`)
 - Vim syntax fallback
+- [Difftastic](https://difftastic.wilfred.me.uk/) highlight support
 - Configurable highlighting blend
 
 ## Requirements

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -44,6 +44,7 @@ CONTENTS                                                 *diffs.nvim-contents*
        Gitsigns ........................................ |diffs.nvim-gitsigns|
        Committia ...................................... |diffs.nvim-committia|
        Telescope ...................................... |diffs.nvim-telescope|
+       Difftastic .................................... |diffs.nvim-difftastic|
   8. Conflict Resolution ............................... |diffs.nvim-conflict|
   9. Merge Diff Resolution ................................ |diffs.nvim-merge|
  10. API .................................................... |diffs.nvim-api|
@@ -188,6 +189,11 @@ Configuration is done via `vim.g.diffs`. Set options before the plugin loads:
             {telescope}      (boolean, default: false)
                              Enable telescope.nvim preview support. See
                              |diffs.nvim-telescope|.
+
+            {difftastic}     (boolean|table, default: false)
+                             Enable structural diffing via the `difft` binary.
+                             Use `{ args = {...} }` to forward flags. See
+                             |diffs.nvim-difftastic|.
 
         {extra_filetypes}    (table, default: {})
                              Additional filetypes to attach to, beyond the
@@ -965,6 +971,44 @@ Known issue: Telescope's previewer may render the first line of the preview
 buffer with a black background regardless of colorscheme. This is a Telescope
 artifact unrelated to diffs.nvim. Tracked upstream:
 https://github.com/nvim-telescope/telescope.nvim/issues/3626
+
+------------------------------------------------------------------------------
+DIFFTASTIC                                             *diffs.nvim-difftastic*
+
+Enable structural diffing via difftastic
+(https://github.com/Wilfred/difftastic). This integration is different from the
+others: difftastic is not a plugin whose buffers are decorated, but an external
+`difft` binary used as a structural diff engine. >lua
+    vim.g.diffs = { integrations = { difftastic = true } }
+    vim.g.diffs = { integrations = { difftastic = { args = { '--ignore-comments' } } } }
+<
+
+The `difft` binary must be installed and on `PATH`. When it is missing,
+disabled, errors, or times out, diffs.nvim silently falls back to its normal
+git/intra rendering. The table form forwards `args` to difft verbatim; do not
+pass output-format flags (`--display`, `--color`), which diffs.nvim controls.
+
+When enabled, difftastic augments the diffs you explicitly open — |:Diff|,
+`:Diff ++layout=split`, `:Diff files`, and staged/untracked file diffs — with:
+
+  - structural intra-line token highlighting (the actual edited tokens, with
+    reformatting/reindentation recognized as unchanged), and
+  - structural side-by-side row alignment in the split layout.
+
+It deliberately does not touch the live/ambient surfaces (fugitive, neogit, the
+builtin `diff` filetype), the multi-file review map, conflicts, or binary
+files; those render unchanged. In the unified layouts difftastic only refines
+the token layer (the +/- line structure stays git's), so its line-level
+structural wins appear in the split layout.
+
+difftastic runs synchronously when you open the diff, with an internal timeout.
+It is independent of |diffs.nvim-config| `highlights.intra`, which configures
+the built-in engine and is the fallback when difftastic is off. When difftastic
+finds no structural change (e.g. a reformat-only edit), it emits an
+informational message and renders no token highlights. Whitespace toggling
+(`gw`) does not apply to a structural diff and is a no-op on such buffers.
+
+Run |:checkhealth| diffs to confirm `difft` is detected.
 
 ==============================================================================
 CONFLICT RESOLUTION                                      *diffs.nvim-conflict*

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -5,6 +5,7 @@ local content = require('diffs.content')
 local diff_parser = require('diffs.diffargs')
 local diffopt = require('diffs.diffopt')
 local diffspec = require('diffs.spec')
+local difftastic = require('diffs.difftastic')
 local generated = require('diffs.generated')
 local git = require('diffs.git')
 local hunk_model = require('diffs.hunks')
@@ -19,6 +20,45 @@ local split = require('diffs.split')
 local dbg = log.dbg
 local notify = log.notify
 local review_split_group = vim.api.nvim_create_augroup('diffs_review_split', { clear = false })
+
+--- Paint difftastic structural intra spans onto a generated unified buffer and
+--- emit the formatting-only notice when difft saw no structural change.
+---@param diff_buf integer
+---@param diff_lines string[]
+---@param diff_spec diffs.DiffSpec?
+---@param lhs table<integer, table[]>
+---@param rhs table<integer, table[]>
+local function paint_difft_unified(diff_buf, diff_lines, diff_spec, lhs, rhs)
+  difftastic.apply_unified(
+    diff_buf,
+    lhs,
+    rhs,
+    diff_lines,
+    diff_spec,
+    rails.width_for_buffer(diff_buf)
+  )
+  if not difftastic.has_changes(lhs, rhs) then
+    notify('difftastic: no structural changes (formatting only)', vim.log.levels.INFO)
+  end
+end
+
+--- Apply difftastic to a generated unified buffer built from two content
+--- arrays. No-op when difftastic is disabled/unavailable or content is missing.
+---@param diff_buf integer
+---@param diff_lines string[]
+---@param diff_spec diffs.DiffSpec?
+---@param old_lines string[]?
+---@param new_lines string[]?
+---@param relpath string
+local function apply_difft_unified(diff_buf, diff_lines, diff_spec, old_lines, new_lines, relpath)
+  if not difftastic.available() or not old_lines or not new_lines then
+    return
+  end
+  local lhs, rhs = difftastic.span_maps_for_content(old_lines, new_lines, relpath)
+  if lhs and rhs then
+    paint_difft_unified(diff_buf, diff_lines, diff_spec, lhs, rhs)
+  end
+end
 
 ---@class diffs.HunkKeymap
 ---@field mode string
@@ -407,6 +447,7 @@ end
 ---@param opts? { rail_style?: diffs.RailStyle }
 local function replace_generated_diff_buffer_lines(bufnr, diff_lines, diff_spec, opts)
   opts = opts or {}
+  difftastic.clear_active(bufnr)
   local display_lines, rail_info = rails.annotate(diff_lines, {
     rail_separator = runtime.get_view_config().rail_separator,
     rail_style = opts.rail_style or rails.style_for_buffer(bufnr),
@@ -951,6 +992,14 @@ function M.diff_files(left, right, opts)
     title = 'diff: files ' .. left_name .. ' -> ' .. right_name,
   })
   attach_generated_diff_buffer(diff_buf)
+
+  if difftastic.available() then
+    local lhs, rhs = difftastic.span_maps_for_paths(left_abs, right_abs)
+    if lhs and rhs then
+      paint_difft_unified(diff_buf, diff_lines, nil, lhs, rhs)
+    end
+  end
+
   dbg('opened files diff buffer %d (%s -> %s)', diff_buf, left_name, right_name)
   return diff_buf
 end
@@ -1509,6 +1558,17 @@ function M.diff(args, vertical, opts)
     title = 'diff: ' .. diffspec.label(diff_spec),
   })
   attach_generated_diff_buffer(diff_buf)
+
+  if difftastic.available() then
+    local abs = repo_root and (repo_root .. '/' .. diff_path) or diff_path
+    local old_lines = render.read_endpoint(diff_spec.left, abs, { empty_on_missing = true })
+    local new_lines = render.read_endpoint(diff_spec.right, abs, {
+      worktree_lines = worktree_lines,
+      empty_on_missing = true,
+    })
+    apply_difft_unified(diff_buf, diff_lines, diff_spec, old_lines, new_lines, diff_path)
+  end
+
   dbg('opened diff buffer %d for %s (%s)', diff_buf, diff_path, diffspec.label(diff_spec))
 end
 
@@ -1642,6 +1702,19 @@ function M.diff_file(filepath, opts)
   })
 
   attach_generated_diff_buffer(diff_buf)
+
+  if difftastic.available() and diff_label ~= 'unmerged' then
+    ---@type diffs.ContentLines|string[]|nil
+    local dold = old_lines
+    ---@type diffs.ContentLines|string[]|nil
+    local dnew = new_lines
+    if (not dold or not dnew) and diff_spec then
+      local abs = repo_root .. '/' .. rel_path
+      dold = render.read_endpoint(diff_spec.left, abs, { empty_on_missing = true })
+      dnew = render.read_endpoint(diff_spec.right, abs, { empty_on_missing = true })
+    end
+    apply_difft_unified(diff_buf, diff_lines, diff_spec, dold, dnew, rel_path)
+  end
 
   if diff_label == 'unmerged' then
     vim.api.nvim_buf_set_var(diff_buf, 'diffs_unmerged', true)
@@ -1852,7 +1925,7 @@ function M.refresh_visible()
   local done = {}
   for _, entry in ipairs(views) do
     local buf = vim.api.nvim_win_is_valid(entry.win) and vim.api.nvim_win_get_buf(entry.win)
-    if buf and not done[buf] then
+    if buf and not done[buf] and not difftastic.is_active(buf) then
       done[buf] = true
       local ok, peer = pcall(vim.api.nvim_buf_get_var, buf, 'diffs_split_peer')
       if ok and type(peer) == 'number' then
@@ -1892,6 +1965,10 @@ end
 --- re-render the visible diffs:// buffers. The setting is global, so it also
 --- affects native diff windows on their next update.
 function M.toggle_whitespace()
+  if difftastic.is_active(vim.api.nvim_get_current_buf()) then
+    notify('whitespace toggle does not apply to difftastic structural diffs', vim.log.levels.WARN)
+    return
+  end
   if diffopt_has('iwhiteall') then
     vim.opt.diffopt:remove('iwhiteall')
     vim.api.nvim_echo({ { '[diffs] diffopt -iwhiteall (showing whitespace)' } }, false, {})

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -52,6 +52,9 @@ local integration_metadata = require('diffs.integrations')
 ---@field show_actions boolean
 ---@field keymaps diffs.ConflictKeymaps|false
 
+---@class diffs.DifftasticConfig
+---@field args? string[]
+
 ---@class diffs.IntegrationsConfig
 ---@field fugitive boolean
 ---@field neogit boolean
@@ -59,6 +62,7 @@ local integration_metadata = require('diffs.integrations')
 ---@field gitsigns boolean
 ---@field committia boolean
 ---@field telescope boolean
+---@field difftastic? boolean|diffs.DifftasticConfig
 
 ---@class diffs.Config
 ---@field debug boolean|string
@@ -158,6 +162,15 @@ function M.validate(opts)
   local integrations = opts.integrations or {}
   for _, key in ipairs(integration_metadata.keys()) do
     vim.validate('integrations.' .. key, integrations[key], 'boolean', true)
+  end
+  vim.validate('integrations.difftastic', integrations.difftastic, function(v)
+    return v == nil or type(v) == 'boolean' or type(v) == 'table'
+  end, 'boolean or table')
+  if type(integrations.difftastic) == 'table' then
+    vim.validate('integrations.difftastic.args', integrations.difftastic.args, 'table', true)
+    for i, arg in ipairs(integrations.difftastic.args or {}) do
+      vim.validate('integrations.difftastic.args[' .. i .. ']', arg, 'string')
+    end
   end
   vim.validate('extra_filetypes', opts.extra_filetypes, 'table', true)
   vim.validate('highlights', opts.highlights, 'table', true)

--- a/lua/diffs/difftastic.lua
+++ b/lua/diffs/difftastic.lua
@@ -1,0 +1,399 @@
+local M = {}
+
+local hunk_model = require('diffs.hunks')
+local log = require('diffs.log')
+local runtime = require('diffs.runtime')
+
+local dbg = log.dbg
+
+local unified_ns = vim.api.nvim_create_namespace('diffs_difftastic_unified')
+local active_var = 'diffs_difft_active'
+
+local COMMAND = 'difft'
+local TIMEOUT_MS = 5000
+
+---@class diffs.DifftAlignment : diffs.SplitAlignment
+---@field left_intra table<integer, {col_start: integer, col_end: integer}[]>
+---@field right_intra table<integer, {col_start: integer, col_end: integer}[]>
+---@field changed boolean
+
+--- Mark a buffer as rendered by difftastic. Suppresses the decorator's own
+--- intra step and short-circuits whitespace toggling (moot for a structural
+--- diff).
+---@param bufnr integer
+function M.mark_active(bufnr)
+  pcall(vim.api.nvim_buf_set_var, bufnr, active_var, true)
+end
+
+---@param bufnr integer
+function M.clear_active(bufnr)
+  pcall(vim.api.nvim_buf_del_var, bufnr, active_var)
+  pcall(vim.api.nvim_buf_clear_namespace, bufnr, unified_ns, 0, -1)
+end
+
+---@param bufnr integer
+---@return boolean
+function M.is_active(bufnr)
+  local ok, value = pcall(vim.api.nvim_buf_get_var, bufnr, active_var)
+  return ok and value == true
+end
+
+---@return { enabled: boolean, args: string[] }
+function M.resolve()
+  local raw = runtime.get_difftastic_config()
+  if raw == nil or raw == false then
+    return { enabled = false, args = {} }
+  end
+  local args = {}
+  if type(raw) == 'table' and type(raw.args) == 'table' then
+    args = raw.args
+  end
+  return { enabled = true, args = args }
+end
+
+---@return boolean
+function M.available()
+  return M.resolve().enabled and vim.fn.executable(COMMAND) == 1
+end
+
+---@param value any
+---@return any
+local function nilify(value)
+  if value == nil or value == vim.NIL then
+    return nil
+  end
+  return value
+end
+
+--- Coerce a ContentLines (a list with extra non-integer metadata keys) into a
+--- plain string[] that vim.fn.writefile can convert to a Vim list.
+---@param lines string[]|diffs.ContentLines
+---@return string[]
+local function plain_lines(lines)
+  local out = {}
+  for i, line in ipairs(lines) do
+    out[i] = line
+  end
+  return out
+end
+
+---@param old_lines string[]
+---@param new_lines string[]
+---@param relpath string
+---@return string, string, string temp dir, old path, new path
+local function write_pair(old_lines, new_lines, relpath)
+  local tmp = vim.fn.tempname()
+  vim.fn.mkdir(tmp, 'p')
+  local base = vim.fn.fnamemodify(relpath, ':t')
+  if base == '' then
+    base = 'file'
+  end
+  local old_file = tmp .. '/old_' .. base
+  local new_file = tmp .. '/new_' .. base
+  vim.fn.writefile(plain_lines(old_lines), old_file)
+  vim.fn.writefile(plain_lines(new_lines), new_file)
+  return tmp, old_file, new_file
+end
+
+--- Run difft on two file paths and return the decoded JSON, or nil + error.
+--- We always force JSON output, no color, and strip-cr off (so difft's byte
+--- offsets stay aligned with our exact line bytes); user `args` are appended.
+---@param old_path string
+---@param new_path string
+---@return table?, string?
+function M.run_json(old_path, new_path)
+  local cfg = M.resolve()
+  if not cfg.enabled then
+    return nil, 'difftastic disabled'
+  end
+
+  local cmd = { COMMAND, '--display', 'json', '--color', 'never', '--strip-cr', 'off' }
+  for _, arg in ipairs(cfg.args) do
+    cmd[#cmd + 1] = arg
+  end
+  cmd[#cmd + 1] = old_path
+  cmd[#cmd + 1] = new_path
+
+  local env = vim.tbl_extend('force', vim.fn.environ(), { DFT_UNSTABLE = 'yes' })
+  local ok, result = pcall(function()
+    return vim.system(cmd, { text = true, env = env }):wait(TIMEOUT_MS)
+  end)
+  if not ok then
+    return nil, 'difft invocation failed: ' .. tostring(result)
+  end
+  if result.code ~= 0 and result.code ~= 1 then
+    return nil, 'difft exited ' .. tostring(result.code) .. ': ' .. (result.stderr or '')
+  end
+  if not result.stdout or result.stdout == '' then
+    return nil, 'difft produced no output'
+  end
+
+  local decoded_ok, decoded = pcall(vim.json.decode, result.stdout)
+  if not decoded_ok then
+    return nil, 'invalid difft json: ' .. tostring(decoded)
+  end
+  if type(decoded) == 'table' and decoded.aligned_lines == nil and decoded[1] ~= nil then
+    decoded = decoded[1]
+  end
+  if type(decoded) ~= 'table' then
+    return nil, 'unexpected difft json shape'
+  end
+  if decoded.status == 'created' or decoded.status == 'deleted' then
+    return nil, 'difftastic: no structural diff for ' .. decoded.status .. ' file'
+  end
+  if decoded.status ~= 'unchanged' and (decoded.aligned_lines == nil or decoded.chunks == nil) then
+    return nil, 'unexpected difft json shape'
+  end
+  if type(decoded.language) == 'string' and decoded.language:match('^Text') then
+    dbg('difftastic line-diff fallback: %s', decoded.language)
+  end
+  return decoded
+end
+
+--- Per-line change spans, keyed by 0-based line number. Robust to difft's
+--- unordered chunk entries (we key by line_number, never rely on order).
+---@param json table
+---@return table<integer, {col_start: integer, col_end: integer}[]>, table<integer, {col_start: integer, col_end: integer}[]>
+function M.span_maps(json)
+  local lhs, rhs = {}, {}
+  local function collect(side_map, side)
+    local entry = nilify(side)
+    if not entry then
+      return
+    end
+    local line = nilify(entry.line_number)
+    if line == nil then
+      return
+    end
+    local spans = {}
+    for _, change in ipairs(entry.changes or {}) do
+      local s = nilify(change.start)
+      local e = nilify(change['end'])
+      if type(s) == 'number' and type(e) == 'number' and e > s then
+        spans[#spans + 1] = { col_start = s, col_end = e }
+      end
+    end
+    side_map[line] = spans
+  end
+  for _, chunk in ipairs(json.chunks or {}) do
+    for _, row in ipairs(chunk) do
+      collect(lhs, row.lhs)
+      collect(rhs, row.rhs)
+    end
+  end
+  return lhs, rhs
+end
+
+---@param maps table<integer, table[]>
+---@return boolean
+local function map_has_spans(maps)
+  return next(maps) ~= nil
+end
+
+---@param lhs table?
+---@param rhs table?
+---@return boolean
+function M.has_changes(lhs, rhs)
+  return (lhs ~= nil and map_has_spans(lhs)) or (rhs ~= nil and map_has_spans(rhs))
+end
+
+---@param spans {col_start: integer, col_end: integer}[]?
+---@return boolean
+local function has_spans(spans)
+  return spans ~= nil and #spans > 0
+end
+
+--- Build a split-compatible alignment (diffs.SplitAlignment shape) from
+--- difftastic's whole-file structural alignment, plus per-row intra spans.
+---@param json table
+---@param old_lines string[]
+---@param new_lines string[]
+---@return diffs.DifftAlignment
+function M.build_alignment(json, old_lines, new_lines)
+  local lhs, rhs = M.span_maps(json)
+  local left_lines, right_lines = {}, {}
+  local left_rows, right_rows = {}, {}
+  local left_intra, right_intra = {}, {}
+  local anchors = {}
+  local prev_changed = false
+  local changed = false
+
+  for _, pair in ipairs(json.aligned_lines or {}) do
+    local l, r = nilify(pair[1]), nilify(pair[2])
+    local left_content = l ~= nil and old_lines[l + 1] or nil
+    local right_content = r ~= nil and new_lines[r + 1] or nil
+    local left_past = l ~= nil and left_content == nil
+    local right_past = r ~= nil and right_content == nil
+    local both_virtual = (l == nil or left_past) and (r == nil or right_past)
+
+    if not both_virtual then
+      local left_changes = (l ~= nil and not left_past) and lhs[l] or nil
+      local right_changes = (r ~= nil and not right_past) and rhs[r] or nil
+      local left_filler = l == nil or left_past
+      local right_filler = r == nil or right_past
+
+      local left_kind = left_filler and 'filler'
+        or (has_spans(left_changes) and 'delete' or 'context')
+      local right_kind = right_filler and 'filler'
+        or (has_spans(right_changes) and 'add' or 'context')
+
+      local idx = #left_lines + 1
+      left_lines[idx] = left_content or ''
+      right_lines[idx] = right_content or ''
+      left_rows[idx] = {
+        kind = left_kind,
+        old_lnum = (not left_filler) and (l + 1) or nil,
+        new_lnum = (not left_filler and r ~= nil and not right_past) and (r + 1) or nil,
+      }
+      right_rows[idx] = {
+        kind = right_kind,
+        old_lnum = (not right_filler and l ~= nil and not left_past) and (l + 1) or nil,
+        new_lnum = (not right_filler) and (r + 1) or nil,
+      }
+      if has_spans(left_changes) then
+        left_intra[idx] = left_changes
+      end
+      if has_spans(right_changes) then
+        right_intra[idx] = right_changes
+      end
+
+      local row_changed = left_kind == 'delete'
+        or left_kind == 'filler'
+        or right_kind == 'add'
+        or right_kind == 'filler'
+      if row_changed then
+        changed = true
+        if not prev_changed then
+          anchors[#anchors + 1] = idx
+        end
+      end
+      prev_changed = row_changed
+    end
+  end
+
+  return {
+    left_lines = left_lines,
+    right_lines = right_lines,
+    left_rows = left_rows,
+    right_rows = right_rows,
+    anchors = anchors,
+    left_intra = left_intra,
+    right_intra = right_intra,
+    changed = changed,
+  }
+end
+
+--- Structural alignment for the split layout, from two content arrays.
+---@param old_lines string[]
+---@param new_lines string[]
+---@param relpath string
+---@return diffs.DifftAlignment?, string?
+function M.align(old_lines, new_lines, relpath)
+  old_lines = plain_lines(old_lines)
+  new_lines = plain_lines(new_lines)
+  local tmp, old_file, new_file = write_pair(old_lines, new_lines, relpath)
+  local json, err = M.run_json(old_file, new_file)
+  pcall(vim.fn.delete, tmp, 'rf')
+  if not json then
+    dbg('difftastic align failed: %s', err or 'unknown')
+    return nil, err
+  end
+  return M.build_alignment(json, old_lines, new_lines)
+end
+
+--- Per-line span maps for two content arrays (materialized to temp files).
+---@param old_lines string[]
+---@param new_lines string[]
+---@param relpath string
+---@return table?, table?, string?
+function M.span_maps_for_content(old_lines, new_lines, relpath)
+  local tmp, old_file, new_file = write_pair(old_lines, new_lines, relpath)
+  local json, err = M.run_json(old_file, new_file)
+  pcall(vim.fn.delete, tmp, 'rf')
+  if not json then
+    dbg('difftastic span maps failed: %s', err or 'unknown')
+    return nil, nil, err
+  end
+  local lhs, rhs = M.span_maps(json)
+  return lhs, rhs
+end
+
+--- Per-line span maps for two real file paths (`:Diff files` — no temp files).
+---@param left_path string
+---@param right_path string
+---@return table?, table?, string?
+function M.span_maps_for_paths(left_path, right_path)
+  local json, err = M.run_json(left_path, right_path)
+  if not json then
+    dbg('difftastic span maps failed: %s', err or 'unknown')
+    return nil, nil, err
+  end
+  local lhs, rhs = M.span_maps(json)
+  return lhs, rhs
+end
+
+--- Paint structural intra-line spans onto a generated unified diffs:// buffer,
+--- mapping difft's per-line spans onto the parsed hunk lines. Spans land in a
+--- dedicated namespace; the decorator's own intra step is suppressed for the
+--- buffer (diffs_difft_active). Content columns are offset past the rail and the
+--- one-character diff prefix (rail_width + 1).
+---@param bufnr integer
+---@param lhs table<integer, table[]>
+---@param rhs table<integer, table[]>
+---@param diff_lines string[]
+---@param spec diffs.DiffSpec?
+---@param rail_width integer
+---@return integer applied span count
+function M.apply_unified(bufnr, lhs, rhs, diff_lines, spec, rail_width)
+  local opts = runtime.get_highlight_opts()
+  local intra_cfg = opts.highlights.intra
+  local priority = opts.highlights.priorities.char_bg
+  local base = rail_width + 1
+
+  vim.api.nvim_buf_clear_namespace(bufnr, unified_ns, 0, -1)
+  M.mark_active(bufnr)
+
+  if not intra_cfg or not intra_cfg.enabled then
+    return 0
+  end
+
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  local applied = 0
+  for _, hunk in ipairs(hunk_model.parse(diff_lines, spec)) do
+    for _, line in ipairs(hunk.lines) do
+      local spans, hl
+      if line.kind == 'delete' and line.old_lnum then
+        spans, hl = lhs[line.old_lnum - 1], 'DiffsDeleteText'
+      elseif line.kind == 'add' and line.new_lnum then
+        spans, hl = rhs[line.new_lnum - 1], 'DiffsAddText'
+      end
+      if spans and line.lnum >= 1 and line.lnum <= line_count then
+        for _, span in ipairs(spans) do
+          local ok = pcall(
+            vim.api.nvim_buf_set_extmark,
+            bufnr,
+            unified_ns,
+            line.lnum - 1,
+            base + span.col_start,
+            {
+              end_col = base + span.col_end,
+              hl_group = hl,
+              priority = priority,
+            }
+          )
+          if ok then
+            applied = applied + 1
+          end
+        end
+      end
+    end
+  end
+  return applied
+end
+
+M._test = {
+  nilify = nilify,
+  plain_lines = plain_lines,
+}
+
+return M

--- a/lua/diffs/health.lua
+++ b/lua/diffs/health.lua
@@ -22,6 +22,15 @@ function M.check()
   else
     vim.health.info('libvscode_diff not found (optional, using native vim.diff fallback)')
   end
+
+  local difftastic = require('diffs.difftastic')
+  if not difftastic.resolve().enabled then
+    vim.health.info('difftastic not enabled (optional, set integrations.difftastic)')
+  elseif difftastic.available() then
+    vim.health.ok('difftastic (difft) found on PATH')
+  else
+    vim.health.warn('integrations.difftastic is enabled but difft was not found on PATH')
+  end
 end
 
 return M

--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -695,10 +695,12 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
   ---@type diffs.IntraChanges?
   local intra = nil
   local intra_cfg = opts.highlights.intra
+  local difft_active = vim.b[bufnr].diffs_difft_active == true
   if
     not opts.syntax_only
     and intra_cfg
     and intra_cfg.enabled
+    and not difft_active
     and pw == 1
     and (hunk._hl_line_count or #hunk.lines) <= intra_cfg.max_lines
   then

--- a/lua/diffs/runtime/init.lua
+++ b/lua/diffs/runtime/init.lua
@@ -175,6 +175,12 @@ function M.get_view_config()
   return config.view
 end
 
+---@return boolean|diffs.DifftasticConfig|nil
+function M.get_difftastic_config()
+  init()
+  return config.integrations.difftastic
+end
+
 ---@return diffs.HunkOpts
 function M.get_highlight_opts()
   init()

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local diff = require('diffs.diff')
 local diffspec = require('diffs.spec')
+local difftastic = require('diffs.difftastic')
 local generated = require('diffs.generated')
 local hunk_model = require('diffs.hunks')
 local lists = require('diffs.lists')
@@ -30,6 +31,7 @@ local win_closed_registered = false
 ---@field rail_width integer
 ---@field change_bar string
 ---@field anchors integer[]
+---@field difft_intra? table<integer, {col_start: integer, col_end: integer}[]>
 
 ---@type table<integer, diffs.SplitPaneInfo>
 local pane_info = {}
@@ -238,9 +240,36 @@ end
 
 ---@param bufnr integer
 ---@param info diffs.SplitPaneInfo
+local function set_split_intra_difft(bufnr, info)
+  local opts = require('diffs.runtime').get_highlight_opts()
+  local intra_cfg = opts.highlights.intra
+  if not intra_cfg or not intra_cfg.enabled then
+    return
+  end
+  local cfg = side_config[info.side]
+  local priority = opts.highlights.priorities.char_bg
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  for row_index, spans in pairs(info.difft_intra) do
+    if row_index >= 1 and row_index <= line_count then
+      for _, span in ipairs(spans) do
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, split_intra_ns, row_index - 1, span.col_start, {
+          end_col = span.col_end,
+          hl_group = cfg.text_hl,
+          priority = priority,
+        })
+      end
+    end
+  end
+end
+
+---@param bufnr integer
+---@param info diffs.SplitPaneInfo
 ---@param hunks diffs.DiffHunk[]
 local function set_split_intra(bufnr, info, hunks)
   vim.api.nvim_buf_clear_namespace(bufnr, split_intra_ns, 0, -1)
+  if info.difft_intra then
+    return set_split_intra_difft(bufnr, info)
+  end
   if not hunks or #hunks == 0 then
     return
   end
@@ -388,6 +417,9 @@ end
 local function paint_pane(bufnr, source, info, hunks)
   pane_info[bufnr] = info
   set_source_vars(bufnr, source, hunks)
+  if info.difft_intra then
+    difftastic.mark_active(bufnr)
+  end
   set_split_line_bg(bufnr, info)
   set_split_intra(bufnr, info, hunks)
 end
@@ -881,13 +913,27 @@ local function delete_pair_buffers(buffers)
   end
 end
 
+---@param spec diffs.DiffSpec
+---@param old_lines string[]
+---@param new_lines string[]
+---@return diffs.DifftAlignment? difftastic alignment when enabled/available, else nil
+local function difft_alignment(spec, old_lines, new_lines)
+  if not difftastic.available() then
+    return nil
+  end
+  local relpath = (spec and spec.scope and spec.scope.path) or 'file'
+  return (difftastic.align(old_lines, new_lines, relpath))
+end
+
 ---@param old_lines string[]
 ---@param new_lines string[]
 ---@param hunks diffs.DiffHunk[]
 ---@param change_bar? string
+---@param difft? diffs.DifftAlignment precomputed difftastic alignment
 ---@return diffs.SplitAlignment, diffs.SplitPaneInfo, diffs.SplitPaneInfo
-local function build_pane_infos(old_lines, new_lines, hunks, change_bar)
-  local alignment = split_align.align(old_lines, new_lines, hunks)
+local function build_pane_infos(old_lines, new_lines, hunks, change_bar, difft)
+  local use_difft = difft ~= nil and difft.changed
+  local alignment = use_difft and difft or split_align.align(old_lines, new_lines, hunks)
   local max_lnum = math.max(#old_lines, #new_lines, 1)
   local rail_width = math.max(2, #tostring(max_lnum))
   local bar = change_bar or default_change_bar
@@ -897,6 +943,7 @@ local function build_pane_infos(old_lines, new_lines, hunks, change_bar)
     rail_width = rail_width,
     change_bar = bar,
     anchors = alignment.anchors,
+    difft_intra = use_difft and difft.left_intra or nil,
   }
   local right_info = {
     rows = alignment.right_rows,
@@ -904,6 +951,7 @@ local function build_pane_infos(old_lines, new_lines, hunks, change_bar)
     rail_width = rail_width,
     change_bar = bar,
     anchors = alignment.anchors,
+    difft_intra = use_difft and difft.right_intra or nil,
   }
   return alignment, left_info, right_info
 end
@@ -937,8 +985,12 @@ function M.open(opts)
     return nil, right_err
   end
   local split_hunks = split_hunks_for(opts.diff_lines, spec)
+  local difft = difft_alignment(spec, old_content, new_content)
+  if difft and not difft.changed then
+    log.notify('difftastic: no structural changes (formatting only)', vim.log.levels.INFO)
+  end
   local alignment, left_info, right_info =
-    build_pane_infos(old_content, new_content, split_hunks, opts.change_bar)
+    build_pane_infos(old_content, new_content, split_hunks, opts.change_bar, difft)
 
   local reuse = opts.reuse_wins
   local invoking_win = vim.api.nvim_get_current_win()
@@ -1082,8 +1134,9 @@ function M.read_buffer(bufnr, source, opts)
   local old_content = source.side == 'left' and current_lines or peer_lines
   local new_content = source.side == 'right' and current_lines or peer_lines
 
+  local difft = difft_alignment(source.spec, old_content, new_content)
   local alignment, left_info, right_info =
-    build_pane_infos(old_content, new_content, split_hunks or {}, opts.change_bar)
+    build_pane_infos(old_content, new_content, split_hunks or {}, opts.change_bar, difft)
   apply_buffer_lines(left_buf, left_source, alignment.left_lines, left_info, split_hunks or {})
   apply_buffer_lines(right_buf, right_source, alignment.right_lines, right_info, split_hunks or {})
   set_peers(left_buf, right_buf)

--- a/spec/difftastic_spec.lua
+++ b/spec/difftastic_spec.lua
@@ -1,0 +1,244 @@
+require('spec.helpers')
+
+local config = require('diffs.config')
+local difftastic = require('diffs.difftastic')
+local runtime = require('diffs.runtime')
+
+describe('diffs.difftastic', function()
+  describe('config', function()
+    it('accepts integrations.difftastic = true', function()
+      assert.has_no.errors(function()
+        config.new({ integrations = { difftastic = true } })
+      end)
+    end)
+
+    it('accepts a table with args', function()
+      assert.has_no.errors(function()
+        config.new({ integrations = { difftastic = { args = { '--ignore-comments' } } } })
+      end)
+    end)
+
+    it('rejects a non-boolean/table value', function()
+      assert.has.errors(function()
+        config.new({ integrations = { difftastic = 42 } })
+      end)
+    end)
+
+    it('rejects args that is not a list', function()
+      assert.has.errors(function()
+        config.new({ integrations = { difftastic = { args = 'nope' } } })
+      end)
+    end)
+
+    it('rejects args with non-string elements', function()
+      assert.has.errors(function()
+        config.new({ integrations = { difftastic = { args = { 123, '--flag' } } } })
+      end)
+    end)
+
+    it('defaults to disabled when unset', function()
+      local cfg = config.new({})
+      assert.is_nil(cfg.integrations.difftastic)
+    end)
+  end)
+
+  describe('resolve', function()
+    local original
+    before_each(function()
+      original = runtime.get_difftastic_config
+    end)
+    after_each(function()
+      runtime.get_difftastic_config = original
+    end)
+
+    it('is disabled for nil/false', function()
+      runtime.get_difftastic_config = function()
+        return nil
+      end
+      assert.is_false(difftastic.resolve().enabled)
+      runtime.get_difftastic_config = function()
+        return false
+      end
+      assert.is_false(difftastic.resolve().enabled)
+    end)
+
+    it('is enabled with empty args for true', function()
+      runtime.get_difftastic_config = function()
+        return true
+      end
+      local cfg = difftastic.resolve()
+      assert.is_true(cfg.enabled)
+      assert.same({}, cfg.args)
+    end)
+
+    it('forwards args from a table', function()
+      runtime.get_difftastic_config = function()
+        return { args = { '--ignore-comments' } }
+      end
+      assert.same({ '--ignore-comments' }, difftastic.resolve().args)
+    end)
+  end)
+
+  describe('span_maps', function()
+    it('keys changes by line_number and is order-independent', function()
+      local json = {
+        chunks = {
+          {
+            { lhs = vim.NIL, rhs = { line_number = 5, changes = { { start = 2, ['end'] = 6 } } } },
+            { lhs = { line_number = 1, changes = { { start = 0, ['end'] = 3 } } }, rhs = vim.NIL },
+          },
+        },
+      }
+      local lhs, rhs = difftastic.span_maps(json)
+      assert.same({ { col_start = 0, col_end = 3 } }, lhs[1])
+      assert.same({ { col_start = 2, col_end = 6 } }, rhs[5])
+    end)
+
+    it('drops empty/zero-width spans and vim.NIL sides', function()
+      local json = {
+        chunks = {
+          {
+            { lhs = { line_number = 0, changes = { { start = 1, ['end'] = 1 } } }, rhs = vim.NIL },
+          },
+        },
+      }
+      local lhs = difftastic.span_maps(json)
+      assert.same({}, lhs[0])
+    end)
+  end)
+
+  describe('has_changes', function()
+    it('is true only when a side has spans', function()
+      assert.is_false(difftastic.has_changes({}, {}))
+      assert.is_true(difftastic.has_changes({ [1] = { { col_start = 0, col_end = 1 } } }, {}))
+    end)
+  end)
+
+  describe('build_alignment', function()
+    -- old = {a,b,c}; new = {a,C}: a unchanged, b deleted, c rewritten to C
+    local json = {
+      language = 'Lua',
+      status = 'changed',
+      aligned_lines = { { 0, 0 }, { 1, vim.NIL }, { 2, 1 } },
+      chunks = {
+        {
+          { lhs = { line_number = 1, changes = { { start = 0, ['end'] = 1 } } }, rhs = vim.NIL },
+          {
+            lhs = { line_number = 2, changes = { { start = 0, ['end'] = 1 } } },
+            rhs = { line_number = 1, changes = { { start = 0, ['end'] = 1 } } },
+          },
+        },
+      },
+    }
+
+    it('produces aligned rows with structural kinds', function()
+      local a = difftastic.build_alignment(json, { 'a', 'b', 'c' }, { 'a', 'C' })
+      assert.same({ 'a', 'b', 'c' }, a.left_lines)
+      assert.same({ 'a', '', 'C' }, a.right_lines)
+      assert.are.equal('context', a.left_rows[1].kind)
+      assert.are.equal('delete', a.left_rows[2].kind)
+      assert.are.equal('filler', a.right_rows[2].kind)
+      assert.are.equal('delete', a.left_rows[3].kind)
+      assert.are.equal('add', a.right_rows[3].kind)
+    end)
+
+    it('reports changed and anchors at the first changed run', function()
+      local a = difftastic.build_alignment(json, { 'a', 'b', 'c' }, { 'a', 'C' })
+      assert.is_true(a.changed)
+      assert.same({ 2 }, a.anchors)
+    end)
+
+    it('carries per-row intra spans', function()
+      local a = difftastic.build_alignment(json, { 'a', 'b', 'c' }, { 'a', 'C' })
+      assert.same({ { col_start = 0, col_end = 1 } }, a.left_intra[3])
+      assert.same({ { col_start = 0, col_end = 1 } }, a.right_intra[3])
+      assert.is_nil(a.right_intra[1])
+    end)
+
+    it('reports not changed for a structurally identical alignment', function()
+      local a = difftastic.build_alignment({
+        aligned_lines = { { 0, 0 }, { 1, 1 } },
+        chunks = {},
+      }, { 'a', 'b' }, { 'a', 'b' })
+      assert.is_false(a.changed)
+      assert.same({}, a.anchors)
+    end)
+  end)
+
+  describe('whitespace toggle guard', function()
+    it('warns and does nothing on a difftastic-active buffer', function()
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'x' })
+      difftastic.mark_active(buf)
+      assert.is_true(difftastic.is_active(buf))
+
+      vim.cmd('botright split')
+      vim.api.nvim_win_set_buf(0, buf)
+      local before = vim.api.nvim_get_option_value('diffopt', {})
+      local warned
+      local orig_notify = vim.notify
+      vim.notify = function(msg)
+        warned = msg
+      end
+
+      require('diffs.commands').toggle_whitespace()
+
+      vim.notify = orig_notify
+      assert.is_truthy(warned and warned:match('difftastic'))
+      assert.are.equal(before, vim.api.nvim_get_option_value('diffopt', {}))
+      vim.cmd('close')
+    end)
+  end)
+
+  describe('integration (difft-gated)', function()
+    if vim.fn.executable('difft') ~= 1 then
+      return
+    end
+
+    local original
+    before_each(function()
+      original = runtime.get_difftastic_config
+      runtime.get_difftastic_config = function()
+        return true
+      end
+    end)
+    after_each(function()
+      runtime.get_difftastic_config = original
+    end)
+
+    it('aligns a rename via real difft', function()
+      local old_lines = { 'local function clamp(value, low, high)', '  return low', 'end' }
+      local new_lines =
+        { 'local function clamp(value, low, high)', '  return math.max(low, value)', 'end' }
+      local a = difftastic.align(old_lines, new_lines, 'rate.lua')
+      assert.is_truthy(a)
+      assert.is_true(a.changed)
+      assert.are.equal(#a.left_lines, #a.right_lines)
+    end)
+
+    it('reports not changed for a reindentation-only change', function()
+      local old_lines = { 'local function f()', 'return 1', 'end' }
+      local new_lines = { 'local function f()', '    return 1', 'end' }
+      local a = difftastic.align(old_lines, new_lines, 'x.lua')
+      assert.is_truthy(a)
+      assert.is_false(a.changed)
+    end)
+
+    it('falls back cleanly on all-added and all-removed files', function()
+      assert.is_nil(difftastic.align({}, { 'local x = 1', 'return x' }, 'x.lua'))
+      assert.is_nil(difftastic.align({ 'local x = 1', 'return x' }, {}, 'x.lua'))
+    end)
+
+    it('keeps byte offsets aligned with tabs and multibyte chars', function()
+      local _, rhs = difftastic.span_maps_for_content(
+        { '\tlocal café_count = 1' },
+        { '\tlocal café_count = 2' },
+        'x.lua'
+      )
+      assert.is_truthy(rhs and rhs[0])
+      local line = '\tlocal café_count = 2'
+      local span = rhs[0][1]
+      assert.are.equal('2', line:sub(span.col_start + 1, span.col_end))
+    end)
+  end)
+end)


### PR DESCRIPTION
closes #395 
## Problem

diffs.nvim highlights diffs with git's line/text model. For reformatted, reindented, or otherwise restructured code, a line/word diff highlights noise: every shifted line looks changed and the tokens that actually changed are buried. There was no way to get difftastic's structural (syntax-tree) view inside the plugin.

## Solution

Add difftastic as an optional, opt-in structural diff engine, configured at `integrations.difftastic` as either a boolean or a table that forwards raw `args` to the binary. When the `difft` binary is available, the diffs you explicitly open are augmented with difftastic's token-level intra-line highlighting and, in the split layout, its structural row alignment. That covers `:Diff`, `:Diff ++layout=split`, `:Diff files`, and staged/untracked file diffs.

difftastic is treated as a backend the plugin invokes rather than a plugin whose buffers are decorated, so it stays independent of `highlights.intra`, which remains the fallback engine. It only augments the two axes it can: intra-line spans wherever intra runs, and side-by-side alignment in the split layout, while the line-level diff stays git's. The engine forces JSON output with `--strip-cr off` so its byte offsets stay aligned with buffer content, and it degrades silently to the normal git rendering whenever `difft` is missing, disabled, errors, times out, or finds no structural change, in which case it emits an informational message.

Because difftastic needs whole files and parses synchronously, it deliberately never runs on the live decorator surfaces (fugitive, neogit, the builtin `diff` filetype), the multi-file review map, conflicts, or binary files; those keep their existing rendering. This keeps the integration synchronous with no asynchronous cache. A whitespace toggle is a no-op on difftastic buffers, reloading a diff clears difft state and falls back, and `:checkhealth` reports whether `difft` is detected.
