### PR TITLE
fix(split): stop overriding gutter options in the review split rail

### DIFF
--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -177,20 +177,35 @@ local side_config = {
   },
 }
 
+---@param source integer? diff-mapped source line number for this row
+---@param width integer
+---@param number boolean
+---@return string
+local function rail_number(source, width, number)
+  if not number then
+    return ''
+  end
+  if not source then
+    return string.rep(' ', width)
+  end
+  return ('%' .. width .. 'd'):format(source)
+end
+
 ---@param info diffs.SplitPaneInfo
 ---@param lnum integer
+---@param number boolean
 ---@return string
-local function rail_segment(info, lnum)
-  local row = info.rows[lnum]
+local function rail_segment(info, lnum, number)
   local width = info.rail_width
+  local row = info.rows[lnum]
   if not row or row.kind == 'filler' then
-    return '%#DiffsRail#' .. string.rep(' ', width + 2)
+    local pad = number and width + 2 or 2
+    return '%C%s%#DiffsRail#' .. string.rep(' ', pad)
   end
   local cfg = side_config[info.side]
-  local number = row[cfg.lnum]
-  local numstr = number and ('%' .. width .. 'd'):format(number) or string.rep(' ', width)
+  local numstr = rail_number(row[cfg.lnum], width, number)
   if row.kind == cfg.kind then
-    return ('%%#%s#%s%%#%s#%s%%#%s# '):format(
+    return ('%%C%%s%%#%s#%s%%#%s#%s%%#%s# '):format(
       cfg.bar_hl,
       info.change_bar,
       cfg.nr_hl,
@@ -198,7 +213,7 @@ local function rail_segment(info, lnum)
       cfg.line_hl
     )
   end
-  return ('%%#DiffsRailNr# %s '):format(numstr)
+  return ('%%C%%s%%#DiffsRailNr# %s '):format(numstr)
 end
 
 ---@return string
@@ -215,7 +230,8 @@ function M.statuscolumn()
   if not info then
     return ''
   end
-  local rendered_ok, rendered = pcall(rail_segment, info, vim.v.lnum)
+  local number = vim.api.nvim_get_option_value('number', { win = win })
+  local rendered_ok, rendered = pcall(rail_segment, info, vim.v.lnum, number)
   return rendered_ok and rendered or ''
 end
 
@@ -446,12 +462,8 @@ local function remember_pair_window_options(win)
     scrollbind = vim.api.nvim_get_option_value('scrollbind', { win = win }),
     cursorbind = vim.api.nvim_get_option_value('cursorbind', { win = win }),
     wrap = vim.api.nvim_get_option_value('wrap', { win = win }),
-    number = vim.api.nvim_get_option_value('number', { win = win }),
-    relativenumber = vim.api.nvim_get_option_value('relativenumber', { win = win }),
     foldmethod = vim.api.nvim_get_option_value('foldmethod', { win = win }),
     foldenable = vim.api.nvim_get_option_value('foldenable', { win = win }),
-    foldcolumn = vim.api.nvim_get_option_value('foldcolumn', { win = win }),
-    signcolumn = vim.api.nvim_get_option_value('signcolumn', { win = win }),
     statuscolumn = vim.api.nvim_get_option_value('statuscolumn', { win = win }),
     winhighlight = vim.api.nvim_get_option_value('winhighlight', { win = win }),
   }
@@ -463,13 +475,9 @@ local function set_pair_window_options(win)
   vim.api.nvim_set_option_value('scrollbind', true, { win = win })
   vim.api.nvim_set_option_value('cursorbind', true, { win = win })
   vim.api.nvim_set_option_value('wrap', false, { win = win })
-  vim.api.nvim_set_option_value('number', false, { win = win })
-  vim.api.nvim_set_option_value('relativenumber', false, { win = win })
-  vim.api.nvim_set_option_value('signcolumn', 'no', { win = win })
   vim.api.nvim_set_option_value('statuscolumn', split_statuscolumn, { win = win })
   vim.api.nvim_set_option_value('foldmethod', 'manual', { win = win })
   vim.api.nvim_set_option_value('foldenable', false, { win = win })
-  vim.api.nvim_set_option_value('foldcolumn', '0', { win = win })
 end
 
 ---@param win integer

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1229,6 +1229,9 @@ describe('commands', function()
       table.insert(test_buffers, right_buf)
       local left_win, right_win = find_split_windows(left_buf, right_buf)
 
+      vim.wo[left_win].number = true
+      vim.wo[right_win].number = true
+
       local function rail(win, lnum)
         local sc = vim.api.nvim_get_option_value('statuscolumn', { win = win })
         return vim.api.nvim_eval_statusline(
@@ -1246,6 +1249,12 @@ describe('commands', function()
       assert.is_true(rail(left_win, 2):find('1', 1, true) ~= nil)
       assert.is_true(rail(right_win, 2):find('2', 1, true) ~= nil)
       assert.is_true(rail(right_win, 2):find('1', 1, true) == nil)
+
+      vim.wo[right_win].relativenumber = true
+      assert.is_true(rail(right_win, 2):find('2', 1, true) ~= nil)
+
+      vim.wo[right_win].number = false
+      assert.is_nil(rail(right_win, 2):find('%d'))
     end)
 
     it('warns and still opens the split when :vertical Diff ++layout=split is used', function()


### PR DESCRIPTION
## Problem

The side-by-side review split (`:Diff review ++layout=split`) draws its change-bar and per-side line-number rail as the window's `statuscolumn`, which takes over the gutter. To make room, each pane force-disabled `number`, `relativenumber`, `signcolumn`, and `foldcolumn`. That silently overrode the user's window options, and because the rail rendered its numbers unconditionally, `:set number` and `:set nonumber` had no effect inside the split.

## Solution

Leave those options alone and drive the rail from them instead. The rail shows the absolute per-side source line numbers and is gated on `number`, so `:set number`/`:set nonumber` toggles them. `relativenumber` is intentionally ignored, because relative source-line numbers are not meaningful in a diff and would hide the absolute source numbers that are the point of the side-by-side view. Signs and folds are composed into the rail through the `%s` and `%C` statuscolumn items rather than being turned off, so a user's `signcolumn`/`foldcolumn` are preserved. Content stays pure source text since the rail lives in the gutter rather than the buffer, and the panes no longer mutate the user's gutter configuration.
