### PR TITLE
feat(conflict): three-way conflict highlighting (base label, diff-pane fix, simplification)

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -1103,18 +1103,22 @@ Configuration: ~
                              diagnostics alone.
 
         {show_virtual_text}  (boolean, default: true)
-                             Show `(current)` and `(incoming)` labels at
-                             the end of `<<<<<<<` and `>>>>>>>` marker
-                             lines. Also controls hunk hints in merge
-                             diff views.
+                             Show `(current)`, `(base)`, and `(incoming)`
+                             labels at the end of `<<<<<<<`, `|||||||`, and
+                             `>>>>>>>` marker lines. The `(base)` label only
+                             appears in `diff3`/`zdiff3` conflicts, which
+                             include the `|||||||` ancestor section. Also
+                             controls hunk hints in merge diff views.
 
         {format_virtual_text} (function|nil, default: nil)
                              Custom formatter for virtual text labels.
                              Receives `(side, keymap)` where `side` is
-                             `"ours"` or `"theirs"` and `keymap` is the
-                             configured keymap string or `false`. Return
-                             a string (label text without parens) or
-                             `nil` to hide the label. Example: >lua
+                             `"ours"`, `"base"`, or `"theirs"` and `keymap`
+                             is the configured keymap string, or `false`
+                             (always `false` for `"base"`, which has no
+                             resolution keymap). Return a string (label text
+                             without parens) or `nil` to hide the label.
+                             Example: >lua
                                  format_virtual_text = function(side, keymap)
                                    if keymap then
                                      return side .. ' [' .. keymap .. ']'

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -48,7 +48,7 @@ local integration_metadata = require('diffs.integrations')
 ---@field enabled boolean
 ---@field disable_diagnostics boolean
 ---@field show_virtual_text boolean
----@field format_virtual_text? fun(side: string, keymap: string|false): string?
+---@field format_virtual_text? fun(side: 'ours'|'base'|'theirs', keymap: string|false): string?
 ---@field show_actions boolean
 ---@field keymaps diffs.ConflictKeymaps|false
 

--- a/lua/diffs/conflict.lua
+++ b/lua/diffs/conflict.lua
@@ -97,16 +97,38 @@ local function parse_buffer(bufnr)
   return M.parse(lines)
 end
 
----@param side string
+---@type table<'ours'|'base'|'theirs', string>
+local default_labels = { ours = 'current', base = 'base', theirs = 'incoming' }
+
+---@param side 'ours'|'base'|'theirs'
 ---@param config diffs.ConflictConfig
 ---@return string?
 local function get_virtual_text_label(side, config)
   if config.format_virtual_text then
-    local keymap = side == 'ours' and keymaps.get_conflict_keymap(config, 'ours')
-      or keymaps.get_conflict_keymap(config, 'theirs')
+    local keymap = (side == 'ours' or side == 'theirs')
+        and keymaps.get_conflict_keymap(config, side)
+      or false
     return config.format_virtual_text(side, keymap)
   end
-  return side == 'ours' and 'current' or 'incoming'
+  return default_labels[side]
+end
+
+---@param bufnr integer
+---@param row integer
+---@param side 'ours'|'base'|'theirs'
+---@param config diffs.ConflictConfig
+local function apply_marker_label(bufnr, row, side, config)
+  if not config.show_virtual_text then
+    return
+  end
+  local label = get_virtual_text_label(side, config)
+  if not label then
+    return
+  end
+  pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, row, 0, {
+    virt_text = { { ' (' .. label .. ')', 'DiffsConflictMarker' } },
+    virt_text_pos = 'eol',
+  })
 end
 
 local setup_keymaps
@@ -125,15 +147,7 @@ local function apply_highlights(bufnr, regions, config)
       priority = CONFLICT_PRIORITY,
     })
 
-    if config.show_virtual_text then
-      local ours_label = get_virtual_text_label('ours', config)
-      if ours_label then
-        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, region.marker_ours, 0, {
-          virt_text = { { ' (' .. ours_label .. ')', 'DiffsConflictMarker' } },
-          virt_text_pos = 'eol',
-        })
-      end
-    end
+    apply_marker_label(bufnr, region.marker_ours, 'ours', config)
 
     if config.show_actions then
       local parts = {}
@@ -180,6 +194,8 @@ local function apply_highlights(bufnr, regions, config)
         priority = CONFLICT_PRIORITY,
       })
 
+      apply_marker_label(bufnr, region.marker_base, 'base', config)
+
       for line = region.base_start, region.base_end - 1 do
         pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, {
           end_row = line + 1,
@@ -221,15 +237,7 @@ local function apply_highlights(bufnr, regions, config)
       priority = CONFLICT_PRIORITY,
     })
 
-    if config.show_virtual_text then
-      local theirs_label = get_virtual_text_label('theirs', config)
-      if theirs_label then
-        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, region.marker_theirs, 0, {
-          virt_text = { { ' (' .. theirs_label .. ')', 'DiffsConflictMarker' } },
-          virt_text_pos = 'eol',
-        })
-      end
-    end
+    apply_marker_label(bufnr, region.marker_theirs, 'theirs', config)
   end
 end
 

--- a/lua/diffs/conflict.lua
+++ b/lua/diffs/conflict.lua
@@ -105,9 +105,13 @@ local default_labels = { ours = 'current', base = 'base', theirs = 'incoming' }
 ---@return string?
 local function get_virtual_text_label(side, config)
   if config.format_virtual_text then
-    local keymap = (side == 'ours' or side == 'theirs')
-        and keymaps.get_conflict_keymap(config, side)
-      or false
+    ---@type string|false
+    local keymap = false
+    if side == 'ours' then
+      keymap = keymaps.get_conflict_keymap(config, 'ours')
+    elseif side == 'theirs' then
+      keymap = keymaps.get_conflict_keymap(config, 'theirs')
+    end
     return config.format_virtual_text(side, keymap)
   end
   return default_labels[side]
@@ -134,109 +138,101 @@ end
 local setup_keymaps
 
 ---@param bufnr integer
+---@param row integer
+---@param hl_group string
+local function mark_line(bufnr, row, hl_group)
+  pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, row, 0, {
+    end_row = row + 1,
+    hl_group = hl_group,
+    hl_eol = true,
+    priority = CONFLICT_PRIORITY,
+  })
+end
+
+---@param bufnr integer
+---@param start_row integer
+---@param end_row integer
+---@param hl_group string
+---@param number_hl_group string
+local function mark_section(bufnr, start_row, end_row, hl_group, number_hl_group)
+  for row = start_row, end_row - 1 do
+    mark_line(bufnr, row, hl_group)
+    pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, row, 0, {
+      number_hl_group = number_hl_group,
+      priority = CONFLICT_PRIORITY,
+    })
+  end
+end
+
+---@param bufnr integer
+---@param region diffs.ConflictRegion
+---@param config diffs.ConflictConfig
+local function apply_action_hints(bufnr, region, config)
+  if not config.show_actions then
+    return
+  end
+  local parts = {}
+  local actions = {
+    { 'Current', keymaps.get_conflict_keymap(config, 'ours') },
+    { 'Incoming', keymaps.get_conflict_keymap(config, 'theirs') },
+    { 'Both', keymaps.get_conflict_keymap(config, 'both') },
+    { 'None', keymaps.get_conflict_keymap(config, 'none') },
+  }
+  for _, action in ipairs(actions) do
+    if action[2] then
+      if #parts > 0 then
+        table.insert(parts, { ' \226\148\130 ', 'DiffsConflictActions' })
+      end
+      table.insert(parts, { ('%s (%s)'):format(action[1], action[2]), 'DiffsConflictActions' })
+    end
+  end
+  if #parts > 0 then
+    pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, region.marker_ours, 0, {
+      virt_lines = { parts },
+      virt_lines_above = true,
+    })
+  end
+end
+
+---@param bufnr integer
 ---@param regions diffs.ConflictRegion[]
 ---@param config diffs.ConflictConfig
 local function apply_highlights(bufnr, regions, config)
   vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
 
   for _, region in ipairs(regions) do
-    pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, region.marker_ours, 0, {
-      end_row = region.marker_ours + 1,
-      hl_group = 'DiffsConflictMarker',
-      hl_eol = true,
-      priority = CONFLICT_PRIORITY,
-    })
-
+    mark_line(bufnr, region.marker_ours, 'DiffsConflictMarker')
     apply_marker_label(bufnr, region.marker_ours, 'ours', config)
-
-    if config.show_actions then
-      local parts = {}
-      local actions = {
-        { 'Current', keymaps.get_conflict_keymap(config, 'ours') },
-        { 'Incoming', keymaps.get_conflict_keymap(config, 'theirs') },
-        { 'Both', keymaps.get_conflict_keymap(config, 'both') },
-        { 'None', keymaps.get_conflict_keymap(config, 'none') },
-      }
-      for _, action in ipairs(actions) do
-        if action[2] then
-          if #parts > 0 then
-            table.insert(parts, { ' \226\148\130 ', 'DiffsConflictActions' })
-          end
-          table.insert(parts, { ('%s (%s)'):format(action[1], action[2]), 'DiffsConflictActions' })
-        end
-      end
-      if #parts > 0 then
-        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, region.marker_ours, 0, {
-          virt_lines = { parts },
-          virt_lines_above = true,
-        })
-      end
-    end
-
-    for line = region.ours_start, region.ours_end - 1 do
-      pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, {
-        end_row = line + 1,
-        hl_group = 'DiffsConflictOurs',
-        hl_eol = true,
-        priority = CONFLICT_PRIORITY,
-      })
-      pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, {
-        number_hl_group = 'DiffsConflictOursNr',
-        priority = CONFLICT_PRIORITY,
-      })
-    end
+    apply_action_hints(bufnr, region, config)
+    mark_section(
+      bufnr,
+      region.ours_start,
+      region.ours_end,
+      'DiffsConflictOurs',
+      'DiffsConflictOursNr'
+    )
 
     if region.marker_base then
-      pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, region.marker_base, 0, {
-        end_row = region.marker_base + 1,
-        hl_group = 'DiffsConflictMarker',
-        hl_eol = true,
-        priority = CONFLICT_PRIORITY,
-      })
-
+      mark_line(bufnr, region.marker_base, 'DiffsConflictMarker')
       apply_marker_label(bufnr, region.marker_base, 'base', config)
-
-      for line = region.base_start, region.base_end - 1 do
-        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, {
-          end_row = line + 1,
-          hl_group = 'DiffsConflictBase',
-          hl_eol = true,
-          priority = CONFLICT_PRIORITY,
-        })
-        pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, {
-          number_hl_group = 'DiffsConflictBaseNr',
-          priority = CONFLICT_PRIORITY,
-        })
-      end
+      mark_section(
+        bufnr,
+        region.base_start,
+        region.base_end,
+        'DiffsConflictBase',
+        'DiffsConflictBaseNr'
+      )
     end
 
-    pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, region.marker_sep, 0, {
-      end_row = region.marker_sep + 1,
-      hl_group = 'DiffsConflictMarker',
-      hl_eol = true,
-      priority = CONFLICT_PRIORITY,
-    })
-
-    for line = region.theirs_start, region.theirs_end - 1 do
-      pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, {
-        end_row = line + 1,
-        hl_group = 'DiffsConflictTheirs',
-        hl_eol = true,
-        priority = CONFLICT_PRIORITY,
-      })
-      pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, line, 0, {
-        number_hl_group = 'DiffsConflictTheirsNr',
-        priority = CONFLICT_PRIORITY,
-      })
-    end
-
-    pcall(vim.api.nvim_buf_set_extmark, bufnr, ns, region.marker_theirs, 0, {
-      end_row = region.marker_theirs + 1,
-      hl_group = 'DiffsConflictMarker',
-      hl_eol = true,
-      priority = CONFLICT_PRIORITY,
-    })
-
+    mark_line(bufnr, region.marker_sep, 'DiffsConflictMarker')
+    mark_section(
+      bufnr,
+      region.theirs_start,
+      region.theirs_end,
+      'DiffsConflictTheirs',
+      'DiffsConflictTheirsNr'
+    )
+    mark_line(bufnr, region.marker_theirs, 'DiffsConflictMarker')
     apply_marker_label(bufnr, region.marker_theirs, 'theirs', config)
   end
 end
@@ -292,118 +288,104 @@ function M.refresh(bufnr, config)
 end
 
 ---@param bufnr integer
+---@param region diffs.ConflictRegion
+---@param side 'ours'|'theirs'|'both'|'none'
+---@return string[]
+function M.replacement_lines(bufnr, region, side)
+  if side == 'none' then
+    return {}
+  end
+  if side == 'theirs' then
+    return vim.api.nvim_buf_get_lines(bufnr, region.theirs_start, region.theirs_end, false)
+  end
+  local lines = vim.api.nvim_buf_get_lines(bufnr, region.ours_start, region.ours_end, false)
+  if side == 'both' then
+    vim.list_extend(
+      lines,
+      vim.api.nvim_buf_get_lines(bufnr, region.theirs_start, region.theirs_end, false)
+    )
+  end
+  return lines
+end
+
+---@param bufnr integer
 ---@param config diffs.ConflictConfig
-function M.resolve_ours(bufnr, config)
+---@param side 'ours'|'theirs'|'both'|'none'
+local function resolve(bufnr, config, side)
   if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
     notify('buffer is not modifiable', vim.log.levels.WARN)
     return
   end
   local regions = parse_buffer(bufnr)
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  local region = find_conflict_at_cursor(cursor[1] - 1, regions)
+  local region = find_conflict_at_cursor(vim.api.nvim_win_get_cursor(0)[1] - 1, regions)
   if not region then
     return
   end
-  local lines = vim.api.nvim_buf_get_lines(bufnr, region.ours_start, region.ours_end, false)
-  M.replace_region(bufnr, region, lines)
+  M.replace_region(bufnr, region, M.replacement_lines(bufnr, region, side))
   M.refresh(bufnr, config)
+end
+
+---@param bufnr integer
+---@param config diffs.ConflictConfig
+function M.resolve_ours(bufnr, config)
+  resolve(bufnr, config, 'ours')
 end
 
 ---@param bufnr integer
 ---@param config diffs.ConflictConfig
 function M.resolve_theirs(bufnr, config)
-  if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
-    notify('buffer is not modifiable', vim.log.levels.WARN)
-    return
-  end
-  local regions = parse_buffer(bufnr)
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  local region = find_conflict_at_cursor(cursor[1] - 1, regions)
-  if not region then
-    return
-  end
-  local lines = vim.api.nvim_buf_get_lines(bufnr, region.theirs_start, region.theirs_end, false)
-  M.replace_region(bufnr, region, lines)
-  M.refresh(bufnr, config)
+  resolve(bufnr, config, 'theirs')
 end
 
 ---@param bufnr integer
 ---@param config diffs.ConflictConfig
 function M.resolve_both(bufnr, config)
-  if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
-    notify('buffer is not modifiable', vim.log.levels.WARN)
-    return
-  end
-  local regions = parse_buffer(bufnr)
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  local region = find_conflict_at_cursor(cursor[1] - 1, regions)
-  if not region then
-    return
-  end
-  local ours = vim.api.nvim_buf_get_lines(bufnr, region.ours_start, region.ours_end, false)
-  local theirs = vim.api.nvim_buf_get_lines(bufnr, region.theirs_start, region.theirs_end, false)
-  local combined = {}
-  for _, l in ipairs(ours) do
-    table.insert(combined, l)
-  end
-  for _, l in ipairs(theirs) do
-    table.insert(combined, l)
-  end
-  M.replace_region(bufnr, region, combined)
-  M.refresh(bufnr, config)
+  resolve(bufnr, config, 'both')
 end
 
 ---@param bufnr integer
 ---@param config diffs.ConflictConfig
 function M.resolve_none(bufnr, config)
-  if not vim.api.nvim_get_option_value('modifiable', { buf = bufnr }) then
-    notify('buffer is not modifiable', vim.log.levels.WARN)
-    return
-  end
+  resolve(bufnr, config, 'none')
+end
+
+---@param bufnr integer
+---@param forward boolean
+local function goto_conflict(bufnr, forward)
   local regions = parse_buffer(bufnr)
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  local region = find_conflict_at_cursor(cursor[1] - 1, regions)
-  if not region then
+  if #regions == 0 then
     return
   end
-  M.replace_region(bufnr, region, {})
-  M.refresh(bufnr, config)
+  local cursor_line = vim.api.nvim_win_get_cursor(0)[1] - 1
+  if forward then
+    for _, region in ipairs(regions) do
+      if region.marker_ours > cursor_line then
+        vim.api.nvim_win_set_cursor(0, { region.marker_ours + 1, 0 })
+        return
+      end
+    end
+    notify('wrapped to first conflict', vim.log.levels.INFO)
+    vim.api.nvim_win_set_cursor(0, { regions[1].marker_ours + 1, 0 })
+  else
+    for i = #regions, 1, -1 do
+      if regions[i].marker_ours < cursor_line then
+        vim.api.nvim_win_set_cursor(0, { regions[i].marker_ours + 1, 0 })
+        return
+      end
+    end
+    notify('wrapped to last conflict', vim.log.levels.INFO)
+    vim.api.nvim_win_set_cursor(0, { regions[#regions].marker_ours + 1, 0 })
+  end
 end
 
 ---@param bufnr integer
 function M.goto_next(bufnr)
-  local regions = parse_buffer(bufnr)
-  if #regions == 0 then
-    return
-  end
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  local cursor_line = cursor[1] - 1
-  for _, region in ipairs(regions) do
-    if region.marker_ours > cursor_line then
-      vim.api.nvim_win_set_cursor(0, { region.marker_ours + 1, 0 })
-      return
-    end
-  end
-  notify('wrapped to first conflict', vim.log.levels.INFO)
-  vim.api.nvim_win_set_cursor(0, { regions[1].marker_ours + 1, 0 })
+  goto_conflict(bufnr, true)
 end
 
 ---@param bufnr integer
 function M.goto_prev(bufnr)
-  local regions = parse_buffer(bufnr)
-  if #regions == 0 then
-    return
-  end
-  local cursor = vim.api.nvim_win_get_cursor(0)
-  local cursor_line = cursor[1] - 1
-  for i = #regions, 1, -1 do
-    if regions[i].marker_ours < cursor_line then
-      vim.api.nvim_win_set_cursor(0, { regions[i].marker_ours + 1, 0 })
-      return
-    end
-  end
-  notify('wrapped to last conflict', vim.log.levels.INFO)
-  vim.api.nvim_win_set_cursor(0, { regions[#regions].marker_ours + 1, 0 })
+  goto_conflict(bufnr, false)
 end
 
 ---@param bufnr integer

--- a/lua/diffs/merge.lua
+++ b/lua/diffs/merge.lua
@@ -156,18 +156,19 @@ local function add_resolved_virtual_text(diff_bufnr, hunk)
   })
 end
 
----@param bufnr integer
+---@param diff_bufnr integer
 ---@param config diffs.ConflictConfig
-function M.resolve_ours(bufnr, config)
-  local hunk = M.find_hunk_at_cursor(bufnr)
+---@param side 'ours'|'theirs'|'both'|'none'
+local function resolve(diff_bufnr, config, side)
+  local hunk = M.find_hunk_at_cursor(diff_bufnr)
   if not hunk then
     return
   end
-  if M.is_resolved(bufnr, hunk.index) then
+  if M.is_resolved(diff_bufnr, hunk.index) then
     notify('hunk already resolved', vim.log.levels.INFO)
     return
   end
-  local working_bufnr = M.get_or_load_working_buf(bufnr)
+  local working_bufnr = M.get_or_load_working_buf(diff_bufnr)
   if not working_bufnr then
     return
   end
@@ -176,177 +177,95 @@ function M.resolve_ours(bufnr, config)
     notify('hunk does not correspond to a conflict region', vim.log.levels.INFO)
     return
   end
-  local lines = vim.api.nvim_buf_get_lines(working_bufnr, region.ours_start, region.ours_end, false)
-  conflict.replace_region(working_bufnr, region, lines)
+  conflict.replace_region(
+    working_bufnr,
+    region,
+    conflict.replacement_lines(working_bufnr, region, side)
+  )
   conflict.refresh(working_bufnr, config)
-  mark_resolved(bufnr, hunk.index)
-  add_resolved_virtual_text(bufnr, hunk)
+  mark_resolved(diff_bufnr, hunk.index)
+  add_resolved_virtual_text(diff_bufnr, hunk)
+end
+
+---@param bufnr integer
+---@param config diffs.ConflictConfig
+function M.resolve_ours(bufnr, config)
+  resolve(bufnr, config, 'ours')
 end
 
 ---@param bufnr integer
 ---@param config diffs.ConflictConfig
 function M.resolve_theirs(bufnr, config)
-  local hunk = M.find_hunk_at_cursor(bufnr)
-  if not hunk then
-    return
-  end
-  if M.is_resolved(bufnr, hunk.index) then
-    notify('hunk already resolved', vim.log.levels.INFO)
-    return
-  end
-  local working_bufnr = M.get_or_load_working_buf(bufnr)
-  if not working_bufnr then
-    return
-  end
-  local region = M.match_hunk_to_conflict(hunk, working_bufnr)
-  if not region then
-    notify('hunk does not correspond to a conflict region', vim.log.levels.INFO)
-    return
-  end
-  local lines =
-    vim.api.nvim_buf_get_lines(working_bufnr, region.theirs_start, region.theirs_end, false)
-  conflict.replace_region(working_bufnr, region, lines)
-  conflict.refresh(working_bufnr, config)
-  mark_resolved(bufnr, hunk.index)
-  add_resolved_virtual_text(bufnr, hunk)
+  resolve(bufnr, config, 'theirs')
 end
 
 ---@param bufnr integer
 ---@param config diffs.ConflictConfig
 function M.resolve_both(bufnr, config)
-  local hunk = M.find_hunk_at_cursor(bufnr)
-  if not hunk then
-    return
-  end
-  if M.is_resolved(bufnr, hunk.index) then
-    notify('hunk already resolved', vim.log.levels.INFO)
-    return
-  end
-  local working_bufnr = M.get_or_load_working_buf(bufnr)
-  if not working_bufnr then
-    return
-  end
-  local region = M.match_hunk_to_conflict(hunk, working_bufnr)
-  if not region then
-    notify('hunk does not correspond to a conflict region', vim.log.levels.INFO)
-    return
-  end
-  local ours = vim.api.nvim_buf_get_lines(working_bufnr, region.ours_start, region.ours_end, false)
-  local theirs =
-    vim.api.nvim_buf_get_lines(working_bufnr, region.theirs_start, region.theirs_end, false)
-  local combined = {}
-  for _, l in ipairs(ours) do
-    table.insert(combined, l)
-  end
-  for _, l in ipairs(theirs) do
-    table.insert(combined, l)
-  end
-  conflict.replace_region(working_bufnr, region, combined)
-  conflict.refresh(working_bufnr, config)
-  mark_resolved(bufnr, hunk.index)
-  add_resolved_virtual_text(bufnr, hunk)
+  resolve(bufnr, config, 'both')
 end
 
 ---@param bufnr integer
 ---@param config diffs.ConflictConfig
 function M.resolve_none(bufnr, config)
-  local hunk = M.find_hunk_at_cursor(bufnr)
-  if not hunk then
+  resolve(bufnr, config, 'none')
+end
+
+---@param bufnr integer
+---@param forward boolean
+local function goto_hunk(bufnr, forward)
+  local hunks = M.parse_hunks(bufnr)
+  if #hunks == 0 then
     return
   end
-  if M.is_resolved(bufnr, hunk.index) then
-    notify('hunk already resolved', vim.log.levels.INFO)
-    return
-  end
+
   local working_bufnr = M.get_or_load_working_buf(bufnr)
   if not working_bufnr then
     return
   end
-  local region = M.match_hunk_to_conflict(hunk, working_bufnr)
-  if not region then
-    notify('hunk does not correspond to a conflict region', vim.log.levels.INFO)
+
+  local candidates = {}
+  for _, hunk in ipairs(hunks) do
+    if not M.is_resolved(bufnr, hunk.index) and M.match_hunk_to_conflict(hunk, working_bufnr) then
+      table.insert(candidates, hunk)
+    end
+  end
+
+  if #candidates == 0 then
     return
   end
-  conflict.replace_region(working_bufnr, region, {})
-  conflict.refresh(working_bufnr, config)
-  mark_resolved(bufnr, hunk.index)
-  add_resolved_virtual_text(bufnr, hunk)
+
+  local cursor_line = vim.api.nvim_win_get_cursor(0)[1] - 1
+
+  if forward then
+    for _, hunk in ipairs(candidates) do
+      if hunk.start_line > cursor_line then
+        vim.api.nvim_win_set_cursor(0, { hunk.start_line + 1, 0 })
+        return
+      end
+    end
+    notify('wrapped to first hunk', vim.log.levels.INFO)
+    vim.api.nvim_win_set_cursor(0, { candidates[1].start_line + 1, 0 })
+  else
+    for i = #candidates, 1, -1 do
+      if candidates[i].start_line < cursor_line then
+        vim.api.nvim_win_set_cursor(0, { candidates[i].start_line + 1, 0 })
+        return
+      end
+    end
+    notify('wrapped to last hunk', vim.log.levels.INFO)
+    vim.api.nvim_win_set_cursor(0, { candidates[#candidates].start_line + 1, 0 })
+  end
 end
 
 ---@param bufnr integer
 function M.goto_next(bufnr)
-  local hunks = M.parse_hunks(bufnr)
-  if #hunks == 0 then
-    return
-  end
-
-  local working_bufnr = M.get_or_load_working_buf(bufnr)
-  if not working_bufnr then
-    return
-  end
-
-  local cursor_line = vim.api.nvim_win_get_cursor(0)[1] - 1
-
-  local candidates = {}
-  for _, hunk in ipairs(hunks) do
-    if not M.is_resolved(bufnr, hunk.index) then
-      if M.match_hunk_to_conflict(hunk, working_bufnr) then
-        table.insert(candidates, hunk)
-      end
-    end
-  end
-
-  if #candidates == 0 then
-    return
-  end
-
-  for _, hunk in ipairs(candidates) do
-    if hunk.start_line > cursor_line then
-      vim.api.nvim_win_set_cursor(0, { hunk.start_line + 1, 0 })
-      return
-    end
-  end
-
-  notify('wrapped to first hunk', vim.log.levels.INFO)
-  vim.api.nvim_win_set_cursor(0, { candidates[1].start_line + 1, 0 })
+  goto_hunk(bufnr, true)
 end
 
 ---@param bufnr integer
 function M.goto_prev(bufnr)
-  local hunks = M.parse_hunks(bufnr)
-  if #hunks == 0 then
-    return
-  end
-
-  local working_bufnr = M.get_or_load_working_buf(bufnr)
-  if not working_bufnr then
-    return
-  end
-
-  local cursor_line = vim.api.nvim_win_get_cursor(0)[1] - 1
-
-  local candidates = {}
-  for _, hunk in ipairs(hunks) do
-    if not M.is_resolved(bufnr, hunk.index) then
-      if M.match_hunk_to_conflict(hunk, working_bufnr) then
-        table.insert(candidates, hunk)
-      end
-    end
-  end
-
-  if #candidates == 0 then
-    return
-  end
-
-  for i = #candidates, 1, -1 do
-    if candidates[i].start_line < cursor_line then
-      vim.api.nvim_win_set_cursor(0, { candidates[i].start_line + 1, 0 })
-      return
-    end
-  end
-
-  notify('wrapped to last hunk', vim.log.levels.INFO)
-  vim.api.nvim_win_set_cursor(0, { candidates[#candidates].start_line + 1, 0 })
+  goto_hunk(bufnr, false)
 end
 
 ---@param bufnr integer

--- a/lua/diffs/runtime/diff_windows.lua
+++ b/lua/diffs/runtime/diff_windows.lua
@@ -9,11 +9,29 @@ local WINHIGHLIGHT = table.concat({
   'DiffText:DiffsDiffText',
 }, ',')
 
+local CONFLICT_WINHIGHLIGHT = table.concat({
+  'DiffAdd:DiffsDiffOff',
+  'DiffDelete:DiffsDiffOff',
+  'DiffChange:DiffsDiffOff',
+  'DiffText:DiffsDiffOff',
+}, ',')
+
 ---@param win integer
 ---@return boolean
 local function is_split_pane(win)
   local buf = vim.api.nvim_win_get_buf(win)
   return pcall(vim.api.nvim_buf_get_var, buf, 'diffs_split_side')
+end
+
+---@param buf integer
+---@return boolean
+local function has_conflict_markers(buf)
+  for _, line in ipairs(vim.api.nvim_buf_get_lines(buf, 0, -1, false)) do
+    if line:match('^<<<<<<<') then
+      return true
+    end
+  end
+  return false
 end
 
 ---@param diff_windows table<integer, boolean>
@@ -34,7 +52,9 @@ function M.attach(diff_windows)
   end
 
   for _, win in ipairs(diff_wins) do
-    vim.api.nvim_set_option_value('winhighlight', WINHIGHLIGHT, { win = win })
+    local buf = vim.api.nvim_win_get_buf(win)
+    local winhighlight = has_conflict_markers(buf) and CONFLICT_WINHIGHLIGHT or WINHIGHLIGHT
+    vim.api.nvim_set_option_value('winhighlight', winhighlight, { win = win })
     diff_windows[win] = true
     log.dbg('applied diff winhighlight to window %d', win)
   end

--- a/lua/diffs/runtime/highlight_groups.lua
+++ b/lua/diffs/runtime/highlight_groups.lua
@@ -118,6 +118,7 @@ function M.apply(config, is_default)
   )
   vim.api.nvim_set_hl(0, 'DiffsDiffChange', { default = dflt, bg = diff_change.bg })
   vim.api.nvim_set_hl(0, 'DiffsDiffText', { default = dflt, bg = diff_text.bg })
+  vim.api.nvim_set_hl(0, 'DiffsDiffOff', {})
 
   local change_bg = diff_change.bg or 0x3a3a4a
   local text_bg = diff_text.bg or 0x4a4a5a

--- a/spec/conflict_spec.lua
+++ b/spec/conflict_spec.lua
@@ -906,6 +906,115 @@ describe('conflict', function()
       helpers.delete_buffer(bufnr)
     end)
 
+    it('labels the base marker in diff3 conflicts', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '||||||| base',
+        'local x = 0',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+
+      conflict.attach(bufnr, default_config())
+
+      local labels = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        if mark[4] and mark[4].virt_text then
+          table.insert(labels, mark[4].virt_text[1][1])
+        end
+      end
+      assert.are.same({ ' (current)', ' (base)', ' (incoming)' }, labels)
+
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('labels the base marker when the base section is empty', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'a',
+        '||||||| base',
+        '=======',
+        'b',
+        '>>>>>>> feature',
+      })
+
+      conflict.attach(bufnr, default_config())
+
+      local labels = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        if mark[4] and mark[4].virt_text then
+          table.insert(labels, mark[4].virt_text[1][1])
+        end
+      end
+      assert.are.same({ ' (current)', ' (base)', ' (incoming)' }, labels)
+
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('passes the base side with no keymap to format_virtual_text', function()
+      local seen = {}
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '||||||| base',
+        'local x = 0',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+
+      conflict.attach(
+        bufnr,
+        default_config({
+          keymaps = { ours = 'co', theirs = 'ct' },
+          format_virtual_text = function(side, keymap)
+            seen[side] = keymap
+            return side
+          end,
+        })
+      )
+
+      assert.are.equal('co', seen.ours)
+      assert.are.equal('ct', seen.theirs)
+      assert.is_false(seen.base)
+
+      local labels = {}
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        if mark[4] and mark[4].virt_text then
+          table.insert(labels, mark[4].virt_text[1][1])
+        end
+      end
+      assert.are.same({ ' (ours)', ' (base)', ' (theirs)' }, labels)
+
+      helpers.delete_buffer(bufnr)
+    end)
+
+    it('omits the base label when show_virtual_text is false', function()
+      local bufnr = create_file_buffer({
+        '<<<<<<< HEAD',
+        'local x = 1',
+        '||||||| base',
+        'local x = 0',
+        '=======',
+        'local x = 2',
+        '>>>>>>> feature',
+      })
+
+      conflict.attach(bufnr, default_config({ show_virtual_text = false }))
+
+      local virt_text_count = 0
+      for _, mark in ipairs(get_extmarks(bufnr)) do
+        if mark[4] and mark[4].virt_text then
+          virt_text_count = virt_text_count + 1
+        end
+      end
+      assert.are.equal(0, virt_text_count)
+
+      helpers.delete_buffer(bufnr)
+    end)
+
     it('uses custom format_virtual_text function', function()
       local bufnr = create_file_buffer({
         '<<<<<<< HEAD',

--- a/spec/runtime_spec.lua
+++ b/spec/runtime_spec.lua
@@ -374,6 +374,46 @@ describe('diffs.runtime', function()
         close_window(non_diff_win)
         close_window(diff_win)
       end)
+
+      it('neutralizes native diff highlighting on conflicted panes', function()
+        local win, buf = create_diff_window()
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+          '<<<<<<< HEAD',
+          'ours',
+          '=======',
+          'theirs',
+          '>>>>>>> feature',
+        })
+        runtime.attach_diff()
+
+        local whl = vim.api.nvim_get_option_value('winhighlight', { win = win })
+        assert.is_not_nil(whl:match('DiffText:DiffsDiffOff'))
+        assert.is_nil(whl:match('DiffsDiffText'))
+        assert.is_nil(whl:match('DiffsDiffAdd'))
+
+        close_window(win)
+      end)
+
+      it('keeps the diff remap on plain panes next to a conflicted one', function()
+        local conflict_win, conflict_buf = create_diff_window()
+        vim.api.nvim_buf_set_lines(conflict_buf, 0, -1, false, {
+          '<<<<<<< HEAD',
+          'x',
+          '=======',
+          'y',
+          '>>>>>>> feature',
+        })
+        local plain_win, _ = create_diff_window()
+        runtime.attach_diff()
+
+        local conflict_whl = vim.api.nvim_get_option_value('winhighlight', { win = conflict_win })
+        local plain_whl = vim.api.nvim_get_option_value('winhighlight', { win = plain_win })
+        assert.is_not_nil(conflict_whl:match('DiffAdd:DiffsDiffOff'))
+        assert.is_not_nil(plain_whl:match('DiffAdd:DiffsDiffAdd'))
+
+        close_window(conflict_win)
+        close_window(plain_win)
+      end)
     end)
 
     describe('detach_diff', function()


### PR DESCRIPTION
## Problem

Issue #397 is about three-way (diff3 / mergetool) conflict surfaces, and exposed two gaps in conflict highlighting.

First, in `diff3`/`zdiff3` conflicts the region carries a `|||||||` section holding the common ancestor (base) of the two sides, but only the `<<<<<<<` and `>>>>>>>` markers received role labels (`(current)` and `(incoming)`); the base marker got a highlight and no label, leaving the ancestor side unidentified.

Second, in a mergetool layout the work-in-progress pane is simultaneously a native `&diff` window and a conflicted buffer, so it received both the native-diff winhighlight remap and the buffer's own conflict highlighting. Native diff then double-painted the conflict regions (notably the raw, unblended `DiffText` color), corrupting the background, dropping syntax colors on changed lines, and washing out the marker foreground. The plain (non-diff) conflict view rendered correctly, so the divergence was specific to native diff panes.

## Solution

Label the `|||||||` marker `(base)`, mirroring the existing current/incoming annotations. It is gated by the same `show_virtual_text` option and only appears for diff3/zdiff3 conflicts that actually contain a base section, so two-way conflicts are unaffected. The `format_virtual_text` callback now also receives a `base` side, whose keymap is always `false` since reverting a region to the ancestor is not a resolution action.

For conflicted native diff panes, neutralize the native diff highlighting by remapping `Diff*` to an empty, transparent group and keeping `diff` enabled for scroll-sync, so the buffer's conflict highlighting owns the pane the way the unified view already does. Non-conflicted panes keep the normal diff remap. Detection is a self-contained marker scan in the diff-window path.

This also simplifies the conflict and merge highlighting modules without changing behavior: the per-section duplication in `apply_highlights` is collapsed through `mark_line`/`mark_section` and an extracted `apply_action_hints`; the four `resolve_*` operations and the `goto_next`/`goto_prev` pair in each module collapse to a single side- or direction-driven helper; and the replacement-line computation is shared through `conflict.replacement_lines`.

Supersedes #407, which covered only the base label.

Looks like this:

![Uploading image.png…]()
