### PR TITLE
fix(review): keep skipped file logs visible

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -1326,25 +1326,55 @@ end
 ---@param selection diffs.GeneratedFileSelection
 ---@param index integer
 ---@param count integer
-local function announce_review_file(selection, index, count)
+---@return string
+local function review_file_message(selection, index, count)
   local label = selection.section_label
   local entry = (type(label) == 'string' and label ~= '')
       and ('[%s] %s'):format(label, selection.file)
     or selection.file
-  notify(('(%d of %d): %s'):format(index, count, entry), vim.log.levels.INFO)
+  return ('(%d of %d): %s'):format(index, count, entry)
+end
+
+---@param selection diffs.GeneratedFileSelection
+---@param index integer
+---@param count integer
+local function announce_review_file(selection, index, count)
+  vim.api.nvim_echo({ { '[diffs]: ' .. review_file_message(selection, index, count) } }, false, {})
 end
 
 ---@param skipped diffs.GeneratedFileSelection[]
-local function notify_skipped_review_files(skipped)
+---@return string?
+local function skipped_review_files_message(skipped)
   if #skipped == 0 then
-    return
+    return nil
   end
   local paths = {}
   for _, selection in ipairs(skipped) do
     paths[#paths + 1] = selection.file
   end
+  return ('review skipped %d file(s): %s'):format(#skipped, table.concat(paths, ', '))
+end
+
+---@param skipped diffs.GeneratedFileSelection[]
+local function notify_skipped_review_files(skipped)
+  local message = skipped_review_files_message(skipped)
+  if message then
+    notify(message, vim.log.levels.INFO)
+  end
+end
+
+---@param skipped diffs.GeneratedFileSelection[]
+---@param selection diffs.GeneratedFileSelection
+---@param index integer
+---@param count integer
+local function notify_skipped_review_file(skipped, selection, index, count)
+  local skipped_message = skipped_review_files_message(skipped)
+  if not skipped_message then
+    announce_review_file(selection, index, count)
+    return
+  end
   notify(
-    ('review skipped %d file(s): %s'):format(#skipped, table.concat(paths, ', ')),
+    skipped_message .. '\n[diffs]: ' .. review_file_message(selection, index, count),
     vim.log.levels.INFO
   )
 end
@@ -1380,8 +1410,7 @@ local function step_review_split_file(state, delta)
     else
       local switched, unsupported = switch_review_split_file(state, selected, { quiet = true })
       if switched then
-        notify_skipped_review_files(skipped)
-        announce_review_file(selected, target, count)
+        notify_skipped_review_file(skipped, selected, target, count)
         return
       end
       if not unsupported then
@@ -1672,8 +1701,7 @@ open_review_split = function(spec, opts)
       break
     end
   end
-  notify_skipped_review_files(skipped)
-  announce_review_file(first, index, #files)
+  notify_skipped_review_file(skipped, first, index, #files)
 
   dbg('opened review split %d/%d (%s)', opened.left_buf, opened.right_buf, normalized.display)
   return opened.left_buf

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -3651,8 +3651,10 @@ describe('commands', function()
       )
       assert.are.same({ 'old' }, vim.api.nvim_buf_get_lines(panes.left_buf, 0, -1, false))
       assert.are.same({ 'new' }, vim.api.nvim_buf_get_lines(panes.right_buf, 0, -1, false))
-      assert.are.equal('[diffs]: review skipped 1 file(s): aaa-bin.dat', notifications[1].message)
-      assert.are.equal('[diffs]: (2 of 2): zzz-changed.lua', notifications[2].message)
+      assert.are.equal(
+        '[diffs]: review skipped 1 file(s): aaa-bin.dat\n[diffs]: (2 of 2): zzz-changed.lua',
+        notifications[1].message
+      )
     end)
 
     it('marks skipped review files in the quickfix file index', function()
@@ -3801,10 +3803,11 @@ describe('commands', function()
         diffspec.rev_to_rev('binary-base', 'binary-topic', 'ccc-two.lua'),
         vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec')
       )
-      assert.are.equal('[diffs]: (1 of 3): aaa-one.lua', notifications[1].message)
-      assert.are.equal('[diffs]: review skipped 1 file(s): bbb-bin.dat', notifications[2].message)
-      assert.are.equal('[diffs]: (3 of 3): ccc-two.lua', notifications[3].message)
-      assert.are.equal(vim.log.levels.INFO, notifications[3].level)
+      assert.are.equal(vim.log.levels.INFO, notifications[#notifications].level)
+      assert.are.equal(
+        '[diffs]: review skipped 1 file(s): bbb-bin.dat\n[diffs]: (3 of 3): ccc-two.lua',
+        notifications[#notifications].message
+      )
 
       vim.api.nvim_set_current_win(panes.right_win)
       commands.review_prev_file()
@@ -3813,9 +3816,11 @@ describe('commands', function()
         diffspec.rev_to_rev('binary-base', 'binary-topic', 'aaa-one.lua'),
         vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec')
       )
-      assert.are.equal('[diffs]: review skipped 1 file(s): bbb-bin.dat', notifications[4].message)
-      assert.are.equal('[diffs]: (1 of 3): aaa-one.lua', notifications[5].message)
-      assert.are.equal(vim.log.levels.INFO, notifications[5].level)
+      assert.are.equal(vim.log.levels.INFO, notifications[#notifications].level)
+      assert.are.equal(
+        '[diffs]: review skipped 1 file(s): bbb-bin.dat\n[diffs]: (1 of 3): aaa-one.lua',
+        notifications[#notifications].message
+      )
     end)
 
     it('keeps the skipped-file message when no candidate switches', function()
@@ -3839,10 +3844,9 @@ describe('commands', function()
         diffspec.rev_to_rev('binary-base', 'binary-topic', 'aaa-one.lua'),
         vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec')
       )
-      assert.are.equal(2, #notifications)
-      assert.are.equal('[diffs]: (1 of 2): aaa-one.lua', notifications[1].message)
-      assert.are.equal(vim.log.levels.INFO, notifications[2].level)
-      assert.are.equal('[diffs]: review skipped 1 file(s): bbb-bin.dat', notifications[2].message)
+      assert.are.equal(1, #notifications)
+      assert.are.equal(vim.log.levels.INFO, notifications[1].level)
+      assert.are.equal('[diffs]: review skipped 1 file(s): bbb-bin.dat', notifications[1].message)
     end)
 
     it('marks skipped review files for the API and picker', function()
@@ -3878,9 +3882,8 @@ describe('commands', function()
         diffspec.rev_to_rev('binary-base', 'binary-topic', 'aaa-one.lua'),
         vim.api.nvim_buf_get_var(panes.left_buf, 'diffs_spec')
       )
-      assert.are.equal(2, #notifications)
-      assert.are.equal('[diffs]: (1 of 3): aaa-one.lua', notifications[1].message)
-      assert.are.equal('[diffs]: review skipped 1 file(s): bbb-bin.dat', notifications[2].message)
+      assert.are.equal(1, #notifications)
+      assert.are.equal('[diffs]: review skipped 1 file(s): bbb-bin.dat', notifications[1].message)
     end)
 
     it('exposes review_files/current/goto, the gO map, and the b:diffs_review marker', function()


### PR DESCRIPTION
## Problem

Skipped review files are recorded in message history, but default Neovim message display can still leave the follow-up file-position announcement as the only visible command-line message. That makes the skipped-file log look silent even though it was emitted.

## Solution

When a review navigation action skips files and lands on another file, emit the skipped-file line and the landed-file line as one ordered info notification. Regular file-position announcements keep their existing echo behavior, and skip-only actions keep their skipped-file notification.
