### PR TITLE
feat(conflict): label the diff3 base marker with (base)

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -1092,18 +1092,22 @@ Configuration: ~
                              diagnostics alone.
 
         {show_virtual_text}  (boolean, default: true)
-                             Show `(current)` and `(incoming)` labels at
-                             the end of `<<<<<<<` and `>>>>>>>` marker
-                             lines. Also controls hunk hints in merge
-                             diff views.
+                             Show `(current)`, `(base)`, and `(incoming)`
+                             labels at the end of `<<<<<<<`, `|||||||`, and
+                             `>>>>>>>` marker lines. The `(base)` label only
+                             appears in `diff3`/`zdiff3` conflicts, which
+                             include the `|||||||` ancestor section. Also
+                             controls hunk hints in merge diff views.
 
         {format_virtual_text} (function|nil, default: nil)
                              Custom formatter for virtual text labels.
                              Receives `(side, keymap)` where `side` is
-                             `"ours"` or `"theirs"` and `keymap` is the
-                             configured keymap string or `false`. Return
-                             a string (label text without parens) or
-                             `nil` to hide the label. Example: >lua
+                             `"ours"`, `"base"`, or `"theirs"` and `keymap`
+                             is the configured keymap string, or `false`
+                             (always `false` for `"base"`, which has no
+                             resolution keymap). Return a string (label text
+                             without parens) or `nil` to hide the label.
+                             Example: >lua
                                  format_virtual_text = function(side, keymap)
                                    if keymap then
                                      return side .. ' [' .. keymap .. ']'

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -48,7 +48,7 @@ local integration_metadata = require('diffs.integrations')
 ---@field enabled boolean
 ---@field disable_diagnostics boolean
 ---@field show_virtual_text boolean
----@field format_virtual_text? fun(side: string, keymap: string|false): string?
+---@field format_virtual_text? fun(side: 'ours'|'base'|'theirs', keymap: string|false): string?
 ---@field show_actions boolean
 ---@field keymaps diffs.ConflictKeymaps|false
 

--- a/lua/diffs/conflict.lua
+++ b/lua/diffs/conflict.lua
@@ -97,16 +97,38 @@ local function parse_buffer(bufnr)
   return M.parse(lines)
 end
 
----@param side string
+---@type table<'ours'|'base'|'theirs', string>
+local default_labels = { ours = 'current', base = 'base', theirs = 'incoming' }
+
+---@param side 'ours'|'base'|'theirs'
 ---@param config diffs.ConflictConfig
 ---@return string?
 local function get_virtual_text_label(side, config)
   if config.format_virtual_text then
-    local keymap = side == 'ours' and keymaps.get_conflict_keymap(config, 'ours')
-      or keymaps.get_conflict_keymap(config, 'theirs')
+    local keymap = (side == 'ours' or side == 'theirs')
+        and keymaps.get_conflict_keymap(config, side)
+      or false
     return config.format_virtual_text(side, keymap)
   end
-  return side == 'ours' and 'current' or 'incoming'
+  return default_labels[side]
+end
+
+---@param bufnr integer
+---@param row integer
+---@param side 'ours'|'base'|'theirs'
+---@param config diffs.ConflictConfig
+local function apply_marker_label(bufnr, row, side, config)
+  if not config.show_virtual_text then
+    return
+  end
+  local label = get_virtual_text_label(side, config)
+  if not label then
+    return
+  end
+  pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, row, 0, {
+    virt_text = { { ' (' .. label .. ')', 'DiffsConflictMarker' } },
+    virt_text_pos = 'eol',
+  })
 end
 
 local setup_keymaps
@@ -125,15 +147,7 @@ local function apply_highlights(bufnr, regions, config)
       priority = CONFLICT_PRIORITY,
     })
 
-    if config.show_virtual_text then
-      local ours_label = get_virtual_text_label('ours', config)
-      if ours_label then
-        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, region.marker_ours, 0, {
-          virt_text = { { ' (' .. ours_label .. ')', 'DiffsConflictMarker' } },
-          virt_text_pos = 'eol',
-        })
-      end
-    end
+    apply_marker_label(bufnr, region.marker_ours, 'ours', config)
 
     if config.show_actions then
       local parts = {}
@@ -180,6 +194,8 @@ local function apply_highlights(bufnr, regions, config)
         priority = CONFLICT_PRIORITY,
       })
 
+      apply_marker_label(bufnr, region.marker_base, 'base', config)
+
       for line = region.base_start, region.base_end - 1 do
         pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, {
           end_row = line + 1,
@@ -221,15 +237,7 @@ local function apply_highlights(bufnr, regions, config)
       priority = CONFLICT_PRIORITY,
     })
 
-    if config.show_virtual_text then
-      local theirs_label = get_virtual_text_label('theirs', config)
-      if theirs_label then
-        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, region.marker_theirs, 0, {
-          virt_text = { { ' (' .. theirs_label .. ')', 'DiffsConflictMarker' } },
-          virt_text_pos = 'eol',
-        })
-      end
-    end
+    apply_marker_label(bufnr, region.marker_theirs, 'theirs', config)
   end
 end
 

--- a/spec/conflict_spec.lua
+++ b/spec/conflict_spec.lua
@@ -906,6 +906,115 @@ describe('conflict', function()
       helpers.delete_buffer(bufnr)
     end)
 
+    it('labels the base marker in diff3 conflicts', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '||||||| base',
+        'local x = 0',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+
+      conflict.attach(bufnr, default_config())
+
+      local labels = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        if mark[4] and mark[4].virt_text then
+          table.insert(labels, mark[4].virt_text[1][1])
+        end
+      end
+      assert.are.same({ ' (current)', ' (base)', ' (incoming)' }, labels)
+
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('labels the base marker when the base section is empty', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'a',
+        '||||||| base',
+        '=======',
+        'b',
+        '>>>>>>> feature',
+      })
+
+      conflict.attach(bufnr, default_config())
+
+      local labels = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        if mark[4] and mark[4].virt_text then
+          table.insert(labels, mark[4].virt_text[1][1])
+        end
+      end
+      assert.are.same({ ' (current)', ' (base)', ' (incoming)' }, labels)
+
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('passes the base side with no keymap to format_virtual_text', function()
+      local seen = {}
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '||||||| base',
+        'local x = 0',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+
+      conflict.attach(
+        bufnr,
+        default_config({
+          keymaps = { ours = 'co', theirs = 'ct' },
+          format_virtual_text = function(side, keymap)
+            seen[side] = keymap
+            return side
+          end,
+        })
+      )
+
+      assert.are.equal('co', seen.ours)
+      assert.are.equal('ct', seen.theirs)
+      assert.is_false(seen.base)
+
+      local labels = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        if mark[4] and mark[4].virt_text then
+          table.insert(labels, mark[4].virt_text[1][1])
+        end
+      end
+      assert.are.same({ ' (ours)', ' (base)', ' (theirs)' }, labels)
+
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('omits the base label when show_virtual_text is false', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '||||||| base',
+        'local x = 0',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+
+      conflict.attach(bufnr, default_config({ show_virtual_text = false }))
+
+      local virt_text_count = 0
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        if mark[4] and mark[4].virt_text then
+          virt_text_count = virt_text_count + 1
+        end
+      end
+      assert.are.equal(0, virt_text_count)
+
+      helpers.delete_buffer(bufnr)
+    end)
+
     it('uses custom format_virtual_text function', function()
       local bufnr = create_file_buffer({
         '<<<<<<< HEAD',


### PR DESCRIPTION
## Problem

In `diff3` and `zdiff3` conflict style, a conflict region includes a `|||||||` section holding the common ancestor (base) of the two diverging sides. diffs.nvim annotated the `<<<<<<<` and `>>>>>>>` markers with `(current)` and `(incoming)` role labels, but the `|||||||` base marker received only its background highlight and no label, leaving the ancestor side unidentified. This gap was reported in #397.

## Solution

Emit a `(base)` virtual-text label on the `|||||||` marker, mirroring the existing current and incoming annotations. It is gated by the same `show_virtual_text` option and only appears for diff3/zdiff3 conflicts that actually contain a base section, so two-way conflicts are unaffected. The `format_virtual_text` callback now also receives a `base` side; its keymap is always `false`, since reverting a region to the ancestor is not a resolution action. Marker-label emission for all three sides now flows through a single helper, and the vimdoc for `show_virtual_text` and `format_virtual_text` documents the new label and side.
