### PR TITLE
feat(config): add default diff layout

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -88,6 +88,7 @@ Configuration is done via `vim.g.diffs`. Set options before the plugin loads:
     vim.g.diffs = {
       debug = false,
       view = {
+        default_layout = 'unified',
         prefix = true,
         change_bar = '▏',
         rail_separator = '│',
@@ -146,6 +147,14 @@ Configuration is done via `vim.g.diffs`. Set options before the plugin loads:
 
                                                        *diffs.nvim.ViewConfig*
     View table fields: ~
+        {default_layout}     (string, default: 'unified')
+                             Default layout for current-file |:Diff| when
+                             `++layout` is omitted. Accepted values are
+                             `unified`, `stacked`, and `split`. An explicit
+                             `++layout` option takes precedence. This does not
+                             affect |:Diff-review|, |diffs.nvim-diff-files|,
+                             Fugitive status mappings, or native diff mode.
+
         {prefix}             (boolean, default: true)
                              Show diff prefixes (`+`/`-`/` `). Set to
                              `false` to hide them with virtual text overlay.
@@ -361,8 +370,8 @@ highlight-only.
     Open a diff of the current file against a diff object. The object language
     is defined at |diffs.nvim-diff-objects|. Use |:Diff-review| (`:Diff review`)
     for repository reviews.
-    The default unified layout opens below the current window and reuses an
-    existing `diffs://` window in the tabpage when one exists.
+    Without `++layout`, the layout comes from `view.default_layout`; an explicit
+    option takes precedence. The default remains `unified`.
 
     `++layout=unified` and `++layout=stacked` create generated `diffs://`
     buffers. Unified buffers include old and new line-number rails before the
@@ -392,8 +401,8 @@ highlight-only.
     itself and leaves the quickfix list untouched.
 
     Parameters: ~
-        ++layout=unified (optional) Open the default generated `diffs://` view
-                    with old and new line-number rails.
+        ++layout=unified (optional) Open a generated `diffs://` view with old
+                    and new line-number rails.
         ++layout=stacked (optional) Open a generated `diffs://` view with one
                     context-aware line-number rail.
         ++layout=split (optional) Open the current single-file comparison as

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -1921,6 +1921,7 @@ function M.diff(args, vertical, opts)
   local parsed, parse_err = diff_parser.parse(args, {
     path = rel_path,
     current = diffspec.worktree(),
+    default_layout = runtime.get_view_config().default_layout,
   })
   if not parsed then
     notify(parse_err, vim.log.levels.ERROR)

--- a/lua/diffs/config.lua
+++ b/lua/diffs/config.lua
@@ -20,6 +20,7 @@ local integration_metadata = require('diffs.integrations')
 ---@field lines integer
 
 ---@class diffs.ViewConfig
+---@field default_layout "unified"|"stacked"|"split"
 ---@field prefix boolean
 ---@field change_bar string
 ---@field rail_separator string
@@ -76,6 +77,7 @@ local integration_metadata = require('diffs.integrations')
 local DEFAULTS = {
   debug = false,
   view = {
+    default_layout = 'unified',
     prefix = true,
     change_bar = '▏',
     rail_separator = '│',
@@ -154,6 +156,9 @@ function M.validate(opts)
   end, 'boolean or string (file path)')
   vim.validate('view', opts.view, 'table', true)
   if opts.view then
+    vim.validate('view.default_layout', opts.view.default_layout, function(v)
+      return v == nil or v == 'unified' or v == 'stacked' or v == 'split'
+    end, "'unified', 'stacked', or 'split'")
     vim.validate('view.prefix', opts.view.prefix, 'boolean', true)
     vim.validate('view.change_bar', opts.view.change_bar, 'string', true)
     vim.validate('view.rail_separator', opts.view.rail_separator, 'string', true)

--- a/lua/diffs/diffargs.lua
+++ b/lua/diffs/diffargs.lua
@@ -5,6 +5,7 @@ local diffspec = require('diffs.spec')
 ---@class diffs.DiffParseContext
 ---@field path string
 ---@field current? diffs.Endpoint
+---@field default_layout? "unified"|"stacked"|"split"
 
 ---@class diffs.DiffParseResult
 ---@field spec diffs.DiffSpec
@@ -28,9 +29,10 @@ local function split_args(args)
 end
 
 ---@param tokens string[]
+---@param default_layout? "unified"|"stacked"|"split"
 ---@return ("unified"|"stacked"|"split")?, string?
-local function take_layout(tokens)
-  local layout = 'unified'
+local function take_layout(tokens, default_layout)
+  local layout = default_layout or 'unified'
   local has_layout = false
   while tokens[1] and tokens[1]:match('^%+%+') do
     if tokens[1]:match('^%+%+layout=') then
@@ -186,7 +188,7 @@ function M.parse(args, context)
 
   local current = context.current and diffspec.endpoint(context.current) or diffspec.worktree()
   local tokens = split_args(args)
-  local layout, layout_err = take_layout(tokens)
+  local layout, layout_err = take_layout(tokens, context.default_layout)
   if not layout then
     return nil, layout_err
   end

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -1043,6 +1043,34 @@ describe('commands', function()
       assert.is_true(text:find('+local M = {}', 1, true) ~= nil)
     end)
 
+    it('opens configured default :Diff as paired endpoint windows', function()
+      local saved_splitright = vim.o.splitright
+      vim.o.splitright = false
+      local ok, err = pcall(function()
+        mock_view_config({
+          default_layout = 'split',
+          prefix = true,
+          change_bar = '┃',
+          rail_separator = '│',
+        })
+        create_split_source()
+        commands.diff(nil, false)
+      end)
+      vim.o.splitright = saved_splitright
+      assert.is_true(ok, err)
+
+      local right_buf = vim.api.nvim_get_current_buf()
+      local left_buf = vim.api.nvim_buf_get_var(right_buf, 'diffs_split_peer')
+      test_buffers[#test_buffers + 1] = left_buf
+      test_buffers[#test_buffers + 1] = right_buf
+
+      assert.are.equal('diffs://split:left:index:lua/foo.lua', vim.api.nvim_buf_get_name(left_buf))
+      assert.are.equal(
+        'diffs://split:right:worktree:lua/foo.lua',
+        vim.api.nvim_buf_get_name(right_buf)
+      )
+    end)
+
     it('opens opt-in split :Diff as paired endpoint windows', function()
       local saved_splitright = vim.o.splitright
       vim.o.splitright = false

--- a/spec/config_spec.lua
+++ b/spec/config_spec.lua
@@ -103,6 +103,25 @@ describe('diffs.config', function()
       assert.are.equal('│', opts.view.rail_separator)
     end)
 
+    it('defaults view.default_layout to unified', function()
+      local opts = config.new()
+      assert.are.equal('unified', opts.view.default_layout)
+    end)
+
+    it('accepts supported default layouts', function()
+      for _, layout in ipairs({ 'unified', 'stacked', 'split' }) do
+        local opts = config.new({ view = { default_layout = layout } })
+        assert.are.equal(layout, opts.view.default_layout)
+      end
+    end)
+
+    it('rejects unsupported default layouts', function()
+      local ok, err = pcall(config.new, { view = { default_layout = 'tiled' } })
+      assert.is_false(ok)
+      assert.matches('view.default_layout', err, 1, true)
+      assert.matches("'unified', 'stacked', or 'split'", err, 1, true)
+    end)
+
     it('accepts custom view glyphs', function()
       local opts = config.new({
         view = {

--- a/spec/diffargs_spec.lua
+++ b/spec/diffargs_spec.lua
@@ -6,10 +6,11 @@ local diffspec = require('diffs.spec')
 describe('diffs.diffargs', function()
   local path = 'lua/foo.lua'
 
-  local function parse(args, current)
+  local function parse(args, current, default_layout)
     local result, err = diffargs.parse(args, {
       path = path,
       current = current or diffspec.worktree(),
+      default_layout = default_layout,
     })
     assert.is_nil(err)
     return result
@@ -20,6 +21,18 @@ describe('diffs.diffargs', function()
 
     assert.are.same(diffspec.index_to_worktree(path), result.spec)
     assert.are.equal('unified', result.layout)
+  end)
+
+  it('uses the configured default layout when no option is provided', function()
+    local result = parse(nil, nil, 'split')
+
+    assert.are.equal('split', result.layout)
+  end)
+
+  it('lets an explicit layout override the configured default', function()
+    local result = parse('++layout=stacked', nil, 'split')
+
+    assert.are.equal('stacked', result.layout)
   end)
 
   it('maps explicit revisions to revision -> worktree', function()


### PR DESCRIPTION
## Problem

Current-file `:Diff` always falls back to the unified layout when no `++layout` option is supplied, so users who prefer the paired split or stacked view must repeat the option on every invocation. The configuration has no way to express that preference independently from review, arbitrary-file, Fugitive, or native diff surfaces.

## Solution

Add `view.default_layout` with `unified`, `stacked`, and `split` values while retaining `unified` as the backward-compatible default. Current-file `:Diff` uses the configured value only when `++layout` is omitted, leaving explicit command options at higher precedence and leaving review, arbitrary-file, Fugitive, and native diff behavior unchanged. The option is validated and documented alongside the existing view settings.

This addresses the default-layout portion of #422.
