### PR TITLE
test: resolve the temp repo path so specs pass on macos

### DIFF
--- a/spec/actions_spec.lua
+++ b/spec/actions_spec.lua
@@ -59,7 +59,7 @@ local function file_lines_without(start, count)
 end
 
 local function create_repo()
-  local repo_root = vim.fn.tempname()
+  local repo_root = vim.fn.resolve(vim.fn.tempname())
   vim.fn.mkdir(repo_root, 'p')
   test_repos[#test_repos + 1] = repo_root
 

--- a/spec/commands_spec.lua
+++ b/spec/commands_spec.lua
@@ -95,7 +95,7 @@ local function git_cmd(repo_root, args)
 end
 
 local function create_repo()
-  local repo_root = vim.fn.tempname()
+  local repo_root = vim.fn.resolve(vim.fn.tempname())
   vim.fn.mkdir(repo_root, 'p')
   test_repos[#test_repos + 1] = repo_root
 
@@ -141,7 +141,7 @@ end
 
 local function create_review_repo(opts)
   opts = opts or {}
-  local repo_root = vim.fn.tempname()
+  local repo_root = vim.fn.resolve(vim.fn.tempname())
   vim.fn.mkdir(repo_root, 'p')
   test_repos[#test_repos + 1] = repo_root
 
@@ -213,7 +213,7 @@ end
 
 local function create_current_state_review_repo(opts)
   opts = opts or {}
-  local repo_root = vim.fn.tempname()
+  local repo_root = vim.fn.resolve(vim.fn.tempname())
   vim.fn.mkdir(repo_root, 'p')
   test_repos[#test_repos + 1] = repo_root
 
@@ -257,7 +257,7 @@ local function create_current_state_review_repo(opts)
 end
 
 local function create_mode_only_review_repo()
-  local repo_root = vim.fn.tempname()
+  local repo_root = vim.fn.resolve(vim.fn.tempname())
   vim.fn.mkdir(repo_root, 'p')
   test_repos[#test_repos + 1] = repo_root
 
@@ -3428,7 +3428,7 @@ describe('commands', function()
     end
 
     local function create_binary_first_review_repo()
-      local repo_root = vim.fn.tempname()
+      local repo_root = vim.fn.resolve(vim.fn.tempname())
       vim.fn.mkdir(repo_root, 'p')
       test_repos[#test_repos + 1] = repo_root
 
@@ -3454,7 +3454,7 @@ describe('commands', function()
 
     local function create_binary_review_repo(opts)
       opts = opts or {}
-      local repo_root = vim.fn.tempname()
+      local repo_root = vim.fn.resolve(vim.fn.tempname())
       vim.fn.mkdir(repo_root, 'p')
       test_repos[#test_repos + 1] = repo_root
 

--- a/spec/content_spec.lua
+++ b/spec/content_spec.lua
@@ -6,7 +6,7 @@ local test_buffers = {}
 local test_files = {}
 
 local function edit_temp_file(lines, flags)
-  local path = vim.fn.tempname()
+  local path = vim.fn.resolve(vim.fn.tempname())
   test_files[#test_files + 1] = path
   vim.fn.writefile(lines, path, flags or '')
   vim.cmd('edit ' .. vim.fn.fnameescape(path))

--- a/spec/context_spec.lua
+++ b/spec/context_spec.lua
@@ -8,7 +8,7 @@ describe('context', function()
     local tmpdir
 
     before_each(function()
-      tmpdir = vim.fn.tempname()
+      tmpdir = vim.fn.resolve(vim.fn.tempname())
       vim.fn.mkdir(tmpdir, 'p')
     end)
 

--- a/spec/diff_files_spec.lua
+++ b/spec/diff_files_spec.lua
@@ -53,7 +53,7 @@ describe('diffs.commands.diff_files', function()
   local b
 
   before_each(function()
-    dir = vim.fn.tempname()
+    dir = vim.fn.resolve(vim.fn.tempname())
     vim.fn.mkdir(dir, 'p')
     dir = vim.fn.resolve(dir)
     a = dir .. '/a.txt'

--- a/spec/git_spec.lua
+++ b/spec/git_spec.lua
@@ -14,7 +14,7 @@ local function git_cmd(repo_root, args)
 end
 
 local function create_repo()
-  local repo_root = vim.fn.tempname()
+  local repo_root = vim.fn.resolve(vim.fn.tempname())
   vim.fn.mkdir(repo_root, 'p')
   test_repos[#test_repos + 1] = repo_root
 

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -2,7 +2,7 @@ require('spec.helpers')
 
 describe('plugin bootstrap', function()
   local function run_child_result(init_lines, after_lines)
-    local tmpdir = vim.fn.tempname()
+    local tmpdir = vim.fn.resolve(vim.fn.tempname())
     assert.are.equal(1, vim.fn.mkdir(tmpdir, 'p'))
     local init_file = tmpdir .. '/init.lua'
     local after_file = tmpdir .. '/after.lua'
@@ -118,7 +118,7 @@ describe('plugin bootstrap', function()
   end)
 
   it('enhances native diff windows opened at startup with nvim -d', function()
-    local tmpdir = vim.fn.tempname()
+    local tmpdir = vim.fn.resolve(vim.fn.tempname())
     assert.are.equal(1, vim.fn.mkdir(tmpdir, 'p'))
     local file_a = tmpdir .. '/a.txt'
     local file_b = tmpdir .. '/b.txt'

--- a/spec/render_spec.lua
+++ b/spec/render_spec.lua
@@ -19,7 +19,7 @@ local function git_cmd(repo_root, args)
 end
 
 local function create_repo()
-  local repo_root = vim.fn.tempname()
+  local repo_root = vim.fn.resolve(vim.fn.tempname())
   vim.fn.mkdir(repo_root, 'p')
   test_repos[#test_repos + 1] = repo_root
 


### PR DESCRIPTION
## Problem

26 specs fail on macOS and pass on Linux: 16 failures and 10 errors across
`actions_spec`, `commands_spec` and `render_spec`.

`vim.fn.tempname()` returns a path under `/var/folders/...`, and on macOS `/var` is
a symlink to `/private/var`. Git resolves it, the spec does not, so the two disagree
about where the repo is:

```
tempname()    = /var/folders/.../PF65FX/0
git toplevel  = /private/var/folders/.../PF65FX/0
```

Confirmed by building the same fixture both ways — with the unresolved path the
rendered diff has no `deleted file mode` line, with the resolved one it does. Linux
`tempname()` gives `/tmp/...` with no symlink, which is why CI never saw it.

## Solution

Resolve the path where the fixture is created: `vim.fn.resolve(vim.fn.tempname())`,
14 sites across 8 spec files. `resolve` handles the not-yet-created leaf, resolving
the parent symlinks.

Applied to every `tempname()` in `spec/`, not only the failing three, so the next
git-backed fixture does not reintroduce it.

802 successes / 0 failures / 0 errors, up from 776/16/10. No change to `lua/`.