### PR TITLE
fix(review): keep modified files visible under diff.mnemonicPrefix

### DIFF
--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -293,7 +293,16 @@ end
 ---@param review diffs.NormalizedReview
 ---@return string[]
 function M.build_cmd(review)
-  local cmd = { 'git', '-C', review.repo_root, 'diff', '--no-ext-diff', '--no-color' }
+  local cmd = {
+    'git',
+    '-C',
+    review.repo_root,
+    'diff',
+    '--no-ext-diff',
+    '--no-color',
+    '--src-prefix=a/',
+    '--dst-prefix=b/',
+  }
   vim.list_extend(cmd, diffopt.git_flags())
   vim.list_extend(cmd, review.exec_args)
   return cmd
@@ -375,7 +384,7 @@ end
 ---@param base_rev string
 ---@return string[]?, string?
 local function branch_lines(review, base_rev)
-  local args = { 'diff', '--no-ext-diff', '--no-color' }
+  local args = { 'diff', '--no-ext-diff', '--no-color', '--src-prefix=a/', '--dst-prefix=b/' }
   vim.list_extend(args, diffopt.git_flags())
   args[#args + 1] = base_rev
   args[#args + 1] = 'HEAD'
@@ -386,7 +395,7 @@ end
 ---@param cached boolean
 ---@return string[]?, string?
 local function worktree_edge_lines(review, cached)
-  local args = { 'diff', '--no-ext-diff', '--no-color' }
+  local args = { 'diff', '--no-ext-diff', '--no-color', '--src-prefix=a/', '--dst-prefix=b/' }
   vim.list_extend(args, diffopt.git_flags())
   if cached then
     args[#args + 1] = '--cached'

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -211,7 +211,8 @@ local function create_review_repo(opts)
   }
 end
 
-local function create_current_state_review_repo()
+local function create_current_state_review_repo(opts)
+  opts = opts or {}
   local repo_root = vim.fn.tempname()
   vim.fn.mkdir(repo_root, 'p')
   test_repos[#test_repos + 1] = repo_root
@@ -220,6 +221,9 @@ local function create_current_state_review_repo()
   assert.are.equal(0, vim.v.shell_error)
   git_cmd(repo_root, { 'config', 'user.email', 'test@example.com' })
   git_cmd(repo_root, { 'config', 'user.name', 'Test' })
+  if opts.mnemonic_prefix then
+    git_cmd(repo_root, { 'config', 'diff.mnemonicPrefix', 'true' })
+  end
 
   write_repo_file(repo_root, 'lua/branch.lua', { 'branch base' })
   write_repo_file(repo_root, 'lua/dup.lua', { 'dup base' })
@@ -3030,6 +3034,8 @@ describe('commands', function()
         'diff',
         '--no-ext-diff',
         '--no-color',
+        '--src-prefix=a/',
+        '--dst-prefix=b/',
         '--merge-base',
         'origin/main',
         'refs/forge/pr/42',
@@ -3126,6 +3132,31 @@ describe('commands', function()
       assert.are.equal('branch:lua/dup.lua', qf[2].user_data.diffs.key)
       assert.are.equal('staged:lua/dup.lua', qf[3].user_data.diffs.key)
       assert.are.equal('unstaged:lua/dup.lua', qf[5].user_data.diffs.key)
+    end)
+
+    it('renders worktree sections when diff.mnemonicPrefix is enabled', function()
+      local repo = create_current_state_review_repo({ mnemonic_prefix = true })
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.review({
+        base = repo.base,
+        repo = repo.repo_root,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+
+      local text = buffer_text(bufnr)
+      assert.is_true(text:find('# Staged:', 1, true) ~= nil)
+      assert.is_true(text:find('# Unstaged:', 1, true) ~= nil)
+      assert.is_true(text:find('+staged changed', 1, true) ~= nil)
+      assert.is_true(text:find('+unstaged changed', 1, true) ~= nil)
+
+      local qf = quickfix_items()
+      assert.are.equal(7, #qf)
+      assert.is_true(qf[3].text:find('[Staged] lua/dup.lua', 1, true) ~= nil)
+      assert.is_true(qf[4].text:find('[Staged] lua/staged.lua', 1, true) ~= nil)
+      assert.is_true(qf[5].text:find('[Unstaged] lua/dup.lua', 1, true) ~= nil)
+      assert.is_true(qf[6].text:find('[Unstaged] lua/unstaged.lua', 1, true) ~= nil)
     end)
 
     it('opens review stacked layout as a single generated review map with single rails', function()

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -715,7 +715,7 @@ describe('read_buffer', function()
           return {}
         end
         captured_cmds[#captured_cmds + 1] = cmd
-        if cmd[7] == 'base-sha' then
+        if vim.tbl_contains(cmd, 'base-sha') then
           return review_diff_lines()
         end
         return {}
@@ -734,6 +734,8 @@ describe('read_buffer', function()
         'diff',
         '--no-ext-diff',
         '--no-color',
+        '--src-prefix=a/',
+        '--dst-prefix=b/',
         'base-sha',
         'HEAD',
       }, captured_cmds[1])
@@ -774,6 +776,8 @@ describe('read_buffer', function()
         'diff',
         '--no-ext-diff',
         '--no-color',
+        '--src-prefix=a/',
+        '--dst-prefix=b/',
         '--merge-base',
         'origin/main',
         'refs/forge/pr/42',
@@ -805,6 +809,8 @@ describe('read_buffer', function()
         'diff',
         '--no-ext-diff',
         '--no-color',
+        '--src-prefix=a/',
+        '--dst-prefix=b/',
         'origin/main',
         'feature/topic',
       }, captured_cmd)


### PR DESCRIPTION
## Problem

With `diff.mnemonicPrefix = true`, `:Diff review` and its quickfix list only
show untracked files; staged and unstaged modifications disappear. Under that
setting git rewrites the `a/` and `b/` path prefixes on worktree-edge diffs,
emitting `i/` and `w/` for index-to-worktree and `c/` and `i/` for
HEAD-to-index. The review file-header parser only matches the
`diff --git a/... b/...` form, so it cannot recognize those headers and drops
the staged and unstaged sections from both the rendered review and the
quickfix list. Commit-to-commit diffs (the branch section) and untracked
entries keep the `a/` `b/` form, which is why only those remain visible.

## Solution

Pass explicit `--src-prefix=a/` and `--dst-prefix=b/` to the review diff
invocations so git always emits `a/` and `b/` prefixes regardless of
`diff.mnemonicPrefix` or `diff.noprefix`. Every review section then parses
reliably and appears in both the buffer and the quickfix list.

Fixes #410.
