### PR TITLE
fix(neogit): clear word-diff inline highlights when integration is enabled

### DIFF
--- a/lua/diffs/runtime/highlight_groups.lua
+++ b/lua/diffs/runtime/highlight_groups.lua
@@ -1,3 +1,4 @@
+local integrations = require('diffs.integrations')
 local log = require('diffs.log')
 
 local M = {}
@@ -148,6 +149,14 @@ function M.apply(config, is_default)
     'DiffsConflictBaseNr',
     { default = dflt, fg = blended_base_nr, bg = blended_base }
   )
+
+  -- Neogit's word-diff highlights changed words with these groups; when our
+  -- integration owns the buffer we paint intra-line ourselves, so clear them.
+  -- https://github.com/NeogitOrg/neogit/blob/99326a1310fb2d616b455d2fd16d01bf00682f06/lua/neogit/lib/diff_highlights.lua#L232-L233
+  if integrations.is_enabled(config.integrations.neogit) then
+    vim.api.nvim_set_hl(0, 'NeogitDiffAddInline', {})
+    vim.api.nvim_set_hl(0, 'NeogitDiffDeleteInline', {})
+  end
 
   if config.highlights.overrides then
     for group, hl in pairs(config.highlights.overrides) do


### PR DESCRIPTION
## Problem

Neogit enables word-diff highlighting by default and paints the changed words within a diff line using `NeogitDiffAddInline` and `NeogitDiffDeleteInline`. These spans are applied at a priority above diffs.nvim's own intra-line highlights, so when the Neogit integration is enabled and diffs.nvim is rendering the diff, Neogit's word-diff colours (notably a saturated red on deletions) can still paint over the changed words instead of diffs.nvim's intra-line highlighting.

## Solution

When the Neogit integration is enabled, diffs.nvim owns intra-line highlighting in Neogit buffers, so clear `NeogitDiffAddInline` and `NeogitDiffDeleteInline`. The clear lives in the highlight-group computation that already re-runs on `ColorScheme`, so it persists across colourscheme changes, and it is gated on the integration so Neogit's native word-diff is left untouched for anyone who does not enable it.
