### PR TITLE
feat(diff): drive whitespace handling from diffopt

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -674,16 +674,33 @@ Whitespace handling: ~                                  *diffs.nvim-whitespace*
     The same flags apply to |:Diff|, |:Diff-review|, and every layout, because
     the generated diffs read 'diffopt' as they are rendered.
 
-    Toggle: ~
-        gw          Toggle `iwhiteall` in the global 'diffopt' and re-render the
-                    visible `diffs://` buffers in place. Mapped by default in
-                    every generated diff buffer; remap with
-                    |<Plug>(diffs-toggle-whitespace)|. The toggle flips only
-                    `iwhiteall`; set `iwhite`, `iwhiteeol`, or `iblank` through
-                    'diffopt' directly.
+    Changes to 'diffopt' take effect live: whenever the option changes the
+    generated `diffs://` buffers regenerate, the decorated surfaces repaint, and
+    native |:diffsplit| windows are refreshed with |:diffupdate|. There is no
+    dedicated mapping; toggle whitespace the standard Vim way by adding or
+    removing a flag from 'diffopt' (for example with a small `:set` mapping of
+    your own).
 
-    Because 'diffopt' is global, the toggle also changes native |:diffsplit|
-    windows, which pick it up on their next |:diffupdate|.
+    What an ignored whitespace change looks like depends on the surface,
+    because the plugin removes the noise where it generates the diff and only
+    re-styles it where the text cannot be regenerated:
+
+    - Generated `diffs://` buffers (|:Diff|, the staged/unstaged sections, and
+      |:Diff-review|): regenerated with the matching git/|vim.diff()| flag, so
+      a whitespace-only hunk is dropped entirely and never appears.
+    - Split layout (`++layout=split`): regenerated the same way, so a
+      whitespace-only change shows as plain, uncolored context — both sides
+      stay visible with their own indentation, just without add/delete color.
+    - Decorated, non-generated buffers (`gitcommit` from `git commit -v`,
+      vim-fugitive, Neogit, plain `diff` buffers): the text cannot be
+      regenerated, so a `+`/`-` line whose only change is whitespace is kept
+      but de-emphasized — the prefix and syntax are kept and the intra-line
+      emphasis dropped, while the added/removed background becomes a faint,
+      neutral |DiffsDim|. Lines that mix a real change with whitespace stay
+      fully highlighted.
+    - difftastic-rendered diffs: left unchanged; the 'diffopt' whitespace flags
+      do not apply (see |diffs.nvim-difftastic|).
+    - Native |:diffsplit| windows: whitespace is handled by Neovim itself.
 
     Limitations: ~
     - With `highlights.intra.algorithm = 'vscode'` the intra-line highlighter
@@ -738,13 +755,6 @@ MAPPINGS                                                 *diffs.nvim-mappings*
                         `gO` by default in the split panes — a review's files are
                         its table of contents — unless `gO` is already mapped in
                         that buffer. See |diffs.nvim.select_review_file()|.
-
-                                          *<Plug>(diffs-toggle-whitespace)*
-<Plug>(diffs-toggle-whitespace)
-                        Toggle ignoring whitespace in diffs. Flips `iwhiteall`
-                        in the global |'diffopt'| and re-renders the visible
-                        `diffs://` buffers. Mapped to `gw` by default in every
-                        generated diff buffer. See |diffs.nvim-whitespace|.
 
                                                    *<Plug>(diffs-refresh)*
 <Plug>(diffs-refresh)
@@ -1034,8 +1044,9 @@ difftastic runs synchronously when you open the diff, with an internal timeout.
 It is independent of |diffs.nvim-config| `highlights.intra`, which configures
 the built-in engine and is the fallback when difftastic is off. When difftastic
 finds no structural change (e.g. a reformat-only edit), it emits an
-informational message and renders no token highlights. Whitespace toggling
-(`gw`) does not apply to a structural diff and is a no-op on such buffers.
+informational message and renders no token highlights. The 'diffopt'
+whitespace handling does not apply to a structural diff; such buffers are
+left unchanged.
 
 Run |:checkhealth| diffs to confirm `difft` is detected.
 
@@ -1374,6 +1385,12 @@ Diff and generated rail highlights: ~
 
                                                                  *DiffsDelete*
     DiffsDelete         Background for `-` lines.
+
+                                                                    *DiffsDim*
+    DiffsDim            Faint, neutral background for a whitespace-only changed
+                        line on a decorated (non-generated) surface while
+                        'diffopt' ignores whitespace. See
+                        |diffs.nvim-whitespace|.
 
                                                                    *DiffsRail*
     DiffsRail           Generated line-number rails and separators.

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -191,9 +191,6 @@ function M.setup_diff_buf(bufnr)
   if not get_buffer_keymap(bufnr, 'n', 'q') then
     vim.keymap.set('n', 'q', '<cmd>close<CR>', { buffer = bufnr })
   end
-  if not get_buffer_keymap(bufnr, 'n', 'gw') then
-    vim.keymap.set('n', 'gw', '<Plug>(diffs-toggle-whitespace)', { buffer = bufnr, remap = true })
-  end
   local has_hunks, parsed_hunks = generated.raw_hunks(bufnr)
   if not has_hunks then
     clear_hunk_keymaps(bufnr)
@@ -2041,20 +2038,9 @@ function M.read_buffer(bufnr)
   runtime.attach(bufnr)
 end
 
----@param flag string
----@return boolean
-local function diffopt_has(flag)
-  for _, item in ipairs(vim.split(vim.o.diffopt, ',', { plain = true })) do
-    if item == flag then
-      return true
-    end
-  end
-  return false
-end
-
 --- Re-render every visible diffs:// buffer in place, preserving each window's
---- view. Used after a global change such as toggling whitespace, so the new
---- setting is reflected consistently across all open diff surfaces.
+--- view. Used after a global change such as 'diffopt', so the new setting is
+--- reflected consistently across all open diff surfaces.
 function M.refresh_visible()
   ---@type { win: integer, view: table }[]
   local views = {}
@@ -2105,22 +2091,19 @@ function M.refresh(bufnr)
   end
 end
 
---- Toggle ignoring all whitespace (iwhiteall) in the global 'diffopt' and
---- re-render the visible diffs:// buffers. The setting is global, so it also
---- affects native diff windows on their next update.
-function M.toggle_whitespace()
-  if difftastic.is_active(vim.api.nvim_get_current_buf()) then
-    notify('whitespace toggle does not apply to difftastic structural diffs', vim.log.levels.WARN)
-    return
-  end
-  if diffopt_has('iwhiteall') then
-    vim.opt.diffopt:remove('iwhiteall')
-    vim.api.nvim_echo({ { '[diffs]: diffopt -iwhiteall (showing whitespace)' } }, false, {})
-  else
-    vim.opt.diffopt:append('iwhiteall')
-    vim.api.nvim_echo({ { '[diffs]: diffopt +iwhiteall (ignoring whitespace)' } }, false, {})
-  end
-  M.refresh_visible()
+--- React to a runtime change of the global 'diffopt'. Generated diffs:// buffers
+--- regenerate (their content honors the whitespace/algorithm flags), attached
+--- repaint surfaces are invalidated so whitespace-only lines are re-classified,
+--- and native &diff windows are refreshed so they pick up the new options
+--- immediately. Deferred so buffer rewrites do not run inside the OptionSet
+--- callback, then a redraw flushes the new highlighting.
+function M.on_diffopt_changed()
+  vim.schedule(function()
+    M.refresh_visible()
+    runtime.invalidate_attached()
+    pcall(vim.cmd.diffupdate)
+    vim.cmd.redraw({ bang = true })
+  end)
 end
 
 function M.setup()

--- a/lua/diffs/diff.lua
+++ b/lua/diffs/diff.lua
@@ -187,29 +187,20 @@ local function char_diff_pair(old_line, new_line, del_idx, add_idx, diff_opts)
   return del_spans, add_spans
 end
 
+---@class diffs.LinePair
+---@field del {idx: integer, text: string}
+---@field add {idx: integer, text: string}
+
+--- Pair up the removed and added lines of a change group so they can be diffed
+--- (or classified) against each other. A 1:1 group pairs directly; larger
+--- groups are line-mapped with a block-level vim.diff() so equal-count runs line
+--- up and unequal-count runs pair as many as possible.
 ---@param group diffs.ChangeGroup
 ---@param diff_opts? diffs.DiffOpts
----@return diffs.CharSpan[], diffs.CharSpan[]
-local function diff_group_native(group, diff_opts)
-  ---@type diffs.CharSpan[]
-  local all_del = {}
-  ---@type diffs.CharSpan[]
-  local all_add = {}
-
-  local del_count = #group.del_lines
-  local add_count = #group.add_lines
-
-  if del_count == 1 and add_count == 1 then
-    local ds, as = char_diff_pair(
-      group.del_lines[1].text,
-      group.add_lines[1].text,
-      group.del_lines[1].idx,
-      group.add_lines[1].idx,
-      diff_opts
-    )
-    vim.list_extend(all_del, ds)
-    vim.list_extend(all_add, as)
-    return all_del, all_add
+---@return diffs.LinePair[]
+local function pair_group_lines(group, diff_opts)
+  if #group.del_lines == 1 and #group.add_lines == 1 then
+    return { { del = group.del_lines[1], add = group.add_lines[1] } }
   end
 
   local old_texts = {}
@@ -224,51 +215,41 @@ local function diff_group_native(group, diff_opts)
   local old_block = table.concat(old_texts, '\n') .. '\n'
   local new_block = table.concat(new_texts, '\n') .. '\n'
 
-  local line_hunks = byte_diff(old_block, new_block, diff_opts)
+  local pair_opts = diff_opts
+  if diff_opts and diff_opts.linematch then
+    pair_opts = { algorithm = diff_opts.algorithm }
+  end
+  local line_hunks = byte_diff(old_block, new_block, pair_opts)
 
-  ---@type table<integer, integer>
-  local old_to_new = {}
+  ---@type diffs.LinePair[]
+  local pairs_out = {}
   for _, lh in ipairs(line_hunks) do
-    if lh.old_count == lh.new_count then
-      for k = 0, lh.old_count - 1 do
-        old_to_new[lh.old_start + k] = lh.new_start + k
+    local count = (lh.old_count == lh.new_count) and lh.old_count
+      or math.min(lh.old_count, lh.new_count)
+    for k = 0, count - 1 do
+      local del = group.del_lines[lh.old_start + k]
+      local add = group.add_lines[lh.new_start + k]
+      if del and add then
+        table.insert(pairs_out, { del = del, add = add })
       end
     end
   end
+  return pairs_out
+end
 
-  for old_i, new_i in pairs(old_to_new) do
-    if group.del_lines[old_i] and group.add_lines[new_i] then
-      local ds, as = char_diff_pair(
-        group.del_lines[old_i].text,
-        group.add_lines[new_i].text,
-        group.del_lines[old_i].idx,
-        group.add_lines[new_i].idx,
-        diff_opts
-      )
-      vim.list_extend(all_del, ds)
-      vim.list_extend(all_add, as)
-    end
-  end
+---@param group diffs.ChangeGroup
+---@param diff_opts? diffs.DiffOpts
+---@return diffs.CharSpan[], diffs.CharSpan[]
+local function diff_group_native(group, diff_opts)
+  ---@type diffs.CharSpan[]
+  local all_del = {}
+  ---@type diffs.CharSpan[]
+  local all_add = {}
 
-  for _, lh in ipairs(line_hunks) do
-    if lh.old_count ~= lh.new_count then
-      local pairs_count = math.min(lh.old_count, lh.new_count)
-      for k = 0, pairs_count - 1 do
-        local oi = lh.old_start + k
-        local ni = lh.new_start + k
-        if group.del_lines[oi] and group.add_lines[ni] then
-          local ds, as = char_diff_pair(
-            group.del_lines[oi].text,
-            group.add_lines[ni].text,
-            group.del_lines[oi].idx,
-            group.add_lines[ni].idx,
-            diff_opts
-          )
-          vim.list_extend(all_del, ds)
-          vim.list_extend(all_add, as)
-        end
-      end
-    end
+  for _, pr in ipairs(pair_group_lines(group, diff_opts)) do
+    local ds, as = char_diff_pair(pr.del.text, pr.add.text, pr.del.idx, pr.add.idx, diff_opts)
+    vim.list_extend(all_del, ds)
+    vim.list_extend(all_add, as)
   end
 
   return all_del, all_add
@@ -427,6 +408,59 @@ function M.compute_intra_hunks(hunk_lines, algorithm)
   end
 
   return { add_spans = all_add, del_spans = all_del }
+end
+
+--- Normalize a line for whitespace-insensitive comparison, following the active
+--- 'diffopt' flags: iwhiteall drops all whitespace, iwhite collapses runs and
+--- trims, iwhiteeol trims only trailing whitespace. iblank has no per-line
+--- counterpart and is not handled here (matching drop_whitespace_spans).
+---@param line string
+---@param diff_opts diffs.DiffOpts
+---@return string
+local function normalize_ws(line, diff_opts)
+  if diff_opts.ignore_whitespace then
+    return (line:gsub('%s+', ''))
+  end
+  if diff_opts.ignore_whitespace_change then
+    return (line:gsub('%s+', ' '):gsub('^%s+', ''):gsub('%s+$', ''))
+  end
+  if diff_opts.ignore_whitespace_change_at_eol then
+    return (line:gsub('%s+$', ''))
+  end
+  return line
+end
+
+--- Classify which hunk lines are whitespace-only changes under the active
+--- 'diffopt' whitespace flags. Returns a set keyed by the 1-based hunk line
+--- index (matching `hunk.lines`). A `+`/`-` line is flagged only when it is
+--- reliably paired with a counterpart that is equal once whitespace is
+--- normalized; unpaired additions/deletions are never flagged. Returns an empty
+--- table immediately when no whitespace flag is active.
+---@param hunk_lines string[]
+---@return table<integer, boolean>
+function M.whitespace_only_lines(hunk_lines)
+  local diff_opts = diffopt.resolve()
+  if
+    not (
+      diff_opts.ignore_whitespace
+      or diff_opts.ignore_whitespace_change
+      or diff_opts.ignore_whitespace_change_at_eol
+    )
+  then
+    return {}
+  end
+
+  ---@type table<integer, boolean>
+  local result = {}
+  for _, group in ipairs(M.extract_change_groups(hunk_lines)) do
+    for _, pr in ipairs(pair_group_lines(group, diff_opts)) do
+      if normalize_ws(pr.del.text, diff_opts) == normalize_ws(pr.add.text, diff_opts) then
+        result[pr.del.idx] = true
+        result[pr.add.idx] = true
+      end
+    end
+  end
+  return result
 end
 
 ---@return boolean

--- a/lua/diffs/highlight.lua
+++ b/lua/diffs/highlight.lua
@@ -738,6 +738,17 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
     end
   end
 
+  ---@type table<integer, boolean>
+  local ws_only = {}
+  if
+    not opts.syntax_only
+    and not difft_active
+    and pw == 1
+    and (hunk._hl_line_count or #hunk.lines) <= (intra_cfg and intra_cfg.max_lines or 500)
+  then
+    ws_only = diff.whitespace_only_lines(hunk.lines)
+  end
+
   if
     (qw > 0 or pw > 1)
     and hunk.header_start_line
@@ -817,9 +828,12 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
     local has_add = prefix:find('+', 1, true) ~= nil
     local has_del = prefix:find('-', 1, true) ~= nil
     local is_diff_line = has_add or has_del
+    local dehl = ws_only[i] == true
     local line_hl = is_diff_line and (has_add and 'DiffsAdd' or 'DiffsDelete') or nil
     local prefix_hl = is_diff_line and (has_add and '@diff.plus' or '@diff.minus') or nil
     local bar_hl = is_diff_line and (has_add and 'DiffsAddBar' or 'DiffsDeleteBar') or nil
+    local dim_hl = is_diff_line and 'DiffsDim' or nil
+    local bg_hl = (dehl and dim_hl) or line_hl
 
     local is_marker = false
     if pw > 1 and line_hl and not prefix:find('[^+]') then
@@ -832,7 +846,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
 
     if not opts.syntax_only then
       if opts.hide_prefix and (not hunk.rail_width or is_diff_line) then
-        local virt_hl = (opts.highlights.background and line_hl) or nil
+        local virt_hl = (opts.highlights.background and bg_hl) or nil
         local rail_width = hunk.rail_width or 0
         local hide_width = math.max(0, pw + qw - rail_width)
         if hide_width > 0 then
@@ -883,7 +897,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
             end
           end
           local rail_nr_start, rail_nr_end, rail_nr_hl
-          if (has_del or has_add) and rail_number_ranges then
+          if (has_del or has_add) and rail_number_ranges and not dehl then
             local first_range = rail_number_ranges[1]
             local last_range = rail_style == 'single' and first_range
               or rail_number_ranges[#rail_number_ranges]
@@ -928,7 +942,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
         })
       end
 
-      if hunk.rail_width and is_diff_line and opts.highlights.background then
+      if hunk.rail_width and is_diff_line and opts.highlights.background and not dehl then
         pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
           virt_text = { { opts.change_bar or default_change_bar, bar_hl } },
           virt_text_pos = 'overlay',
@@ -941,7 +955,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
         pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, buf_line, 0, {
           end_row = buf_line + 1,
           end_col = 0,
-          hl_group = line_hl,
+          hl_group = bg_hl,
           hl_eol = true,
           priority = p.line_bg,
         })
@@ -955,7 +969,7 @@ function M.highlight_hunk(bufnr, ns, hunk, opts)
         })
       end
 
-      if char_spans_by_line[i] then
+      if char_spans_by_line[i] and not dehl then
         local char_hl = has_add and 'DiffsAddText' or 'DiffsDeleteText'
         for _, span in ipairs(char_spans_by_line[i]) do
           dbg(

--- a/lua/diffs/runtime/cache.lua
+++ b/lua/diffs/runtime/cache.lua
@@ -412,6 +412,17 @@ function Cache:process_pending_clear(bufnr)
 end
 
 ---@param bufnr integer
+function Cache:reset_highlights(bufnr)
+  local entry = self.hunk_cache[bufnr]
+  if not entry or not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+  vim.api.nvim_buf_clear_namespace(bufnr, self.ns, 0, -1)
+  entry.highlighted = {}
+  entry.pending_clear = false
+end
+
+---@param bufnr integer
 function Cache:delete(bufnr)
   self.hunk_cache[bufnr] = nil
   self.ft_retry_pending[bufnr] = nil

--- a/lua/diffs/runtime/highlight_groups.lua
+++ b/lua/diffs/runtime/highlight_groups.lua
@@ -96,6 +96,8 @@ function M.apply(config, is_default)
   vim.api.nvim_set_hl(0, 'DiffsAddText', { default = dflt, bg = blended_add_text })
   vim.api.nvim_set_hl(0, 'DiffsDeleteText', { default = dflt, bg = blended_del_text })
 
+  vim.api.nvim_set_hl(0, 'DiffsDim', { default = dflt, bg = blend_color(normal_fg, bg, 0.04) })
+
   log.dbg(
     'highlight groups: Normal.bg=%s DiffAdd.bg=#%06x diffAdded.fg=#%06x',
     normal.bg and string.format('#%06x', normal.bg) or 'NONE',

--- a/lua/diffs/runtime/init.lua
+++ b/lua/diffs/runtime/init.lua
@@ -130,6 +130,18 @@ function M.refresh(bufnr)
   cache:invalidate(bufnr)
 end
 
+--- Eagerly clear and re-arm every attached buffer's highlights so the next
+--- redraw repaints them. Used when a global change (such as 'diffopt') affects
+--- how all surfaces are highlighted. The clear is done eagerly rather than via
+--- the lazy pending_clear flag because the decoration provider's on_buf hook
+--- (which would process that flag) is not invoked by a bare redraw.
+function M.invalidate_attached()
+  init()
+  for bufnr, _ in pairs(attached_buffers) do
+    cache:reset_highlights(bufnr)
+  end
+end
+
 function M.attach_diff()
   init()
   diff_windows_mod.attach(diff_windows)

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -397,9 +397,6 @@ local function set_keymaps(bufnr)
       M.goto_prev(vim.api.nvim_get_current_buf())
     end, { buffer = bufnr, desc = 'Previous diff hunk' })
   end
-  if not get_buffer_keymap(bufnr, 'n', 'gw') then
-    vim.keymap.set('n', 'gw', '<Plug>(diffs-toggle-whitespace)', { buffer = bufnr, remap = true })
-  end
 end
 
 ---@param source diffs.SplitEndpointSource

--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -79,6 +79,13 @@ vim.api.nvim_create_autocmd('VimEnter', {
   end,
 })
 
+vim.api.nvim_create_autocmd('OptionSet', {
+  pattern = 'diffopt',
+  callback = function()
+    require('diffs.commands').on_diffopt_changed()
+  end,
+})
+
 local cmds = require('diffs.commands')
 vim.keymap.set('n', '<Plug>(diffs-diff)', function()
   cmds.diff(nil, false)
@@ -101,9 +108,6 @@ end, { desc = 'Previous file in review split' })
 vim.keymap.set('n', '<Plug>(diffs-review-select-file)', function()
   cmds.select_review_file()
 end, { desc = 'Pick a file in the review split' })
-vim.keymap.set('n', '<Plug>(diffs-toggle-whitespace)', function()
-  cmds.toggle_whitespace()
-end, { desc = 'Toggle ignoring whitespace in diffs' })
 vim.keymap.set('n', '<Plug>(diffs-refresh)', function()
   cmds.refresh()
 end, { desc = 'Re-render the current diff buffer' })

--- a/spec/diffopt_spec.lua
+++ b/spec/diffopt_spec.lua
@@ -89,8 +89,7 @@ describe('git-backed diffs honor diffopt whitespace', function()
   end)
 end)
 
-describe('whitespace toggle', function()
-  local commands = require('diffs.commands')
+describe('whitespace-only line classification', function()
   local saved
 
   before_each(function()
@@ -101,12 +100,91 @@ describe('whitespace toggle', function()
     vim.o.diffopt = saved
   end)
 
-  it('flips iwhiteall in the global diffopt', function()
+  it('returns an empty set when no whitespace flag is active', function()
     vim.o.diffopt = 'internal,filler'
-    commands.toggle_whitespace()
-    assert.is_true(vim.tbl_contains(vim.opt.diffopt:get(), 'iwhiteall'))
-    commands.toggle_whitespace()
-    assert.is_false(vim.tbl_contains(vim.opt.diffopt:get(), 'iwhiteall'))
+    assert.are.same({}, diff.whitespace_only_lines({ '-foo bar', '+foo  bar' }))
+  end)
+
+  it('flags a whitespace-only -/+ pair under iwhiteall', function()
+    vim.o.diffopt = 'internal,iwhiteall'
+    assert.are.same(
+      { [1] = true, [2] = true },
+      diff.whitespace_only_lines({ '-foo bar', '+foo  bar' })
+    )
+  end)
+
+  it('does not flag a content change under iwhiteall', function()
+    vim.o.diffopt = 'internal,iwhiteall'
+    assert.are.same({}, diff.whitespace_only_lines({ '-foo', '+bar' }))
+  end)
+
+  it('does not flag a line that mixes content and whitespace', function()
+    vim.o.diffopt = 'internal,iwhiteall'
+    assert.are.same({}, diff.whitespace_only_lines({ '-local x = 1', '+local y = 1  ' }))
+  end)
+
+  it('collapses whitespace runs under iwhite', function()
+    vim.o.diffopt = 'internal,iwhite'
+    assert.are.same(
+      { [1] = true, [2] = true },
+      diff.whitespace_only_lines({ '-foo  bar', '+foo bar' })
+    )
+  end)
+
+  it('flags only trailing differences under iwhiteeol', function()
+    vim.o.diffopt = 'internal,iwhiteeol'
+    assert.are.same({ [1] = true, [2] = true }, diff.whitespace_only_lines({ '-foo', '+foo  ' }))
+    assert.are.same({}, diff.whitespace_only_lines({ '-foo  bar', '+foo bar' }))
+  end)
+
+  it('ignores unpaired additions and deletions', function()
+    vim.o.diffopt = 'internal,iwhiteall'
+    assert.are.same({}, diff.whitespace_only_lines({ ' context', '+added line' }))
+  end)
+
+  it('classifies a reindented multi-line block', function()
+    vim.o.diffopt = 'internal,iwhiteall'
+    assert.are.same(
+      { [1] = true, [2] = true, [3] = true, [4] = true },
+      diff.whitespace_only_lines({
+        '-  function foo()',
+        '-    return 1',
+        '+    function foo()',
+        '+      return 1',
+      })
+    )
+  end)
+
+  it('classifies a reindented multi-line block when linematch is set', function()
+    vim.o.diffopt = 'internal,iwhiteall,linematch:60'
+    assert.are.same(
+      { [1] = true, [2] = true, [3] = true, [4] = true },
+      diff.whitespace_only_lines({
+        '-  function foo()',
+        '-    return 1',
+        '+    function foo()',
+        '+      return 1',
+      })
+    )
+  end)
+
+  it('treats a trailing-only multibyte change as whitespace-only under iwhiteall', function()
+    vim.o.diffopt = 'internal,iwhiteall'
+    assert.are.same(
+      { [1] = true, [2] = true },
+      diff.whitespace_only_lines({ '-café', '+café  ' })
+    )
+  end)
+
+  it('flags a blank-line-only change under iwhiteall', function()
+    vim.o.diffopt = 'internal,iwhiteall'
+    assert.are.same({ [1] = true, [2] = true }, diff.whitespace_only_lines({ '-  ', '+    ' }))
+  end)
+end)
+
+describe('diffopt change handler', function()
+  it('exposes on_diffopt_changed', function()
+    assert.are.equal('function', type(require('diffs.commands').on_diffopt_changed))
   end)
 end)
 

--- a/spec/difftastic_spec.lua
+++ b/spec/difftastic_spec.lua
@@ -165,31 +165,6 @@ describe('diffs.difftastic', function()
     end)
   end)
 
-  describe('whitespace toggle guard', function()
-    it('warns and does nothing on a difftastic-active buffer', function()
-      local buf = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'x' })
-      difftastic.mark_active(buf)
-      assert.is_true(difftastic.is_active(buf))
-
-      vim.cmd('botright split')
-      vim.api.nvim_win_set_buf(0, buf)
-      local before = vim.api.nvim_get_option_value('diffopt', {})
-      local warned
-      local orig_notify = vim.notify
-      vim.notify = function(msg)
-        warned = msg
-      end
-
-      require('diffs.commands').toggle_whitespace()
-
-      vim.notify = orig_notify
-      assert.is_truthy(warned and warned:match('difftastic'))
-      assert.are.equal(before, vim.api.nvim_get_option_value('diffopt', {}))
-      vim.cmd('close')
-    end)
-  end)
-
   describe('integration (difft-gated)', function()
     if vim.fn.executable('difft') ~= 1 then
       return

--- a/spec/highlight_spec.lua
+++ b/spec/highlight_spec.lua
@@ -179,6 +179,153 @@ describe('highlight', function()
       delete_buffer(bufnr)
     end)
 
+    it('dims whitespace-only line backgrounds under iwhiteall but keeps real changes', function()
+      local saved = vim.o.diffopt
+      vim.o.diffopt = 'internal,iwhiteall'
+
+      local bufnr = create_buffer({
+        '@@ -1,4 +1,4 @@',
+        ' local function g(a, b)',
+        '-  return a + b',
+        '+    return a + b',
+        '-local total = g(1, 2)',
+        '+local total = g(3, 4)',
+      })
+      local hunk = {
+        filename = 'test.lua',
+        start_line = 1,
+        prefix_width = 1,
+        quote_width = 0,
+        lines = {
+          ' local function g(a, b)',
+          '-  return a + b',
+          '+    return a + b',
+          '-local total = g(1, 2)',
+          '+local total = g(3, 4)',
+        },
+      }
+
+      highlight.highlight_hunk(
+        bufnr,
+        ns,
+        hunk,
+        default_opts({ highlights = { background = true } })
+      )
+      vim.o.diffopt = saved
+
+      local line_bg = {}
+      local dim_bg = {}
+      local intra = {}
+      local prefix_marks = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        local d = mark[4]
+        if d and d.hl_eol and (d.hl_group == 'DiffsAdd' or d.hl_group == 'DiffsDelete') then
+          line_bg[mark[2]] = d.hl_group
+        end
+        if d and d.hl_eol and d.hl_group == 'DiffsDim' then
+          dim_bg[mark[2]] = d.hl_group
+        end
+        if d and (d.hl_group == 'DiffsAddText' or d.hl_group == 'DiffsDeleteText') then
+          intra[mark[2]] = true
+        end
+        if d and (d.hl_group == '@diff.plus' or d.hl_group == '@diff.minus') then
+          prefix_marks[mark[2]] = d.hl_group
+        end
+      end
+
+      assert.is_nil(line_bg[2])
+      assert.is_nil(line_bg[3])
+      assert.are.equal('DiffsDim', dim_bg[2])
+      assert.are.equal('DiffsDim', dim_bg[3])
+      assert.is_nil(intra[2])
+      assert.is_nil(intra[3])
+      assert.are.equal('DiffsDelete', line_bg[4])
+      assert.are.equal('DiffsAdd', line_bg[5])
+      assert.are.equal('@diff.minus', prefix_marks[2])
+      assert.are.equal('@diff.plus', prefix_marks[3])
+
+      delete_buffer(bufnr)
+    end)
+
+    it('keeps whitespace-only highlighting on difftastic-active buffers', function()
+      local saved = vim.o.diffopt
+      vim.o.diffopt = 'internal,iwhiteall'
+
+      local bufnr = create_buffer({
+        '@@ -1,1 +1,1 @@',
+        '-  return a + b',
+        '+    return a + b',
+      })
+      vim.b[bufnr].diffs_difft_active = true
+      local hunk = {
+        filename = 'test.lua',
+        start_line = 1,
+        prefix_width = 1,
+        quote_width = 0,
+        lines = { '-  return a + b', '+    return a + b' },
+      }
+
+      highlight.highlight_hunk(
+        bufnr,
+        ns,
+        hunk,
+        default_opts({ highlights = { background = true } })
+      )
+      vim.o.diffopt = saved
+
+      local line_bg = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        local d = mark[4]
+        if d and d.hl_eol and (d.hl_group == 'DiffsAdd' or d.hl_group == 'DiffsDelete') then
+          line_bg[mark[2]] = d.hl_group
+        end
+      end
+
+      assert.are.equal('DiffsDelete', line_bg[1])
+      assert.are.equal('DiffsAdd', line_bg[2])
+
+      delete_buffer(bufnr)
+    end)
+
+    it('does not dim whitespace-only lines on combined diffs (prefix_width > 1)', function()
+      local saved = vim.o.diffopt
+      vim.o.diffopt = 'internal,iwhiteall'
+
+      local bufnr = create_buffer({
+        '@@@ -1,1 -1,1 +1,1 @@@',
+        '-   return x',
+        '+     return x',
+      })
+      local hunk = {
+        filename = 'test.lua',
+        start_line = 1,
+        prefix_width = 2,
+        quote_width = 0,
+        lines = {
+          '-   return x',
+          '+     return x',
+        },
+      }
+
+      highlight.highlight_hunk(
+        bufnr,
+        ns,
+        hunk,
+        default_opts({ highlights = { background = true } })
+      )
+      vim.o.diffopt = saved
+
+      local has_dim = false
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        if mark[4] and mark[4].hl_group == 'DiffsDim' then
+          has_dim = true
+        end
+      end
+      assert.is_false(has_dim)
+
+      delete_buffer(bufnr)
+    end)
+
     it('produces treesitter captures on all lines with split parsing', function()
       local bufnr = create_buffer({
         '@@ -1,3 +1,3 @@',

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -253,6 +253,32 @@ describe('diffs.runtime', function()
       delete_buffer(bufnr)
     end)
 
+    it('invalidate_attached eagerly clears extmarks and resets highlighted', function()
+      local bufnr = create_buffer({
+        '@@ -1,1 +1,1 @@',
+        '-local x = 1',
+        '+local x = 2',
+      })
+      runtime.attach(bufnr)
+      local ns = vim.api.nvim_create_namespace('diffs')
+      vim.api.nvim_buf_set_extmark(bufnr, ns, 1, 0, {
+        end_row = 2,
+        end_col = 0,
+        hl_group = 'DiffsDelete',
+        hl_eol = true,
+      })
+      local entry = runtime._test.hunk_cache[bufnr]
+      entry.highlighted = { [1] = true }
+      entry.pending_clear = false
+
+      runtime.invalidate_attached()
+
+      assert.are.equal(0, #vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, {}))
+      assert.are.equal(0, vim.tbl_count(runtime._test.hunk_cache[bufnr].highlighted))
+      assert.is_false(runtime._test.hunk_cache[bufnr].pending_clear)
+      delete_buffer(bufnr)
+    end)
+
     it('evicts on buffer wipeout', function()
       local bufnr = create_buffer({})
       runtime.attach(bufnr)


### PR DESCRIPTION
## Problem

Whitespace handling is meant to be driven entirely by Neovim's global `'diffopt'` — the help even states "there is no separate plugin option; 'diffopt' is the single lever." Two things undercut that. A bespoke `gw` mapping, a `<Plug>(diffs-toggle-whitespace)` mapping, and a `toggle_whitespace()` command existed only to flip the single `iwhiteall` flag and re-render the generated `diffs://` buffers. That singled out one facet of an option whose other facets (`algorithm`, `linematch`, and the rest of the whitespace flags) we already honor implicitly by reading `'diffopt'` as we render, and it shadowed Vim's built-in `gw` operator. The whitespace setting also only reached the buffers we generate: on the surfaces diffs.nvim decorates but does not own — `gitcommit` (`git commit -v`), vim-fugitive, Neogit, and plain `diff` buffers — a line whose only change was whitespace still received the full add/delete background even with `iwhiteall` set, because we cannot regenerate text we do not own.

## Solution

Drop the bespoke toggle and react to `'diffopt'` directly. An `OptionSet` autocmd on `diffopt` regenerates the visible generated buffers, repaints the decorated surfaces, and refreshes native diff windows with `:diffupdate`, so every facet of the option takes effect live no matter how it changes — a plain `:set`, an unimpaired-style toggle, or startup configuration. Whitespace is toggled the standard Vim way; there is no longer a plugin-specific key or command for it, and no new configuration is introduced.

On the surfaces we decorate but cannot regenerate, whitespace is now handled in the one layer we do own. When a whitespace flag is active, a `+`/`-` line whose paired counterpart is equal once whitespace is normalized is rendered like a context line: its prefix glyph and syntax highlighting stay while the add/delete background, the change bar, and the intra-line emphasis drop away, so reindented or trailing-whitespace lines recede instead of competing with real changes. The classification is deliberately conservative — only lines reliably paired with an equal-ignoring-whitespace counterpart are de-emphasized, so unpaired insertions or deletions and lines that mix a real change with whitespace stay fully highlighted. The generated `diffs://` buffers keep their existing behavior of collapsing whitespace-only hunks by regenerating with the matching git flags, and difftastic's structural diffs are left untouched.
