### PR TITLE
feat(conflict): parse jujutsu snapshot conflict markers

### DIFF
--- a/lua/diffs/conflict.lua
+++ b/lua/diffs/conflict.lua
@@ -1,4 +1,5 @@
 ---@class diffs.ConflictRegion
+---@field marker_open integer?
 ---@field marker_ours integer
 ---@field ours_start integer
 ---@field ours_end integer
@@ -27,6 +28,13 @@ local diagnostics_suppressed = {}
 ---@type table<integer, table<string, diffs.BufferKeymap>>
 local buffer_keymaps = {}
 
+---@param line string
+---@param char string
+---@return boolean
+local function is_marker(line, char)
+  return line:sub(1, 7) == string.rep(char, 7)
+end
+
 ---@param lines string[]
 ---@return diffs.ConflictRegion[]
 function M.parse(lines)
@@ -39,9 +47,15 @@ function M.parse(lines)
     local idx = i - 1
 
     if state == 'idle' then
-      if line:match('^<<<<<<<') then
-        current = { marker_ours = idx, ours_start = idx + 1 }
-        state = 'in_ours'
+      if is_marker(line, '<') then
+        local following = lines[i + 1]
+        if following and is_marker(following, '+') then
+          current = { marker_open = idx }
+          state = 'in_snapshot_open'
+        else
+          current = { marker_ours = idx, ours_start = idx + 1 }
+          state = 'in_ours'
+        end
       end
     elseif state == 'in_ours' then
       if line:match('^|||||||') then
@@ -84,10 +98,51 @@ function M.parse(lines)
         current = { marker_ours = idx, ours_start = idx + 1 }
         state = 'in_ours'
       end
+    elseif state == 'in_snapshot_open' then
+      current.marker_ours = idx
+      current.ours_start = idx + 1
+      state = 'in_snapshot_ours'
+    elseif state == 'in_snapshot_ours' then
+      if is_marker(line, '-') then
+        current.ours_end = idx
+        current.marker_base = idx
+        current.base_start = idx + 1
+        state = 'in_snapshot_base'
+      elseif is_marker(line, '%') or is_marker(line, '+') or is_marker(line, '>') then
+        current = nil
+        state = 'idle'
+      end
+    elseif state == 'in_snapshot_base' then
+      if is_marker(line, '+') then
+        current.base_end = idx
+        current.marker_sep = idx
+        current.theirs_start = idx + 1
+        state = 'in_snapshot_theirs'
+      elseif is_marker(line, '%') or is_marker(line, '-') or is_marker(line, '>') then
+        current = nil
+        state = 'idle'
+      end
+    elseif state == 'in_snapshot_theirs' then
+      if is_marker(line, '>') then
+        current.theirs_end = idx
+        current.marker_theirs = idx
+        table.insert(regions, current)
+        current = nil
+        state = 'idle'
+      elseif is_marker(line, '%') or is_marker(line, '+') or is_marker(line, '-') then
+        current = nil
+        state = 'idle'
+      end
     end
   end
 
   return regions
+end
+
+---@param region diffs.ConflictRegion
+---@return integer
+local function region_start(region)
+  return region.marker_open or region.marker_ours
 end
 
 ---@param bufnr integer
@@ -201,6 +256,9 @@ local function apply_highlights(bufnr, regions, config)
   vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
 
   for _, region in ipairs(regions) do
+    if region.marker_open then
+      mark_line(bufnr, region.marker_open, 'DiffsConflictMarker')
+    end
     mark_line(bufnr, region.marker_ours, 'DiffsConflictMarker')
     apply_marker_label(bufnr, region.marker_ours, 'ours', config)
     apply_action_hints(bufnr, region, config)
@@ -242,7 +300,7 @@ end
 ---@return diffs.ConflictRegion?
 local function find_conflict_at_cursor(cursor_line, regions)
   for _, region in ipairs(regions) do
-    if cursor_line >= region.marker_ours and cursor_line <= region.marker_theirs then
+    if cursor_line >= region_start(region) and cursor_line <= region.marker_theirs then
       return region
     end
   end
@@ -255,7 +313,7 @@ end
 function M.replace_region(bufnr, region, replacement)
   vim.api.nvim_buf_set_lines(
     bufnr,
-    region.marker_ours,
+    region_start(region),
     region.marker_theirs + 1,
     false,
     replacement
@@ -359,22 +417,22 @@ local function goto_conflict(bufnr, forward)
   local cursor_line = vim.api.nvim_win_get_cursor(0)[1] - 1
   if forward then
     for _, region in ipairs(regions) do
-      if region.marker_ours > cursor_line then
-        vim.api.nvim_win_set_cursor(0, { region.marker_ours + 1, 0 })
+      if region_start(region) > cursor_line then
+        vim.api.nvim_win_set_cursor(0, { region_start(region) + 1, 0 })
         return
       end
     end
     notify('wrapped to first conflict', vim.log.levels.INFO)
-    vim.api.nvim_win_set_cursor(0, { regions[1].marker_ours + 1, 0 })
+    vim.api.nvim_win_set_cursor(0, { region_start(regions[1]) + 1, 0 })
   else
     for i = #regions, 1, -1 do
-      if regions[i].marker_ours < cursor_line then
-        vim.api.nvim_win_set_cursor(0, { regions[i].marker_ours + 1, 0 })
+      if region_start(regions[i]) < cursor_line then
+        vim.api.nvim_win_set_cursor(0, { region_start(regions[i]) + 1, 0 })
         return
       end
     end
     notify('wrapped to last conflict', vim.log.levels.INFO)
-    vim.api.nvim_win_set_cursor(0, { regions[#regions].marker_ours + 1, 0 })
+    vim.api.nvim_win_set_cursor(0, { region_start(regions[#regions]) + 1, 0 })
   end
 end
 
@@ -433,20 +491,13 @@ function M.attach(bufnr, config)
   end
 
   local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  local has_marker = false
-  for _, line in ipairs(lines) do
-    if line:match('^<<<<<<<') then
-      has_marker = true
-      break
-    end
-  end
-  if not has_marker then
+  local regions = M.parse(lines)
+  if #regions == 0 then
     return
   end
 
   attached_buffers[bufnr] = true
 
-  local regions = M.parse(lines)
   apply_highlights(bufnr, regions, config)
   setup_keymaps(bufnr, config)
 

--- a/spec/jj_conflict_spec.lua
+++ b/spec/jj_conflict_spec.lua
@@ -1,0 +1,177 @@
+local conflict = require('diffs.conflict')
+
+local function default_config(overrides)
+  local cfg = {
+    enabled = true,
+    disable_diagnostics = false,
+    show_virtual_text = false,
+    show_actions = false,
+    keymaps = false,
+  }
+  if overrides then
+    cfg = vim.tbl_deep_extend('force', cfg, overrides)
+  end
+  return cfg
+end
+
+local function create_file_buffer(lines)
+  local bufnr = vim.api.nvim_create_buf(false, false)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines or {})
+  return bufnr
+end
+
+local function snapshot_lines()
+  return {
+    'line1',
+    '<<<<<<< conflict 1 of 1',
+    '+++++++ tzmtwuuv 321864a5 "sidea" (rebase destination)',
+    'AAA',
+    '------- sozvolrq 24563c2b "base" (parents of rebased revision)',
+    'line2',
+    '+++++++ vooloppp 8bb449c1 "sideb" (rebased revision)',
+    'BBB',
+    '>>>>>>> conflict 1 of 1 ends',
+    'line3',
+  }
+end
+
+local function diff_lines()
+  return {
+    'line1',
+    '<<<<<<< conflict 1 of 1',
+    '%%%%%%% diff from: sozvolrq 24563c2b "base" (parents of rebased revision)',
+    '\\\\\\\\\\\\\\        to: tzmtwuuv 321864a5 "sidea" (rebase destination)',
+    '-line2',
+    '+AAA',
+    '+++++++ vooloppp 8bb449c1 "sideb" (rebased revision)',
+    'BBB',
+    '>>>>>>> conflict 1 of 1 ends',
+    'line3',
+  }
+end
+
+local function three_sided_lines()
+  return {
+    'line1',
+    '<<<<<<< conflict 1 of 1',
+    '+++++++ sideA',
+    'AAA',
+    '------- base',
+    'line2',
+    '+++++++ sideB',
+    'BBB',
+    '------- base',
+    'line2',
+    '+++++++ sideC',
+    'CCC',
+    '>>>>>>> conflict 1 of 1 ends',
+    'line3',
+  }
+end
+
+describe('jj conflict markers', function()
+  describe('snapshot style', function()
+    it('parses a two sided conflict', function()
+      local regions = conflict.parse(snapshot_lines())
+      assert.are.equal(1, #regions)
+      local region = regions[1]
+      assert.are.equal(1, region.marker_open)
+      assert.are.equal(2, region.marker_ours)
+      assert.are.equal(3, region.ours_start)
+      assert.are.equal(4, region.ours_end)
+      assert.are.equal(4, region.marker_base)
+      assert.are.equal(5, region.base_start)
+      assert.are.equal(6, region.base_end)
+      assert.are.equal(6, region.marker_sep)
+      assert.are.equal(7, region.theirs_start)
+      assert.are.equal(8, region.theirs_end)
+      assert.are.equal(8, region.marker_theirs)
+    end)
+
+    it('resolves to the first side', function()
+      local bufnr = create_file_buffer(snapshot_lines())
+      vim.api.nvim_set_current_buf(bufnr)
+      vim.api.nvim_win_set_cursor(0, { 4, 0 })
+      conflict.resolve_ours(bufnr, default_config())
+      assert.are.same({ 'line1', 'AAA', 'line3' }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('resolves to the last side', function()
+      local bufnr = create_file_buffer(snapshot_lines())
+      vim.api.nvim_set_current_buf(bufnr)
+      vim.api.nvim_win_set_cursor(0, { 4, 0 })
+      conflict.resolve_theirs(bufnr, default_config())
+      assert.are.same({ 'line1', 'BBB', 'line3' }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('removes the opening marker when resolving', function()
+      local bufnr = create_file_buffer(snapshot_lines())
+      vim.api.nvim_set_current_buf(bufnr)
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+      conflict.resolve_none(bufnr, default_config())
+      assert.are.same({ 'line1', 'line3' }, vim.api.nvim_buf_get_lines(bufnr, 0, -1, false))
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('highlights the opening marker', function()
+      local bufnr = create_file_buffer(snapshot_lines())
+      conflict.attach(bufnr, default_config())
+      local rows = {}
+      for _, mark in
+        ipairs(
+          vim.api.nvim_buf_get_extmarks(bufnr, conflict.get_namespace(), 0, -1, { details = true })
+        )
+      do
+        if mark[4] and mark[4].hl_group == 'DiffsConflictMarker' then
+          rows[mark[2]] = true
+        end
+      end
+      assert.is_true(rows[1])
+      assert.is_true(rows[2])
+      assert.is_true(rows[4])
+      assert.is_true(rows[6])
+      assert.is_true(rows[8])
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
+
+  describe('unsupported styles', function()
+    it('does not parse diff style', function()
+      assert.are.equal(0, #conflict.parse(diff_lines()))
+    end)
+
+    it('does not parse conflicts with more than two sides', function()
+      assert.are.equal(0, #conflict.parse(three_sided_lines()))
+    end)
+
+    it('does not attach when nothing parses', function()
+      local bufnr = create_file_buffer(diff_lines())
+      conflict.attach(bufnr, default_config({ keymaps = { ours = 'gto' } }))
+      assert.are.equal(
+        0,
+        #vim.api.nvim_buf_get_extmarks(bufnr, conflict.get_namespace(), 0, -1, {})
+      )
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
+
+  describe('git style regression', function()
+    it('still parses without an opening marker field', function()
+      local regions = conflict.parse({
+        '<<<<<<< tzmtwuuv 321864a5 "sidea" (rebase destination)',
+        'AAA',
+        '||||||| sozvolrq 24563c2b "base" (parents of rebased revision)',
+        'line2',
+        '=======',
+        'BBB',
+        '>>>>>>> vooloppp 8bb449c1 "sideb" (rebased revision)',
+      })
+      assert.are.equal(1, #regions)
+      assert.is_nil(regions[1].marker_open)
+      assert.are.equal(0, regions[1].marker_ours)
+      assert.are.equal(6, regions[1].marker_theirs)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Problem

Jujutsu materializes conflicts into ordinary working-copy files, so a conflicted buffer reaches the conflict module exactly the way a git one does. Only git's diff3 markers are recognized, and the two halves of the module disagree about what counts as a conflict: `attach` gates on the opening marker alone, while `parse` needs a separator to close a region. A jujutsu buffer therefore attaches, binds the resolution keymaps and suppresses diagnostics, then highlights nothing and does nothing when those keymaps are pressed.

## Solution

Jujutsu's snapshot style carries the same information as diff3 with different punctuation — an opening marker followed by alternating add and remove sections — so a two sided snapshot conflict maps onto the existing region model once that model can record the opening marker separately from the first side. `marker_open` does this, and `region_start` keeps highlighting, cursor lookup, replacement and navigation pointed at the right first line. Git conflicts leave `marker_open` unset and behave exactly as before.

Styles the region model cannot represent — jujutsu's default diff style, which is a snapshot plus patches to apply rather than sides to choose between, and conflicts with more than two sides — now leave the buffer alone rather than half-attaching to it. `attach` gates on a parseable region instead of on the opening marker, which also stops it claiming buffers it cannot help with.