### PR TITLE
fix(diff): enhance native diff windows opened at startup

### DIFF
--- a/plugin/diffs.lua
+++ b/plugin/diffs.lua
@@ -71,6 +71,14 @@ vim.api.nvim_create_autocmd('OptionSet', {
   end,
 })
 
+vim.api.nvim_create_autocmd('VimEnter', {
+  callback = function()
+    if vim.wo.diff then
+      runtime.attach_diff()
+    end
+  end,
+})
+
 local cmds = require('diffs.commands')
 vim.keymap.set('n', '<Plug>(diffs-diff)', function()
   cmds.diff(nil, false)

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -116,4 +116,46 @@ describe('plugin bootstrap', function()
     assert.matches('Error in ', output, 1, true)
     assert.matches('diffs: hide_prefix has been removed; use view.prefix', output, 1, true)
   end)
+
+  it('enhances native diff windows opened at startup with nvim -d', function()
+    local tmpdir = vim.fn.tempname()
+    assert.are.equal(1, vim.fn.mkdir(tmpdir, 'p'))
+    local file_a = tmpdir .. '/a.txt'
+    local file_b = tmpdir .. '/b.txt'
+    vim.fn.writefile({ 'local x = 1', 'local y = 2' }, file_a)
+    vim.fn.writefile({ 'local x = 1', 'local y = 3' }, file_b)
+
+    local init_file = tmpdir .. '/init.lua'
+    vim.fn.writefile({
+      ('vim.opt.runtimepath:prepend(%s)'):format(vim.inspect(vim.fn.getcwd())),
+    }, init_file)
+
+    local check = table.concat({
+      'lua vim.schedule(function()',
+      'local parts = {}',
+      'for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do',
+      'if vim.wo[win].diff then parts[#parts + 1] = vim.wo[win].winhighlight end',
+      'end',
+      "print('DIFF_WINHL=' .. table.concat(parts, '||'))",
+      "vim.cmd('qa!')",
+      'end)',
+    }, ' ')
+
+    local output = vim.fn.system({
+      vim.v.progpath,
+      '--headless',
+      '--clean',
+      '-u',
+      init_file,
+      '-d',
+      file_a,
+      file_b,
+      '-c',
+      check,
+    })
+    vim.fn.delete(tmpdir, 'rf')
+
+    assert.matches('DIFF_WINHL=', output, 1, true)
+    assert.matches('DiffAdd:DiffsDiffAdd', output, 1, true)
+  end)
 end)


### PR DESCRIPTION
## Problem

The only thing diffs.nvim contributes to a native `&diff` window is a window-local `winhighlight` remap (`DiffAdd:DiffsDiffAdd`, and so on) whose `Diffs*` groups are background-only, so treesitter foreground survives on changed lines instead of being clobbered by the default diff colors. That remap is applied by `attach_diff()`, which is wired up exclusively to the `OptionSet diff` autocmd. `OptionSet` is suppressed while Neovim creates windows during startup, so the diff windows opened by `nvim -d` and `vimdiff` never trigger it and render with vanilla diff colors until diff mode happens to be toggled again. Entering diff mode interactively after startup (`:diffsplit`, `:diffthis`, `:windo diffthis`) fires `OptionSet` normally and was never affected; only the startup entry points were missed.

## Solution

Re-apply the styling on `VimEnter` when the entered window is a diff window. `VimEnter` fires once after startup has finished, by which point the `-d`/`vimdiff` windows already exist with `diff` set, so `attach_diff()` styles them the same way the post-startup paths already do. The guard mirrors the existing `OptionSet diff` handler's `vim.wo.diff` check, which keeps the plugin's lazy initialization intact for sessions that never start in diff mode, and `attach_diff()` itself filters down to genuine diff windows and excludes the plugin's own split-diff panes.
