### PR TITLE
fix(diff): rebuild generated buffers after an unload

### DIFF
--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -328,17 +328,17 @@ end
 ---@param info diffs.RailInfo?
 local function set_diff_rails_var(bufnr, info)
   if info then
-    vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_width', info.prefix_width)
-    vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_separator_width', info.separator_width)
+    generated.set_var(bufnr, 'diffs_rail_width', info.prefix_width)
+    generated.set_var(bufnr, 'diffs_rail_separator_width', info.separator_width)
     if info.style == 'single' or info.style == 'dual' then
-      vim.api.nvim_buf_set_var(bufnr, 'diffs_rail_style', info.style)
+      generated.set_var(bufnr, 'diffs_rail_style', info.style)
     else
-      pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_style')
+      generated.del_var(bufnr, 'diffs_rail_style')
     end
   else
-    pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_width')
-    pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_separator_width')
-    pcall(vim.api.nvim_buf_del_var, bufnr, 'diffs_rail_style')
+    generated.del_var(bufnr, 'diffs_rail_width')
+    generated.del_var(bufnr, 'diffs_rail_separator_width')
+    generated.del_var(bufnr, 'diffs_rail_style')
   end
 end
 
@@ -415,7 +415,7 @@ local function create_generated_diff_buffer(opts)
   end
   for name, value in pairs(opts.vars or {}) do
     if value ~= nil then
-      vim.api.nvim_buf_set_var(bufnr, name, value)
+      generated.set_var(bufnr, name, value)
     end
   end
 
@@ -533,7 +533,7 @@ end
 ---@param display string
 ---@param layout diffs.ReviewMapLayout
 local function setup_review_map_buffer(bufnr, display, layout)
-  vim.b[bufnr].diffs_review = { display = display, layout = layout }
+  generated.set_var(bufnr, 'diffs_review', { display = display, layout = layout })
   if not get_buffer_keymap(bufnr, 'n', 'gs') then
     vim.keymap.set(
       'n',
@@ -2240,6 +2240,8 @@ function M.read_buffer(bufnr)
     return
   end
 
+  generated.restore(bufnr)
+
   local source, source_err = get_source_var(bufnr)
   if source_err then
     notify('invalid diffs_source metadata: ' .. tostring(source_err), vim.log.levels.WARN)
@@ -2354,6 +2356,15 @@ function M.read_buffer(bufnr)
     quickfix = is_review or nil,
   })
   M.setup_diff_buf(bufnr)
+
+  local review_marker = generated.get_var(bufnr, 'diffs_review')
+  if type(review_marker) == 'table' and review_marker.layout ~= 'split' then
+    setup_review_map_buffer(
+      bufnr,
+      review_marker.display,
+      normalize_review_map_layout(review_marker.layout)
+    )
+  end
 
   dbg('reloaded diff buffer %d (%s)', bufnr, debug_label)
 

--- a/lua/diffs/generated/source.lua
+++ b/lua/diffs/generated/source.lua
@@ -3,6 +3,32 @@ local M = {}
 local diffspec = require('diffs.spec')
 local hunk_model = require('diffs.hunks')
 
+local group = vim.api.nvim_create_augroup('diffs_generated_source', { clear = false })
+
+---@type table<integer, table<string, any>>
+local restorable = {}
+
+---@param bufnr integer
+---@return table<string, any>
+local function tracked_vars(bufnr)
+  local vars = restorable[bufnr]
+  if vars then
+    return vars
+  end
+
+  vars = {}
+  restorable[bufnr] = vars
+  vim.api.nvim_create_autocmd('BufWipeout', {
+    group = group,
+    buffer = bufnr,
+    once = true,
+    callback = function()
+      restorable[bufnr] = nil
+    end,
+  })
+  return vars
+end
+
 ---@param bufnr integer
 ---@param name string
 ---@return any
@@ -15,6 +41,33 @@ function M.get_var(bufnr, name)
 end
 
 ---@param bufnr integer
+---@param name string
+---@param value any
+function M.set_var(bufnr, name, value)
+  vim.api.nvim_buf_set_var(bufnr, name, value)
+  tracked_vars(bufnr)[name] = value
+end
+
+---@param bufnr integer
+---@param name string
+function M.del_var(bufnr, name)
+  local vars = restorable[bufnr]
+  if vars then
+    vars[name] = nil
+  end
+  pcall(vim.api.nvim_buf_del_var, bufnr, name)
+end
+
+---@param bufnr integer
+function M.restore(bufnr)
+  for name, value in pairs(restorable[bufnr] or {}) do
+    if M.get_var(bufnr, name) == nil then
+      pcall(vim.api.nvim_buf_set_var, bufnr, name, value)
+    end
+  end
+end
+
+---@param bufnr integer
 ---@return string?
 function M.repo_root(bufnr)
   return M.get_var(bufnr, 'diffs_repo_root')
@@ -23,13 +76,13 @@ end
 ---@param bufnr integer
 ---@param repo_root string
 function M.set_repo_root(bufnr, repo_root)
-  vim.api.nvim_buf_set_var(bufnr, 'diffs_repo_root', repo_root)
+  M.set_var(bufnr, 'diffs_repo_root', repo_root)
 end
 
 ---@param bufnr integer
 ---@param diff_spec diffs.DiffSpec
 function M.set_spec(bufnr, diff_spec)
-  vim.api.nvim_buf_set_var(bufnr, 'diffs_spec', diffspec.new(diff_spec))
+  M.set_var(bufnr, 'diffs_spec', diffspec.new(diff_spec))
 end
 
 ---@param bufnr integer
@@ -187,7 +240,7 @@ end
 ---@param bufnr integer
 ---@param source diffs.GeneratedBufferSource|diffs.SplitEndpointSource
 function M.set_source(bufnr, source)
-  vim.api.nvim_buf_set_var(bufnr, 'diffs_source', source)
+  M.set_var(bufnr, 'diffs_source', source)
 end
 
 ---@param repo_root string

--- a/spec/read_buffer_spec.lua
+++ b/spec/read_buffer_spec.lua
@@ -165,6 +165,87 @@ describe('read_buffer', function()
     end)
   end)
 
+  describe('unloaded buffers', function()
+    it('regenerates content after an unload cleared the buffer variables', function()
+      mock_git()
+
+      local bufnr = commands._test.create_generated_diff_buffer({
+        name = 'diffs://unstaged:unloaded.lua',
+        lines = review_diff_lines(),
+        repo_root = '/tmp',
+        source = {
+          version = 1,
+          kind = 'file',
+          repo_root = '/tmp',
+          spec = diffspec.index_to_worktree('unloaded.lua'),
+        },
+        rail_style = 'single',
+      })
+      table.insert(test_buffers, bufnr)
+
+      vim.api.nvim_win_set_buf(0, bufnr)
+      vim.cmd('enew')
+
+      assert.is_false(vim.api.nvim_buf_is_loaded(bufnr))
+      assert.is_false(has_buf_var(bufnr, 'diffs_source'))
+      assert.is_false(has_buf_var(bufnr, 'diffs_repo_root'))
+
+      commands.read_buffer(bufnr)
+
+      local lines = buffer_lines(bufnr)
+      assert.are.equal('diff --git a/unloaded.lua b/unloaded.lua', lines[1])
+      assert.are.equal('+local x = 1', lines[6])
+      assert.are.equal('/tmp', vim.api.nvim_buf_get_var(bufnr, 'diffs_repo_root'))
+      assert.are.equal('single', vim.api.nvim_buf_get_var(bufnr, 'diffs_rail_style'))
+    end)
+
+    it('restores review metadata and keymaps for an unloaded review map', function()
+      mock_systemlist(function(cmd)
+        if cmd[4] == 'rev-parse' then
+          return { 'commit' }
+        end
+        if cmd[4] ~= 'diff' then
+          return {}
+        end
+        return review_diff_lines()
+      end)
+
+      local bufnr = commands._test.create_generated_diff_buffer({
+        name = 'diffs://review:origin/main...feature/topic',
+        lines = review_diff_lines(),
+        repo_root = '/tmp/repo',
+        source = {
+          version = 1,
+          kind = 'review',
+          repo_root = '/tmp/repo',
+          review = {
+            base = 'origin/main',
+            target = 'feature/topic',
+            mode = 'merge-base',
+          },
+        },
+        vars = {
+          diffs_review_base = 'origin/main',
+          diffs_review = { display = 'origin/main...feature/topic', layout = 'stacked' },
+        },
+      })
+      table.insert(test_buffers, bufnr)
+
+      vim.api.nvim_win_set_buf(0, bufnr)
+      vim.cmd('enew')
+
+      commands.read_buffer(bufnr)
+
+      assert.are.same(review_diff_lines(), buffer_lines(bufnr))
+      assert.are.equal('origin/main', vim.api.nvim_buf_get_var(bufnr, 'diffs_review_base'))
+      assert.are.same(
+        { display = 'origin/main...feature/topic', layout = 'stacked' },
+        vim.api.nvim_buf_get_var(bufnr, 'diffs_review')
+      )
+      assert.is_true(helpers.has_keymap(bufnr, 'gs'))
+    end)
+  end)
+
   describe('buffer options', function()
     it('sets buftype, bufhidden, swapfile, modifiable, filetype', function()
       mock_git()


### PR DESCRIPTION
## Problem

Generated `diffs://` buffers hold everything needed to rebuild themselves in buffer-local variables, and they set `bufhidden=delete` so closing the last window showing one unloads it. Unloading clears a buffer's variables, so a redisplayed buffer reaches `BufReadCmd` with no `diffs_source` and no `diffs_repo_root` left. The reload gives up with `cannot reload diffs:// buffer without diffs_repo_root` and leaves a single empty line, which is indistinguishable from a review with no changes. The same unload also drops buffer-local keymaps, so even a buffer that did reload would come back without its review layout toggle.

`:Diff review`, then closing that window, then returning to the buffer reproduces it; the buffer stays empty until it is wiped and the review is rerun.

## Solution

Keep the variables that describe how a generated buffer was built in a table keyed by buffer number, written through the same `diffs.generated` setters that already own that state, and reapply the missing ones at the top of the reload. A redisplayed buffer then regenerates from its stored source exactly the way a visible one does when it refreshes, including the rail style that decides how it is rendered. The entry is dropped when the buffer is wiped out, which is when the handle is really gone.

A reloaded review map also has its review marker and `gs` layout toggle reinstated, so it returns as a working review surface rather than a plain diff buffer. Buffers with no recorded state, such as a hand-typed `diffs://` name, still take the existing warning path.