### PR TITLE
feat(review): add ++nountracked to omit the review untracked section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ See the documentation for more information.
 Yes. Configure Git to open `$MERGED` with Neovim; diffs.nvim will detect
 conflict markers automatically. See `:help diffs.nvim-git-mergetool`.
 
+**Q: Can I exclude untracked files from `:Diff review`?**
+
+Yes. Run `:Diff review ++nountracked`. To make it the default, wrap it in your
+own command, e.g. `:command! Review Diff review ++nountracked`.
+
 ## Known Limitations
 
 - **Incomplete syntax context**: Treesitter parses each diff hunk in isolation.

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -540,7 +540,7 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     the current row maps to worktree content.
 
 
-:Diff review [++layout=unified|stacked|split] [review-spec]     *:Diff-review*
+:Diff review [++layout=...] [++nountracked] [review-spec]       *:Diff-review*
     Open a repository review. `review` must be the first argument; a revision
     literally named `review` must be addressed another way (for example
     `refs/heads/review`).
@@ -554,6 +554,14 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     base ref. With `A...B`, reviews explicit target `B` against base `A`
     using merge-base semantics. With `A..B`, reviews explicit target `B`
     against base `A` as a direct two-endpoint comparison.
+
+    A current-state review (no explicit target) ends with an Untracked
+    section listing files not yet tracked by git. Pass `++nountracked` to
+    omit it. To omit it every time, wrap the command, for example: >vim
+        command! Review Diff review ++nountracked
+<
+    Explicit-target reviews (`A...B`, `A..B`) never include untracked files,
+    so the option has no effect there.
 
     `++layout=unified` and `++layout=stacked` both create full generated review
     maps. Unified review maps use old and new line-number rails; stacked review
@@ -604,6 +612,8 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
                        context-aware line-number rail.
         ++layout=split (optional) Open the first renderable changed review file
                        as a paired side-by-side endpoint diff.
+        ++nountracked  (optional) Omit the Untracked section of a
+                       current-state review (shown by default).
         {review-spec}  (string, optional) One of:
                        - empty: review current repo state against the repo
                          default branch
@@ -613,12 +623,13 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
                        - `{base}..{target}`: direct review of explicit target
                          `{target}` against base `{base}`
 
-    Completion covers `++layout=...` and git refs.
+    Completion covers `++layout=...`, `++nountracked`, and git refs.
 
     Examples: >vim
         :Diff review
         :Diff review ++layout=stacked origin/main
         :Diff review ++layout=split
+        :Diff review ++nountracked
         :Diff review origin/main
         :vertical Diff review origin/main
         :Diff review origin/main...refs/forge/pr/42
@@ -645,6 +656,8 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
                   Use this from async/plugin contexts when the current buffer
                   is not a reliable repo hint.
         {vertical} (boolean, optional) Open the review in a vertical split.
+        {untracked} (boolean, optional) Include the Untracked section of a
+                  current-state review. Defaults to true.
 
     Utilities: ~
         `require('diffs.commands').review_split()` opens the currently

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -643,6 +643,10 @@ local layout_options = {
   '++layout=split',
 }
 
+local untracked_options = {
+  '++nountracked',
+}
+
 ---@param layout? "unified"|"stacked"|"split"
 ---@return diffs.RailStyle
 local function rail_style_for_layout(layout)
@@ -739,20 +743,24 @@ end
 
 ---@param args string[]
 ---@param from? integer # first argument index to scan (defaults to 1)
----@return { has_layout: boolean, has_value: boolean }
+---@return { has_layout: boolean, has_untracked: boolean, has_value: boolean }
 local function args_context(args, from)
   local has_layout = false
+  local has_untracked = false
   local has_value = false
   for i = from or 1, #args do
     local token = args[i]
     if token:match('^%+%+layout=') then
       has_layout = true
+    elseif token == '++nountracked' then
+      has_untracked = true
     elseif not token:match('^%+%+') then
       has_value = true
     end
   end
   return {
     has_layout = has_layout,
+    has_untracked = has_untracked,
     has_value = has_value,
   }
 end
@@ -760,7 +768,7 @@ end
 ---@param arglead string
 ---@param cmdline? string
 ---@param cursorpos? integer
----@return { has_layout: boolean, has_value: boolean }
+---@return { has_layout: boolean, has_untracked: boolean, has_value: boolean }
 local function completion_context(arglead, cmdline, cursorpos)
   return args_context(command_arg_tokens(arglead, cmdline, cursorpos))
 end
@@ -789,7 +797,7 @@ local function complete_diff_args(arglead, cmdline, cursorpos)
 end
 
 ---@param arglead string
----@param context { has_layout: boolean, has_value: boolean }
+---@param context { has_layout: boolean, has_untracked: boolean, has_value: boolean }
 ---@return string[]
 local function complete_review_args(arglead, context)
   if context.has_value then
@@ -800,12 +808,18 @@ local function complete_review_args(arglead, context)
     if not context.has_layout then
       vim.list_extend(matches, prefix_matches(layout_options, arglead))
     end
+    if not context.has_untracked then
+      vim.list_extend(matches, prefix_matches(untracked_options, arglead))
+    end
     vim.list_extend(matches, review.complete(arglead))
     return matches
   end
   local matches = {}
   if arglead == '' and not context.has_layout then
     vim.list_extend(matches, layout_options)
+  end
+  if arglead == '' and not context.has_untracked then
+    vim.list_extend(matches, untracked_options)
   end
   vim.list_extend(matches, review.complete(arglead))
   return matches
@@ -1106,6 +1120,7 @@ local function stored_review_spec(normalized)
     base = normalized.base,
     target = normalized.target,
     mode = normalized.mode,
+    untracked = normalized.untracked,
   }
 end
 

--- a/lua/diffs/review.lua
+++ b/lua/diffs/review.lua
@@ -17,6 +17,7 @@ local notify = log.notify
 ---@field repo? string
 ---@field mode? string
 ---@field vertical? boolean
+---@field untracked? boolean
 
 ---@class diffs.ReviewCommandParseResult
 ---@field spec diffs.ReviewSpec
@@ -28,6 +29,7 @@ local notify = log.notify
 ---@field repo_root string
 ---@field mode string?
 ---@field vertical boolean
+---@field untracked boolean
 ---@field display string
 ---@field exec_args string[]
 
@@ -179,17 +181,28 @@ function M.parse_command_args(args)
   local tokens = split_args(args)
   local layout = 'unified'
   local has_layout = false
+  local untracked = nil
+  local has_untracked = false
 
-  while tokens[1] and tokens[1]:match('^%+%+layout=') do
-    if has_layout then
-      return nil, 'repeated ++layout option'
+  while tokens[1] and (tokens[1]:match('^%+%+layout=') or tokens[1] == '++nountracked') do
+    local token = tokens[1]
+    if token:match('^%+%+layout=') then
+      if has_layout then
+        return nil, 'repeated ++layout option'
+      end
+      local value = token:match('^%+%+layout=(.+)$')
+      if value ~= 'unified' and value ~= 'stacked' and value ~= 'split' then
+        return nil, 'unsupported layout ' .. tostring(value)
+      end
+      has_layout = true
+      layout = value
+    else
+      if has_untracked then
+        return nil, 'repeated ++nountracked option'
+      end
+      has_untracked = true
+      untracked = false
     end
-    local value = tokens[1]:match('^%+%+layout=(.+)$')
-    if value ~= 'unified' and value ~= 'stacked' and value ~= 'split' then
-      return nil, 'unsupported layout ' .. tostring(value)
-    end
-    has_layout = true
-    layout = value
     table.remove(tokens, 1)
   end
 
@@ -200,6 +213,9 @@ function M.parse_command_args(args)
   local spec, err = M.parse_arg(tokens[1])
   if not spec then
     return nil, err
+  end
+  if has_untracked then
+    spec.untracked = untracked
   end
 
   return {
@@ -230,6 +246,9 @@ function M.normalize(spec, repo_root_override)
   end
   if spec.vertical ~= nil and type(spec.vertical) ~= 'boolean' then
     error('diffs: review.vertical must be a boolean')
+  end
+  if spec.untracked ~= nil and type(spec.untracked) ~= 'boolean' then
+    error('diffs: review.untracked must be a boolean')
   end
 
   local repo_root = repo_root_override or resolve_repo_root(spec.repo)
@@ -278,12 +297,18 @@ function M.normalize(spec, repo_root_override)
     return nil, ref_err
   end
 
+  local untracked = true
+  if spec.untracked ~= nil then
+    untracked = spec.untracked
+  end
+
   return {
     base = base,
     target = target,
     repo_root = repo_root,
     mode = mode,
     vertical = spec.vertical or false,
+    untracked = untracked,
     display = display,
     exec_args = exec_args,
   },
@@ -575,36 +600,38 @@ local function run_current_state(review, deps)
     lines = unstaged_rendered,
   }, unstaged_specs, state)
 
-  local untracked, untracked_err = untracked_paths(review)
-  if not untracked then
-    return nil,
-      untracked_err ~= '' and untracked_err or 'git ls-files failed for review Untracked section',
-      nil
-  end
-  local untracked_lines = {}
-  local untracked_specs = {}
-  for _, path in ipairs(untracked) do
-    if is_untracked_binary(review.repo_root, path) then
-      dbg('skipping binary untracked %s', path)
-    else
-      local spec = diffspec.index_to_worktree(path)
-      local rendered, render_err = render.file(spec, review.repo_root)
-      if rendered then
-        for _, line in ipairs(rendered) do
-          untracked_lines[#untracked_lines + 1] = line
+  if review.untracked then
+    local untracked, untracked_err = untracked_paths(review)
+    if not untracked then
+      return nil,
+        untracked_err ~= '' and untracked_err or 'git ls-files failed for review Untracked section',
+        nil
+    end
+    local untracked_lines = {}
+    local untracked_specs = {}
+    for _, path in ipairs(untracked) do
+      if is_untracked_binary(review.repo_root, path) then
+        dbg('skipping binary untracked %s', path)
+      else
+        local spec = diffspec.index_to_worktree(path)
+        local rendered, render_err = render.file(spec, review.repo_root)
+        if rendered then
+          for _, line in ipairs(rendered) do
+            untracked_lines[#untracked_lines + 1] = line
+          end
+          untracked_specs[path] = spec
+        elseif render_err then
+          dbg('skipping untracked %s: %s', path, render_err)
         end
-        untracked_specs[path] = spec
-      elseif render_err then
-        dbg('skipping untracked %s: %s', path, render_err)
       end
     end
+    append_section(lines, {
+      id = 'untracked',
+      label = 'Untracked',
+      description = 'empty -> worktree',
+      lines = untracked_lines,
+    }, untracked_specs, state)
   end
-  append_section(lines, {
-    id = 'untracked',
-    label = 'Untracked',
-    description = 'empty -> worktree',
-    lines = untracked_lines,
-  }, untracked_specs, state)
 
   return lines,
     nil,
@@ -779,12 +806,14 @@ function M.open(spec, deps)
       base = review.base,
       target = review.target,
       mode = review.mode,
+      untracked = review.untracked,
     }),
     rail_style = deps.rail_style,
     vars = {
       diffs_review_base = review.base,
       diffs_review_target = review.target,
       diffs_review_mode = review.mode,
+      diffs_review_untracked = review.untracked,
     },
   })
 
@@ -847,6 +876,7 @@ function M.reload(bufnr, repo_root, path, deps)
   local stored_base = get_buf_var(bufnr, 'diffs_review_base')
   local stored_target = get_buf_var(bufnr, 'diffs_review_target')
   local stored_mode = get_buf_var(bufnr, 'diffs_review_mode')
+  local stored_untracked = get_buf_var(bufnr, 'diffs_review_untracked')
 
   local review_spec
   if stored_base then
@@ -854,6 +884,7 @@ function M.reload(bufnr, repo_root, path, deps)
       base = stored_base,
       target = stored_target,
       mode = stored_mode,
+      untracked = stored_untracked,
     }
   else
     local parse_err

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -660,12 +660,14 @@ describe('commands', function()
         '++layout=unified',
         '++layout=stacked',
         '++layout=split',
+        '++nountracked',
         'origin/main',
         'feature/topic',
       }, commands._test.complete_diff('', 'Diff review ', #'Diff review '))
 
       assert.are.same(
         {
+          '++nountracked',
           'origin/main',
           'feature/topic',
         },
@@ -2673,6 +2675,7 @@ describe('commands', function()
               base = 'origin/main',
               target = 'refs/forge/pr/42',
               mode = 'merge-base',
+              untracked = true,
             },
           },
           review = {
@@ -2784,6 +2787,38 @@ describe('commands', function()
       assert.are.equal('expected at most one review spec', err)
     end)
 
+    it('parses ++nountracked into spec.untracked = false', function()
+      local parsed = commands._test.parse_review_command('++nountracked origin/main')
+
+      assert.are.same({
+        layout = 'unified',
+        spec = { base = 'origin/main', untracked = false },
+      }, parsed)
+    end)
+
+    it('combines ++nountracked with ++layout and a spec', function()
+      local parsed =
+        commands._test.parse_review_command('++layout=split ++nountracked origin/main...feature')
+
+      assert.are.same({
+        layout = 'split',
+        spec = {
+          base = 'origin/main',
+          target = 'feature',
+          mode = 'merge-base',
+          untracked = false,
+        },
+      }, parsed)
+    end)
+
+    it('rejects repeated ++nountracked options', function()
+      local parsed, err =
+        commands._test.parse_review_command('++nountracked ++nountracked origin/main')
+
+      assert.is_nil(parsed)
+      assert.are.equal('repeated ++nountracked option', err)
+    end)
+
     it('normalizes default base inside the resolved repo', function()
       local captured_cmds = {}
       mock_repo_root(function(path)
@@ -2867,12 +2902,14 @@ describe('commands', function()
         '++layout=unified',
         '++layout=stacked',
         '++layout=split',
+        '++nountracked',
         'origin/main',
         'feature/topic',
         '++topic',
       }, commands._test.complete_diff('', 'Diff review ', #'Diff review '))
       assert.are.same(
         {
+          '++nountracked',
           'origin/main',
           'feature/topic',
           '++topic',
@@ -2903,10 +2940,11 @@ describe('commands', function()
         '++layout=unified',
         '++layout=stacked',
         '++layout=split',
+        '++nountracked',
         '++topic',
       }, commands._test.complete_diff('++', 'Diff review ++', #'Diff review ++'))
       assert.are.same(
-        { '++topic' },
+        { '++nountracked', '++topic' },
         commands._test.complete_diff(
           '++',
           'Diff review ++layout=split ++',
@@ -3168,6 +3206,50 @@ describe('commands', function()
       assert.are.equal('unstaged:lua/dup.lua', qf[5].user_data.diffs.key)
     end)
 
+    it('omits the untracked section when spec.untracked is false', function()
+      local repo = create_current_state_review_repo()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.review({
+        base = repo.base,
+        repo = repo.repo_root,
+        untracked = false,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+
+      local text = buffer_text(bufnr)
+      assert.is_true(text:find('# Branch:', 1, true) ~= nil)
+      assert.is_true(text:find('# Staged:', 1, true) ~= nil)
+      assert.is_true(text:find('# Unstaged:', 1, true) ~= nil)
+      assert.is_nil(text:find('# Untracked:', 1, true))
+      assert.is_nil(text:find('+new file', 1, true))
+
+      local qf = quickfix_items()
+      assert.are.equal(6, #qf)
+      for _, item in ipairs(qf) do
+        assert.is_nil(item.text:find('[Untracked]', 1, true))
+      end
+    end)
+
+    it('preserves untracked=false across reload', function()
+      local repo = create_current_state_review_repo()
+      mock_runtime_attach(function() end)
+
+      local bufnr = commands.review({
+        base = repo.base,
+        repo = repo.repo_root,
+        untracked = false,
+      })
+      assert.is_not_nil(bufnr)
+      table.insert(test_buffers, bufnr)
+
+      commands.read_buffer(bufnr)
+
+      local text = buffer_text(bufnr)
+      assert.is_nil(text:find('# Untracked:', 1, true))
+    end)
+
     it('renders worktree sections when diff.mnemonicPrefix is enabled', function()
       local repo = create_current_state_review_repo({ mnemonic_prefix = true })
       mock_runtime_attach(function() end)
@@ -3389,6 +3471,25 @@ describe('commands', function()
       assert.are.equal(1, #loc)
       assert.are.equal(panes.left_buf, loc[1].bufnr)
       assert.is_true(loc[1].text:find('file.txt', 1, true) ~= nil)
+    end)
+
+    it('excludes untracked files from the split file list with ++nountracked', function()
+      local repo = create_current_state_review_repo()
+      edit_file(repo.repo_root .. '/lua/branch.lua')
+      mock_runtime_attach(function() end)
+
+      local left_buf = commands.review_command('++layout=split ++nountracked ' .. repo.base)
+      assert.is_not_nil(left_buf)
+      local panes = track_panes(left_buf)
+
+      local files = commands.review_files(panes.left_buf)
+      local paths = {}
+      for _, file in ipairs(files) do
+        paths[file.path] = true
+      end
+      assert.is_nil(paths['lua/new.lua'])
+      assert.is_true(paths['lua/staged.lua'])
+      assert.is_true(paths['lua/unstaged.lua'])
     end)
 
     it('warns and still opens the workspace for :vertical Diff review ++layout=split', function()


### PR DESCRIPTION
## Problem

`:Diff review` of the current repository state always renders an Untracked
section, and there was no way to leave it out. For anyone reviewing only
tracked changes the untracked files are noise — and this came up as a direct
user request.

## Solution

Add a `++nountracked` flag to `:Diff review` that omits the Untracked section
of a current-state review.
