### PR TITLE
feat(api): open a review in a window the caller names

### DIFF
--- a/doc/diffs.nvim.txt
+++ b/doc/diffs.nvim.txt
@@ -1300,12 +1300,51 @@ refresh({bufnr})                                        *diffs.nvim.refresh()*
     Parameters: ~
         {bufnr}  (integer, optional) Buffer number. Defaults to current buffer.
 
-The review API below is buffer-centric. Navigation functions resolve the review
-split that {bufnr} (default: current buffer) belongs to, and are no-ops
+                                                            *diffs.ReviewSpec*
+A `diffs.ReviewSpec` says what to review, as the arguments to |:Diff-review|
+do: ~
+    {base}       (string, optional) The ref to review against.
+    {target}     (string, optional) The ref to review. Omit for the current
+                 repository state.
+    {mode}       ("merge-base"|"direct", optional) How {base} and {target}
+                 relate, matching `A...B` and `A..B` respectively.
+    {repo}       (string, optional) Repository root. Defaults to the one the
+                 current buffer is in.
+    {untracked}  (boolean, optional) Include untracked files in a
+                 current-state review. Ignored when {target} is given.
+
+open_review({spec}, {opts})                         *diffs.nvim.open_review()*
+    Open a review, as |:Diff-review| does, for a caller that already knows
+    what it wants reviewed. Returns the review buffer, or `nil` on failure.
+
+    {opts.replace_win} is why this exists alongside the command: |:Diff|
+    has nowhere to say "this window", so with no review already open it
+    splits. A plugin handing a review off from its own buffer already has a
+    window and wants that one used, rather than a new one and the rest of the
+    tab closed to compensate. The window is not closed or created, only its
+    buffer replaced.
+
+    Parameters: ~
+        {spec}   (|diffs.ReviewSpec|, optional) What to review. Omit to
+                 review the current repository state against the remote
+                 default branch, as `:Diff review` with no arguments does.
+        {opts}   (table, optional) ~
+                 • {layout} ("unified"|"stacked"|"split", optional) As
+                   `++layout`. Defaults to `view.default_layout`.
+                 • {replace_win} (integer, optional) Show the review in this
+                   window instead of splitting.
+
+    Example, reviewing a pull request in the window you are standing in: >lua
+        require('diffs').open_review(
+          { base = 'main', target = 'refs/forge/pull/12', mode = 'merge-base' },
+          { replace_win = vim.api.nvim_get_current_win() }
+        )
+<
+The rest of the review API is buffer-centric. Navigation functions resolve the
+review split that {bufnr} (default: current buffer) belongs to, and are no-ops
 (`nil`/`false`) elsewhere. |diffs.nvim.review_toggle_layout()| also accepts a
-generated review map buffer and can move between map and split surfaces. These
-helpers are only meaningful inside an open review; nothing here opens a new
-review spec.
+generated review map buffer and can move between map and split surfaces. Those
+helpers are only meaningful inside an open review.
 
                                                             *diffs.ReviewFile*
 A `diffs.ReviewFile` describes one changed file in a review: ~

--- a/lua/diffs/commands.lua
+++ b/lua/diffs/commands.lua
@@ -966,6 +966,32 @@ function M.review_command(args, vertical, opts)
   return bufnr
 end
 
+---@class diffs.ReviewOpts
+---@field layout? "unified"|"stacked"|"split"
+---@field replace_win? integer
+
+--- Open a review from Lua, for a caller that already knows what it wants
+--- reviewed.
+---
+--- `replace_win` is why this exists as well as `:Diff review`: a command has
+--- nowhere to say "this window", so with no review open it splits. An embedder
+--- handing a review off from its own buffer already has a window and wants that
+--- one, not a new one and not the rest of the tab closed to compensate.
+---@param spec? diffs.ReviewSpec
+---@param opts? diffs.ReviewOpts
+---@return integer?
+function M.open_review(spec, opts)
+  opts = opts or {}
+  if opts.layout == 'split' then
+    return open_review_split(spec, { replace_win = opts.replace_win })
+  end
+  return M.review(spec, {
+    rail_style = rail_style_for_layout(opts.layout),
+    review_layout = normalize_review_map_layout(opts.layout),
+    replace_win = opts.replace_win,
+  })
+end
+
 --- Primary `:Diff` command handler. Routes `:Diff review ...` to the review
 --- surface and everything else to the current-file diff, threading the
 --- `:vertical` modifier through to generated layouts.

--- a/lua/diffs/init.lua
+++ b/lua/diffs/init.lua
@@ -1,5 +1,6 @@
 ---@class diffs.PublicApi
 ---@field attach fun(bufnr?: integer)
+---@field open_review fun(spec?: diffs.ReviewSpec, opts?: diffs.ReviewOpts): integer?
 ---@field refresh fun(bufnr?: integer)
 ---@field review_files fun(bufnr?: integer): diffs.ReviewFile[]?
 ---@field review_current fun(bufnr?: integer): { index: integer, count: integer, file: diffs.ReviewFile }?
@@ -15,6 +16,7 @@ local runtime = require('diffs.runtime')
 ---@type diffs.PublicApi
 return {
   attach = runtime.attach,
+  open_review = commands.open_review,
   refresh = runtime.refresh,
   review_files = commands.review_files,
   review_current = commands.review_current,

--- a/spec/api_spec.lua
+++ b/spec/api_spec.lua
@@ -12,6 +12,7 @@ describe('diffs public API', function()
 
     assert.same({
       'attach',
+      'open_review',
       'refresh',
       'review_current',
       'review_files',
@@ -22,6 +23,7 @@ describe('diffs public API', function()
       'select_review_file',
     }, keys)
     assert.is_function(diffs.attach)
+    assert.is_function(diffs.open_review)
     assert.is_function(diffs.refresh)
     assert.is_function(diffs.review_files)
     assert.is_function(diffs.review_current)


### PR DESCRIPTION
## Problem

`:Diff review` has nowhere to say "this window". With no review already open,
`show_generated_diff_buffer` falls through to `vim.cmd(vertical and 'vsplit' or 'split')`,
so an embedder handing a review off from its own buffer gets a new window and half
the rows — worst for a review map, which is the widest and longest surface here.

## Solution

Export `open_review(spec, opts)`, taking `replace_win` and `layout`. Additive: the
command passes neither, so `:Diff review` is unchanged. Nothing is created or closed,
only a named window's buffer replaced.