### PR TITLE
fix(review): keep the cursor line across a review layout toggle

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -609,6 +609,11 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     reflected in the map. Map lines with no source line of their own, such as
     file and hunk headers, open the split at the first change of the hunk.
 
+    The split shows a removed line and the line that replaced it on one row,
+    which the map shows as two. Returning uses the line under the cursor, so
+    leaving from the right pane lands on the `+` line of such a pair even when
+    the `-` line is what selected it. Toggling again keeps that line.
+
     In split layout, `]f`/`[f` step to the next/previous changed file in the
     review (wrapping at the ends), swapping the displayed pair in place and
     reusing the two windows. Each step (and the initial open) echoes the file's

--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -603,6 +603,12 @@ Paired-window behavior: ~                          *diffs.nvim-paired-windows*
     |<Plug>(diffs-review-toggle-layout)|, set only when you have not already
     mapped `gs` in that buffer.
 
+    The toggle carries the cursor line in both directions. The split opens on
+    the source line the map cursor was on, and returning lands on the map line
+    for the source line the split cursor is on, so moving inside the split is
+    reflected in the map. Map lines with no source line of their own, such as
+    file and hunk headers, open the split at the first change of the hunk.
+
     In split layout, `]f`/`[f` step to the next/previous changed file in the
     review (wrapping at the ends), swapping the displayed pair in place and
     reusing the two windows. Each step (and the initial open) echoes the file's
@@ -1334,8 +1340,9 @@ review_toggle_layout({opts})              *diffs.nvim.review_toggle_layout()*
     Toggle the current review surface between the generated review map and split
     layout. From a generated review map, opens the selected file in split layout.
     From a review split, closes the pair and restores the generated map layout
-    recorded on the split (`unified` or `stacked`). Returns the opened buffer
-    number or `nil` if the current buffer is not a review surface.
+    recorded on the split (`unified` or `stacked`). Either direction keeps the
+    cursor on the line it was on, mapped through the diff. Returns the opened
+    buffer number or `nil` if the current buffer is not a review surface.
 
     Parameters: ~
         {opts}   (table, optional) Supports `{ bufnr = <integer> }`. Defaults to

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -911,6 +911,7 @@ end
 
 ---@class diffs.OpenReviewSplitOpts
 ---@field selection? diffs.GeneratedFileSelection
+---@field source_position? diffs.SourcePosition
 ---@field replace_win? integer
 ---@field map_layout? diffs.ReviewMapLayout
 
@@ -1111,6 +1112,7 @@ end
 ---@field review_buf integer
 ---@field replace_win integer
 ---@field selected diffs.GeneratedFileSelection
+---@field source_position? diffs.SourcePosition
 ---@field repo_root string
 ---@field map_layout diffs.ReviewMapLayout
 
@@ -1156,10 +1158,14 @@ local function review_split_context(opts)
       review_buf
   end
 
+  local selected_line = selected.lnum
+    and hunk_model.line_at(lists.generated_hunks(review_buf), selected.lnum)
+
   return {
     review_buf = review_buf,
     replace_win = review_win,
     selected = selected,
+    source_position = hunk_model.source_position_for(selected_line),
     repo_root = source.repo_root,
     map_layout = map_layout,
   },
@@ -1756,6 +1762,7 @@ open_review_split = function(spec, opts)
   review_split_states[opened.left_buf] = state
   review_split_states[opened.right_buf] = state
   attach_review_split_autocmds(state)
+  split.move_pair_to_source(opened.right_buf, opts.source_position)
 
   local files = lists.generated_files(review_lines, review_generated_list_opts(list_opts))
   local index = 1
@@ -1797,6 +1804,7 @@ function M.review_split(opts)
   review_spec.repo = context.repo_root
   return open_review_split(review_spec, {
     selection = context.selected,
+    source_position = context.source_position,
     replace_win = context.replace_win,
     map_layout = context.map_layout,
   })
@@ -1827,20 +1835,28 @@ end
 ---@param bufnr integer
 ---@param selected_file string
 ---@param selected_key string?
+---@param position diffs.SourcePosition?
 ---@return boolean
-local function goto_review_map_selection(bufnr, selected_file, selected_key)
+local function goto_review_map_selection(bufnr, selected_file, selected_key, position)
   local win = first_window_for_buffer(bufnr)
   if not win then
     return false
   end
+  local matched_line = position
+    and hunk_model.line_at_source(
+      lists.generated_hunks(bufnr),
+      { file = selected_file, key = selected_key },
+      position
+    )
   for _, item in ipairs(vim.fn.getqflist({ items = 0 }).items) do
     local data = item.user_data and item.user_data.diffs
     if item.bufnr == bufnr and type(data) == 'table' then
       local matches = selected_key and data.key == selected_key
         or (not selected_key and data.file == selected_file)
       if matches then
+        local lnum = (matched_line and matched_line.lnum) or item.lnum or 1
         vim.api.nvim_set_current_win(win)
-        vim.api.nvim_win_set_cursor(win, { math.max(1, item.lnum or 1), 0 })
+        vim.api.nvim_win_set_cursor(win, { math.max(1, lnum), 0 })
         vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
         return true
       end
@@ -1861,6 +1877,7 @@ local function open_review_map_from_split(state, layout)
   local source_buf = vim.api.nvim_win_get_buf(keep_win)
   local selected_file = state.selected_file
   local selected_key = state.selected_key
+  local position = split.displayed_position(source_buf, vim.api.nvim_win_get_cursor(keep_win)[1])
   local review_spec = vim.deepcopy(state.review)
   review_spec.repo = state.repo_root
   forget_review_split(state)
@@ -1879,7 +1896,7 @@ local function open_review_map_from_split(state, layout)
   })
   split.delete_pair_buffers(split_buffers)
   if bufnr then
-    goto_review_map_selection(bufnr, selected_file, selected_key)
+    goto_review_map_selection(bufnr, selected_file, selected_key, position)
   end
   return bufnr
 end

--- a/lua/diffs/hunks.lua
+++ b/lua/diffs/hunks.lua
@@ -392,6 +392,46 @@ function M.prev_hunk(hunks, lnum)
   return nil
 end
 
+---@class diffs.SourcePosition
+---@field side "left"|"right"
+---@field lnum integer
+
+---@param line diffs.DiffHunkLine?
+---@return diffs.SourcePosition?
+function M.source_position_for(line)
+  if not line then
+    return nil
+  end
+  if line.kind == 'delete' and line.old_lnum then
+    return { side = 'left', lnum = line.old_lnum }
+  end
+  if (line.kind == 'add' or line.kind == 'context') and line.new_lnum then
+    return { side = 'right', lnum = line.new_lnum }
+  end
+  return nil
+end
+
+---@param hunks diffs.DiffHunk[]?
+---@param selection { file: string, key?: string }
+---@param position diffs.SourcePosition
+---@return diffs.DiffHunkLine?
+function M.line_at_source(hunks, selection, position)
+  local field = position.side == 'left' and 'old_lnum' or 'new_lnum'
+  local kind = position.side == 'left' and 'delete' or 'add'
+  for _, hunk in ipairs(hunks or {}) do
+    local matches = selection.key and hunk.generated_key == selection.key
+      or (not selection.key and (hunk.file or hunk.path) == selection.file)
+    if matches then
+      for _, line in ipairs(hunk.lines) do
+        if (line.kind == kind or line.kind == 'context') and line[field] == position.lnum then
+          return line
+        end
+      end
+    end
+  end
+  return nil
+end
+
 ---@param item diffs.DiffHunk|diffs.DiffHunkLine|nil
 ---@return { path: string, lnum: integer }?
 function M.source_line_for(item)

--- a/lua/diffs/lists.lua
+++ b/lua/diffs/lists.lua
@@ -820,6 +820,13 @@ function M.set_for_unified_buffer(bufnr, diff_lines, opts)
   end
 end
 
+---@param bufnr integer
+---@return diffs.DiffHunk[]
+function M.generated_hunks(bufnr)
+  local state = generated_list_state[bufnr]
+  return state and state.hunks or {}
+end
+
 ---@param diff_lines string[]
 ---@param opts? diffs.GeneratedListOptions
 ---@return diffs.GeneratedFileSelection?

--- a/lua/diffs/split.lua
+++ b/lua/diffs/split.lua
@@ -1264,6 +1264,115 @@ local function nearest_non_filler_row(rows, cursor_row, lnum_field)
 end
 
 ---@param bufnr integer
+---@param side "left"|"right"
+---@return integer?
+local function pane_buffer_for_side(bufnr, side)
+  local source = buffer_source(bufnr)
+  if source and source.side == side then
+    return bufnr
+  end
+
+  local peer = split_peer(bufnr)
+  local peer_source = peer and buffer_source(peer) or nil
+  if peer_source and peer_source.side == side then
+    return peer
+  end
+  return nil
+end
+
+---@param bufnr integer
+---@param row? integer
+---@return integer?
+local function resolve_pane_row(bufnr, row)
+  if row then
+    return row
+  end
+
+  local win = current_or_first_window_for_buffer(bufnr)
+  if not win then
+    return nil
+  end
+  return vim.api.nvim_win_get_cursor(win)[1]
+end
+
+---@param bufnr integer
+---@param row? integer
+---@return diffs.SourcePosition?
+local function source_position(bufnr, row)
+  local source = buffer_source(bufnr)
+  local info = pane_info[bufnr]
+  local pane_row = resolve_pane_row(bufnr, row)
+  if not source or not info or not info.rows or not pane_row then
+    return nil
+  end
+
+  local lnum_field = side_config[source.side].lnum
+  local matched = nearest_non_filler_row(info.rows, pane_row, lnum_field)
+  if not matched then
+    return nil
+  end
+  return { side = source.side, lnum = matched[lnum_field] }
+end
+
+---@param bufnr integer
+---@param side "left"|"right"
+---@param row integer
+---@return diffs.SourcePosition?
+local function position_at_row(bufnr, side, row)
+  local pane = pane_buffer_for_side(bufnr, side)
+  local info = pane and pane_info[pane]
+  local entry = info and info.rows and info.rows[row]
+  if not entry or entry.kind == 'filler' then
+    return nil
+  end
+
+  local lnum = entry[side_config[side].lnum]
+  if not lnum then
+    return nil
+  end
+  return { side = side, lnum = lnum }
+end
+
+---@param bufnr integer
+---@param row? integer
+---@return diffs.SourcePosition?
+function M.displayed_position(bufnr, row)
+  local source = buffer_source(bufnr)
+  local pane_row = resolve_pane_row(bufnr, row)
+  if not source or not pane_row then
+    return nil
+  end
+
+  local peer_side = source.side == 'left' and 'right' or 'left'
+  return position_at_row(bufnr, source.side, pane_row)
+    or position_at_row(bufnr, peer_side, pane_row)
+end
+
+---@param bufnr integer
+---@param position diffs.SourcePosition?
+---@return boolean
+function M.move_pair_to_source(bufnr, position)
+  if type(position) ~= 'table' or not side_config[position.side] then
+    return false
+  end
+
+  local pane = pane_buffer_for_side(bufnr, position.side)
+  local info = pane and pane_info[pane]
+  if not info or not info.rows then
+    return false
+  end
+
+  local lnum_field = side_config[position.side].lnum
+  for row, entry in ipairs(info.rows) do
+    if entry.kind ~= 'filler' and entry[lnum_field] == position.lnum then
+      move_pair_to_row(bufnr, row)
+      return true
+    end
+  end
+  return false
+end
+
+---@param bufnr integer
 ---@return boolean
 function M.open_source(bufnr)
   local source = buffer_source(bufnr)
@@ -1293,13 +1402,8 @@ function M.open_source(bufnr)
 
   local filepath = resolve_worktree_path(source.repo_root, source.path)
   local cursor_row = vim.api.nvim_win_get_cursor(source_win)[1]
-  local info = pane_info[bufnr]
-  local target_lnum = cursor_row
-  if info and info.rows then
-    local lnum_field = side_config[source.side].lnum
-    local row = nearest_non_filler_row(info.rows, cursor_row, lnum_field)
-    target_lnum = (row and row[lnum_field]) or cursor_row
-  end
+  local position = source_position(bufnr, cursor_row)
+  local target_lnum = (position and position.lnum) or cursor_row
   local existing_win = find_window_for_file(filepath)
   if existing_win then
     vim.api.nvim_set_current_win(existing_win)

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -3687,7 +3687,7 @@ describe('commands', function()
         vim.b[map_buf].diffs_review
       )
       assert.is_true(helpers.has_keymap(map_buf, 'gs'))
-      assert.is_true(cursor_text:find('diff --git a/lua/two.lua b/lua/two.lua', 1, true) ~= nil)
+      assert.is_true(cursor_text:find('+line 2 changed', 1, true) ~= nil)
       assert.is_true(#loc >= 1)
       assert.are.equal(map_buf, loc[1].bufnr)
       assert.is_true(loc[1].text:find('lua/two.lua', 1, true) ~= nil)
@@ -3712,6 +3712,108 @@ describe('commands', function()
       assert.are.equal('dual', vim.api.nvim_buf_get_var(map_buf, 'diffs_rail_style'))
       assert.are.same({ display = 'HEAD', layout = 'unified' }, vim.b[map_buf].diffs_review)
       assert.is_true(buffer_text(map_buf):find('diff --git a/file.txt b/file.txt', 1, true) ~= nil)
+    end)
+
+    local function create_block_review_repo()
+      local repo_root = create_repo()
+      write_repo_file(repo_root, 'lua/block.lua', {
+        'one',
+        'two',
+        'three',
+        'four',
+        'five',
+        'six',
+      })
+      git_cmd(repo_root, { 'add', 'lua/block.lua' })
+      git_cmd(repo_root, { 'commit', '-qm', 'block' })
+      write_repo_file(repo_root, 'lua/block.lua', {
+        'one',
+        'two changed',
+        'three changed',
+        'five',
+        'six',
+      })
+      return repo_root
+    end
+
+    ---@param repo_root string
+    ---@param text string
+    ---@return integer, integer, integer
+    local function toggle_from_review_line(repo_root, text)
+      edit_file(repo_root .. '/lua/block.lua')
+      mock_runtime_attach(function() end)
+
+      local review_buf = commands.review({ base = 'HEAD', repo = repo_root })
+      assert.is_not_nil(review_buf)
+      table.insert(test_buffers, review_buf)
+      local review_win = find_window_for_buffer(review_buf)
+      assert.is_not_nil(review_win)
+      local review_line = find_buffer_line(review_buf, text)
+      assert.is_not_nil(review_line)
+      vim.api.nvim_set_current_win(review_win)
+      vim.api.nvim_win_set_cursor(review_win, { review_line, 0 })
+
+      local panes = track_panes(commands.review_toggle_layout())
+      vim.api.nvim_set_current_win(panes.right_win)
+      local split_row = vim.api.nvim_win_get_cursor(panes.right_win)[1]
+
+      local map_buf = commands.review_toggle_layout()
+      assert.is_not_nil(map_buf)
+      table.insert(test_buffers, map_buf)
+      local map_win = find_window_for_buffer(map_buf)
+      assert.is_not_nil(map_win)
+
+      return review_line, split_row, vim.api.nvim_win_get_cursor(map_win)[1]
+    end
+
+    it('opens the split at the selected review line and returns to it', function()
+      local repo_root = create_block_review_repo()
+
+      local review_line, split_row, returned_line =
+        toggle_from_review_line(repo_root, '+three changed')
+
+      assert.are.equal(3, split_row)
+      assert.are.equal(review_line, returned_line)
+    end)
+
+    it('returns to a deleted review line from the filler row facing it', function()
+      local repo_root = create_block_review_repo()
+
+      local review_line, _, returned_line = toggle_from_review_line(repo_root, '-four')
+
+      assert.are.equal(review_line, returned_line)
+    end)
+
+    it('returns to the review line the split cursor moved to', function()
+      local repo_root = create_block_review_repo()
+      edit_file(repo_root .. '/lua/block.lua')
+      mock_runtime_attach(function() end)
+
+      local review_buf = commands.review({ base = 'HEAD', repo = repo_root })
+      assert.is_not_nil(review_buf)
+      table.insert(test_buffers, review_buf)
+      local review_win = find_window_for_buffer(review_buf)
+      vim.api.nvim_set_current_win(review_win)
+      vim.api.nvim_win_set_cursor(review_win, { find_buffer_line(review_buf, '+two changed'), 0 })
+
+      local panes = track_panes(commands.review_toggle_layout())
+      vim.api.nvim_set_current_win(panes.right_win)
+      local moved_row = nil
+      for lnum, line in ipairs(vim.api.nvim_buf_get_lines(panes.right_buf, 0, -1, false)) do
+        if line == 'six' then
+          moved_row = lnum
+        end
+      end
+      assert.is_not_nil(moved_row)
+      vim.api.nvim_win_set_cursor(panes.right_win, { moved_row, 0 })
+
+      local map_buf = commands.review_toggle_layout()
+      assert.is_not_nil(map_buf)
+      table.insert(test_buffers, map_buf)
+      local map_win = find_window_for_buffer(map_buf)
+      local returned_line = vim.api.nvim_win_get_cursor(map_win)[1]
+
+      assert.are.equal(find_buffer_line(map_buf, ' six'), returned_line)
     end)
 
     it('restores duplicate current-state review paths by review key', function()
@@ -3743,8 +3845,7 @@ describe('commands', function()
       table.insert(test_buffers, map_buf)
       local map_win = find_window_for_buffer(map_buf)
       assert.is_not_nil(map_win)
-      local expected_line =
-        find_buffer_line_after(map_buf, '# Unstaged:', 'diff --git a/lua/dup.lua b/lua/dup.lua')
+      local expected_line = find_buffer_line_after(map_buf, '# Unstaged:', '-dup staged')
 
       assert.are.equal(expected_line, vim.api.nvim_win_get_cursor(map_win)[1])
     end)

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -3784,6 +3784,16 @@ describe('commands', function()
       assert.are.equal(review_line, returned_line)
     end)
 
+    it('settles on the replacing line when a removed line selected the split', function()
+      local repo_root = create_block_review_repo()
+
+      local first_line, _, second_line = toggle_from_review_line(repo_root, '-two')
+      local third_line = select(3, toggle_from_review_line(repo_root, '+two changed'))
+
+      assert.are_not.equal(first_line, second_line)
+      assert.are.equal(second_line, third_line)
+    end)
+
     it('returns to the review line the split cursor moved to', function()
       local repo_root = create_block_review_repo()
       edit_file(repo_root .. '/lua/block.lua')


### PR DESCRIPTION
## Problem

The review layout toggle carried a file, not a position. Going into the split, the selection handed over was the file plus its hunk index, so the pair opened at the first change of the hunk rather than the line that was selected. Coming back, `goto_review_map_selection()` looked the file up in the quickfix list and jumped to its entry, which is the `diff --git` header row, so `gs` out of a split always landed at the top of that file's diff no matter where the cursor had been.

The mapping needed for the return trip already existed in one direction: a split row resolves to a source line through the pane's alignment rows, which is how opening the source file from a split lands on the right line. Nothing computed the inverse.

## Solution

Both directions now travel as a source position, a side and a line number, which is the one thing a review map row and a split row can both name. Entering resolves the map row to that position through the hunk model and moves the pane pair to the row that shows it; leaving reads the position under the split cursor and resolves it back to the map row that carries it, falling back to the file's quickfix row when the row names no source line, such as a file or hunk header. The split position is read when the toggle happens rather than when the split was opened, so moving around inside the split is reflected in the map.

Rows facing a filler, a deletion with nothing opposite it, take their position from the other pane, so deleted lines return to their own map row instead of the nearest surviving line. Duplicate paths across review sections resolve by review key, so a file that appears both staged and unstaged returns to the section it came from.