### PR TITLE
fix(parser): parse paths in diff hunks without overriding user preferences

### DIFF
--- a/lua/diffs/hunks.lua
+++ b/lua/diffs/hunks.lua
@@ -87,14 +87,14 @@ local function normalize_path(path, strip_prefix)
     return nil
   end
   path = path:gsub('\t.*$', '')
-  local normalized = strip_prefix and path:gsub('^[ab]/', '') or path
+  local normalized = strip_prefix and path:gsub('^%a/', '') or path
   return normalized
 end
 
 ---@param line string
 ---@return string?, string?
 local function parse_diff_git_paths(line)
-  local old_path, new_path = line:match('^diff %-%-git a/(.-) b/(.+)$')
+  local old_path, new_path = line:match('^diff %-%-git %a/(.-) %a/(.+)$')
   return normalize_path(old_path), normalize_path(new_path)
 end
 

--- a/lua/diffs/lists.lua
+++ b/lua/diffs/lists.lua
@@ -69,7 +69,7 @@ end
 ---@param line string
 ---@return string?
 local function diff_file(line)
-  local old_path, new_path = line:match('^diff %-%-git a/(.-) b/(.+)$')
+  local old_path, new_path = line:match('^diff %-%-git %a/(.-) %a/(.+)$')
   return new_path or old_path
 end
 

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -300,8 +300,6 @@ function M.build_cmd(review)
     'diff',
     '--no-ext-diff',
     '--no-color',
-    '--src-prefix=a/',
-    '--dst-prefix=b/',
   }
   vim.list_extend(cmd, diffopt.git_flags())
   vim.list_extend(cmd, review.exec_args)
@@ -324,7 +322,7 @@ end
 ---@param line string
 ---@return string?
 local function diff_line_file(line)
-  local old_path, new_path = line:match('^diff %-%-git a/(.-) b/(.+)$')
+  local old_path, new_path = line:match('^diff %-%-git %a/(.-) %a/(.+)$')
   return new_path or old_path
 end
 
@@ -384,7 +382,7 @@ end
 ---@param base_rev string
 ---@return string[]?, string?
 local function branch_lines(review, base_rev)
-  local args = { 'diff', '--no-ext-diff', '--no-color', '--src-prefix=a/', '--dst-prefix=b/' }
+  local args = { 'diff', '--no-ext-diff', '--no-color' }
   vim.list_extend(args, diffopt.git_flags())
   args[#args + 1] = base_rev
   args[#args + 1] = 'HEAD'
@@ -395,7 +393,7 @@ end
 ---@param cached boolean
 ---@return string[]?, string?
 local function worktree_edge_lines(review, cached)
-  local args = { 'diff', '--no-ext-diff', '--no-color', '--src-prefix=a/', '--dst-prefix=b/' }
+  local args = { 'diff', '--no-ext-diff', '--no-color' }
   vim.list_extend(args, diffopt.git_flags())
   if cached then
     args[#args + 1] = '--cached'
@@ -810,7 +808,7 @@ end
 function M.file_at_line(buf, lnum)
   local lines = vim.api.nvim_buf_get_lines(buf, 0, lnum, false)
   for i = #lines, 1, -1 do
-    local file = lines[i]:match('^diff %-%-git a/.+ b/(.+)$')
+    local file = lines[i]:match('^diff %-%-git %a/.+ %a/(.+)$')
     if file then
       return file
     end

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -3034,8 +3034,6 @@ describe('commands', function()
         'diff',
         '--no-ext-diff',
         '--no-color',
-        '--src-prefix=a/',
-        '--dst-prefix=b/',
         '--merge-base',
         'origin/main',
         'refs/forge/pr/42',

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -734,8 +734,6 @@ describe('read_buffer', function()
         'diff',
         '--no-ext-diff',
         '--no-color',
-        '--src-prefix=a/',
-        '--dst-prefix=b/',
         'base-sha',
         'HEAD',
       }, captured_cmds[1])
@@ -776,8 +774,6 @@ describe('read_buffer', function()
         'diff',
         '--no-ext-diff',
         '--no-color',
-        '--src-prefix=a/',
-        '--dst-prefix=b/',
         '--merge-base',
         'origin/main',
         'refs/forge/pr/42',
@@ -809,8 +805,6 @@ describe('read_buffer', function()
         'diff',
         '--no-ext-diff',
         '--no-color',
-        '--src-prefix=a/',
-        '--dst-prefix=b/',
         'origin/main',
         'feature/topic',
       }, captured_cmd)


### PR DESCRIPTION
## Problem

The current fix for #410 overrides the user preference to work around
the diff hunk header parser not recognizing mnemonic prefixes.

## Solution

Update git diff hunk parsing to support different prefixes, using the
same technique that was used in #195.
